### PR TITLE
[WIP] Ecto.Model.assign

### DIFF
--- a/lib/ecto/model.ex
+++ b/lib/ecto/model.ex
@@ -76,5 +76,6 @@ defmodule Ecto.Model do
   end
 
   defdelegate assign(model, values), to: Ecto.Model.Assign
+  defdelegate assign(model, values, opts), to: Ecto.Model.Assign
 end
 

--- a/lib/ecto/model.ex
+++ b/lib/ecto/model.ex
@@ -18,6 +18,7 @@ defmodule Ecto.Model do
     quote do
       use Ecto.Model.Schema
       use Ecto.Model.Validations
+      import Ecto.Model.Assign, only: [assign: 2]
     end
   end
 

--- a/lib/ecto/model.ex
+++ b/lib/ecto/model.ex
@@ -73,5 +73,7 @@ defmodule Ecto.Model do
       from unquote(field) in __MODULE__, unquote(opts)
     end
   end
+
+  defdelegate assign(model, values), to: Ecto.Model.Assign
 end
 

--- a/lib/ecto/model/assign.ex
+++ b/lib/ecto/model/assign.ex
@@ -1,0 +1,18 @@
+defmodule Ecto.Model.Assign do
+  def assign(model, values) do
+    values = filtered_keys(model, values)
+    struct(model, values)
+  end
+
+  defp filtered_keys(model, values) do
+    field_names = model.__schema__(:field_names)
+    binary_field_names = model.__schema__(:field_names) |> Enum.map(&Atom.to_string/1)
+    Enum.flat_map values, fn({k, v}) ->
+      cond do
+        k in field_names -> [{k, v}]
+        k in binary_field_names -> [{String.to_atom(k), v}]
+        true -> []
+      end
+    end
+  end
+end

--- a/lib/ecto/model/assign.ex
+++ b/lib/ecto/model/assign.ex
@@ -1,12 +1,13 @@
 defmodule Ecto.Model.Assign do
-  def assign(model, values) do
-    values = filtered_keys(model(model), values)
+  def assign(model, values, opts \\ []) do
+    all_field_names = model(model).__schema__(:field_names)
+    field_names = Keyword.get(opts, :only, all_field_names)
+    values = filtered_keys(values, field_names)
     struct(model, values)
   end
 
-  defp filtered_keys(model, values) do
-    field_names = model.__schema__(:field_names)
-    binary_field_names = model.__schema__(:field_names) |> Enum.map(&Atom.to_string/1)
+  defp filtered_keys(values, field_names) do
+    binary_field_names = field_names |> Enum.map(&Atom.to_string/1)
     Enum.flat_map values, fn({k, v}) ->
       cond do
         k in field_names -> [{k, v}]

--- a/lib/ecto/model/assign.ex
+++ b/lib/ecto/model/assign.ex
@@ -1,6 +1,6 @@
 defmodule Ecto.Model.Assign do
   def assign(model, values) do
-    values = filtered_keys(model, values)
+    values = filtered_keys(model(model), values)
     struct(model, values)
   end
 
@@ -15,4 +15,8 @@ defmodule Ecto.Model.Assign do
       end
     end
   end
+
+  # Given either a model or a struct, return the model
+  defp model(module) when is_atom(module), do: module
+  defp model(%{__struct__: module} = model), do: module
 end

--- a/lib/ecto/model/assign.ex
+++ b/lib/ecto/model/assign.ex
@@ -1,6 +1,6 @@
 defmodule Ecto.Model.Assign do
   def assign(model, values, opts \\ []) do
-    all_field_names = model(model).__schema__(:field_names)
+    all_normal_field_names = model(model).__schema__(:field_names)
     field_names = Keyword.get(opts, :only, all_field_names)
     values = filtered_keys(values, field_names)
     struct(model, values)

--- a/test/ecto/model/assign_test.exs
+++ b/test/ecto/model/assign_test.exs
@@ -63,4 +63,12 @@ defmodule Ecto.Model.AssignTest do
     assert user.name == "martin"
     assert user.email == "martin@email"
   end
+
+  test "supports assigning to a virtual field" do
+    assert Ecto.Model.assign(User, %{temp: "assigned"}).temp == "assigned"
+  end
+
+  test "supports assigning to a virtual field when the field is listed in the :only option" do
+    assert Ecto.Model.assign(User, %{temp: "assigned"}, only: [:temp]).temp == "assigned"
+  end
 end

--- a/test/ecto/model/assign_test.exs
+++ b/test/ecto/model/assign_test.exs
@@ -1,0 +1,45 @@
+defmodule Ecto.Model.AssignTest do
+  use ExUnit.Case, async: true
+
+  defmodule User do
+    use Ecto.Model
+
+    schema "users" do
+      field :name, :string, default: "eric"
+      field :email, :string, default: "eric@email"
+      field :temp, :virtual, default: "temp"
+      field :array, {:array, :string}
+    end
+  end
+
+  test "assigning returns the correct struct" do
+    assert %User{} = Ecto.Model.assign(User, %{})
+  end
+
+  test "assigns with strings as keys" do
+    user = Ecto.Model.assign(User, %{"name" => "martin"})
+    assert user.name == "martin"
+  end
+
+  test "assigns with atoms as keys" do
+    user = Ecto.Model.assign(User, %{name: "martin"})
+    assert user.name == "martin"
+  end
+
+  test "assigns with both atoms and strings as keys" do
+    user = Ecto.Model.assign(User, %{:name => "martin", "email" => "martin@email"})
+    assert user.name == "martin"
+    assert user.email == "martin@email"
+  end
+
+  test "assigning honors defaults for absent values" do
+    user = Ecto.Model.assign(User, %{name: "martin"})
+    assert user.name == "martin"
+    assert user.email == "eric@email"
+  end
+
+  test "discards keys that don't correspond to a field" do
+    user = Ecto.Model.assign(User, %{"blafoo" => "martin"})
+    assert_raise KeyError, fn -> user.blafoo end
+  end
+end

--- a/test/ecto/model/assign_test.exs
+++ b/test/ecto/model/assign_test.exs
@@ -14,20 +14,25 @@ defmodule Ecto.Model.AssignTest do
 
   test "assigning returns the correct struct" do
     assert %User{} = Ecto.Model.assign(User, %{})
+    assert %User{} = Ecto.Model.assign(%User{}, %{})
   end
 
   test "assigns with strings as keys" do
-    user = Ecto.Model.assign(User, %{"name" => "martin"})
-    assert user.name == "martin"
+    assert Ecto.Model.assign(User, %{"name" => "martin"}).name == "martin"
+    assert Ecto.Model.assign(%User{}, %{"name" => "martin"}).name == "martin"
   end
 
   test "assigns with atoms as keys" do
-    user = Ecto.Model.assign(User, %{name: "martin"})
-    assert user.name == "martin"
+    assert Ecto.Model.assign(User, %{name: "martin"}).name == "martin"
+    assert Ecto.Model.assign(%User{}, %{name: "martin"}).name == "martin"
   end
 
   test "assigns with both atoms and strings as keys" do
     user = Ecto.Model.assign(User, %{:name => "martin", "email" => "martin@email"})
+    assert user.name == "martin"
+    assert user.email == "martin@email"
+
+    user = Ecto.Model.assign(%User{}, %{:name => "martin", "email" => "martin@email"})
     assert user.name == "martin"
     assert user.email == "martin@email"
   end
@@ -36,10 +41,14 @@ defmodule Ecto.Model.AssignTest do
     user = Ecto.Model.assign(User, %{name: "martin"})
     assert user.name == "martin"
     assert user.email == "eric@email"
+
+    user = Ecto.Model.assign(%User{}, %{name: "martin"})
+    assert user.name == "martin"
+    assert user.email == "eric@email"
   end
 
   test "discards keys that don't correspond to a field" do
-    user = Ecto.Model.assign(User, %{"blafoo" => "martin"})
-    assert_raise KeyError, fn -> user.blafoo end
+    assert_raise KeyError, fn -> Ecto.Model.assign(User, %{"blafoo" => "martin"}).blafoo end
+    assert_raise KeyError, fn -> Ecto.Model.assign(%User{}, %{"blafoo" => "martin"}).blafoo end
   end
 end

--- a/test/ecto/model/assign_test.exs
+++ b/test/ecto/model/assign_test.exs
@@ -51,4 +51,16 @@ defmodule Ecto.Model.AssignTest do
     assert_raise KeyError, fn -> Ecto.Model.assign(User, %{"blafoo" => "martin"}).blafoo end
     assert_raise KeyError, fn -> Ecto.Model.assign(%User{}, %{"blafoo" => "martin"}).blafoo end
   end
+
+  test "restricts assignment to given keys if :only option is used" do
+    user = Ecto.Model.assign(User, %{:name => "martin", "email" => "martin@email"}, only: [:email])
+    assert user.name == "eric"
+    assert user.email == "martin@email"
+  end
+
+  test "keeps existing entries even if key is restricted with :only option" do
+    user = Ecto.Model.assign(%User{name: "martin"}, %{name: "not martin", email: "martin@email"}, only: [:email])
+    assert user.name == "martin"
+    assert user.email == "martin@email"
+  end
 end


### PR DESCRIPTION
I've started working on `Ecto.Model.assign` as described in https://github.com/elixir-lang/ecto/issues/258#issuecomment-52421545 and https://github.com/elixir-lang/ecto/issues/246

Currently open questions:
- `assign` should accept both a struct and a module right?

  ```elixir
  assign(%User{name: "martin"}, %{name: "not martin"})
  assign(User, %{name: "not martin"})
  ```

- `assign` should probably be generated by the `Ecto.Model.schema` macro and not use `model.__schema__(:field_names)` at runtime, right?

- `__schema__(:field_names)` doesn't return virtual fields, but there's no `__schema__(:virtual_field_names)`. Is there a reason why?