### PR TITLE
add support for passing custom encoder/decoder/formatter to Adapters.Postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,11 @@ language: erlang
 otp_release:
   - 17.0
 before_install:
-  - wget http://s3.hex.pm/builds/elixir/v1.0.0.zip
-  - unzip -d elixir v1.0.0.zip
+  - wget http://s3.hex.pm/builds/elixir/v1.0.1.zip
+  - unzip -d elixir v1.0.1.zip
 before_script:
   - export PATH=`pwd`/elixir/bin:$PATH
   - mix local.hex --force
   - mix deps.get
 script:
   - MIX_ENV=all mix test
-notifications:
-  recipients:
-    - jose.valim@plataformatec.com.br
-    - eric.meadows.jonsson@gmail.com

--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ Besides, a set of options can be passed to the adapter as:
 
     ecto://USERNAME:PASSWORD@HOST/DATABASE?KEY=VALUE
 
+You may also specify specific options to pass directly to the adapter. For example, to add support for [PostGIS](http://postgis.net/), simply add [geo](https://github.com/bryanjos/geo) to your deps and pass in the library's custom encoder, decoder, and formatter:
+
+```elixir
+defmodule Repo do
+  use Ecto.Repo, adapter: Ecto.Adapters.Postgres
+
+  def conf do
+    [
+      hostname: "localhost",
+      username: "postgres",
+      database: "addresses",
+      encoder: &Geo.PostGIS.encoder/3,
+      decoder: &Geo.PostGIS.decoder/4,
+      formatter: &Geo.PostGIS.formatter/1
+    ]
+  end
+end
+```
+
 Each repository in Ecto defines a `start_link/0` function that needs to be invoked before using the repository. In general, this function is not called directly, but via the supervisor chain. If your application was generated with a supervisor (by passing `--sup` to `mix new`) you will have a `lib/my_app.ex` file containing the application start callback that defines and starts your supervisor. You just need to edit the `start/2` function to start the repo as a worker on the supervisor:
 
 ```elixir

--- a/integration_test/pg/hstore_test.exs
+++ b/integration_test/pg/hstore_test.exs
@@ -1,0 +1,26 @@
+defmodule Ecto.Integration.HstoreTest do
+  use Ecto.Integration.Postgres.Case
+
+  alias Ecto.Adapters.Postgres
+
+  defmodule HstoreTestModel do
+    use Ecto.Model
+    schema "hstore_test" do
+      field :data, :hstore
+    end
+  end
+
+  setup do
+    Postgres.query(TestRepo, "CREATE EXTENSION IF NOT EXISTS hstore", [])
+    Postgres.query(TestRepo, "CREATE TABLE IF NOT EXISTS hstore_test(id serial primary key, data hstore)", [])
+    :ok
+  end
+
+  test "it can add data to the database" do
+    test_data = %{ "name" => "frank", "bubbles" => 7 }
+    %HstoreTestModel{id: id} =  %HstoreTestModel{data: test_data} |> TestRepo.insert
+    assert is_integer(id)
+    saved_model = Postgres.query(TestRepo, "SELECT * FROM hstore_test WHERE id = $1", [id])
+    assert saved_model.data == test_data
+  end
+end

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -21,6 +21,17 @@ defmodule Ecto.Integration.Postgres.TestRepo do
 
   def conf do
     parse_url "ecto://postgres:postgres@localhost/ecto_test?size=1&max_overflow=0"
+
+    [ username: "postgres",
+      password: "postgres",
+      hostname: "0.0.0.0",
+      port: 5432,
+      database: "ecto_test",
+      encoder: &Hstore.encoder/3,
+      decoder: &Hstore.decoder/4,
+      formatter: &Hstore.formatter/1,
+      max_overflow: "0",
+      size: "1"]
   end
 
   # def log(action, fun) do
@@ -149,7 +160,8 @@ Application.ensure_all_started(:logger)
 
 setup_cmds = [
   ~s(psql -U postgres -c "DROP DATABASE IF EXISTS ecto_test;"),
-  ~s(psql -U postgres -c "CREATE DATABASE ecto_test TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';")
+  ~s(psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS hstore;"),
+  ~s(psql -U postgres -c "CREATE DATABASE ecto_test TEMPLATE=template1 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';")
 ]
 
 Enum.each(setup_cmds, fn(cmd) ->
@@ -189,6 +201,7 @@ setup_database = [
   "CREATE TABLE uuid_primary_keys (id uuid PRIMARY KEY)",
   "CREATE TABLE transaction (id serial, text text)",
   "CREATE TABLE lock_counters (id serial PRIMARY KEY, count integer)",
+  "CREATE TABLE IF NOT EXISTS hstore_test(id serial primary key, data hstore)",
   "CREATE FUNCTION custom(integer) RETURNS integer AS 'SELECT $1 * 10;' LANGUAGE SQL"
 ]
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -247,72 +247,75 @@ if Code.ensure_loaded?(Postgrex.Connection) do
 
     ## Postgrex casting
 
-    defp formatter(%TypeInfo{sender: "uuid"}), do: :binary
-    defp formatter(_), do: nil
+    @doc false
+    def formatter(%TypeInfo{sender: "uuid"}), do: :binary
+    def formatter(_), do: nil
 
-    defp decoder(%TypeInfo{sender: "interval"}, :binary, default, param) do
+    @doc false
+    def decoder(%TypeInfo{sender: "interval"}, :binary, default, param) do
       {mon, day, sec} = default.(param)
       %Ecto.Interval{year: 0, month: mon, day: day, hour: 0, min: 0, sec: sec}
     end
 
-    defp decoder(%TypeInfo{sender: sender}, :binary, default, param)
+    def decoder(%TypeInfo{sender: sender}, :binary, default, param)
         when sender in ["timestamp", "timestamptz"] do
       default.(param)
       |> Ecto.DateTime.from_erl
     end
 
-    defp decoder(%TypeInfo{sender: "date"}, :binary, default, param) do
+    def decoder(%TypeInfo{sender: "date"}, :binary, default, param) do
       default.(param)
       |> Ecto.Date.from_erl
     end
 
-    defp decoder(%TypeInfo{sender: sender}, :binary, default, param)
+    def decoder(%TypeInfo{sender: sender}, :binary, default, param)
         when sender in ["time", "timetz"] do
       default.(param)
       |> Ecto.Time.from_erl
     end
 
-    defp decoder(%TypeInfo{sender: "uuid"}, :binary, _default, param) do
+    def decoder(%TypeInfo{sender: "uuid"}, :binary, _default, param) do
       param
     end
 
-    defp decoder(_type, _format, default, param) do
+    def decoder(_type, _format, default, param) do
       default.(param)
     end
 
-    defp encoder(type, default, %Ecto.Tagged{value: value}) do
+    @doc false
+    def encoder(type, default, %Ecto.Tagged{value: value}) do
       encoder(type, default, value)
     end
 
-    defp encoder(%TypeInfo{sender: "interval"}, default, %Ecto.Interval{} = interval) do
+    def encoder(%TypeInfo{sender: "interval"}, default, %Ecto.Interval{} = interval) do
       mon = interval.year * 12 + interval.month
       day = interval.day
       sec = interval.hour * 3600 + interval.min * 60 + interval.sec
       default.({mon, day, sec})
     end
 
-    defp encoder(%TypeInfo{sender: sender}, default, %Ecto.DateTime{} = datetime)
+    def encoder(%TypeInfo{sender: sender}, default, %Ecto.DateTime{} = datetime)
         when sender in ["timestamp", "timestamptz"] do
       Ecto.DateTime.to_erl(datetime)
       |> default.()
     end
 
-    defp encoder(%TypeInfo{sender: "date"}, default, %Ecto.Date{} = date) do
+    def encoder(%TypeInfo{sender: "date"}, default, %Ecto.Date{} = date) do
       Ecto.Date.to_erl(date)
       |> default.()
     end
 
-    defp encoder(%TypeInfo{sender: sender}, default, %Ecto.Time{} = time)
+    def encoder(%TypeInfo{sender: sender}, default, %Ecto.Time{} = time)
         when sender in ["time", "timetz"] do
       Ecto.Time.to_erl(time)
       |> default.()
     end
 
-    defp encoder(%TypeInfo{sender: "uuid"}, _default, uuid) do
+    def encoder(%TypeInfo{sender: "uuid"}, _default, uuid) do
       uuid
     end
 
-    defp encoder(_type, default, param) do
+    def encoder(_type, default, param) do
       default.(param)
     end
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -18,6 +18,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     `:ssl` - Set to true if ssl should be used (default: false);
     `:ssl_opts` - A list of ssl options, see ssl docs;
     `:lazy` - If false all connections will be started immediately on Repo startup (default: true)
+    `:formatter` - custom formatter to be used by the adapter. (default: &Ecto.Adapters.Postgres.formatter/1)
+    `:decoder` - custom decoder to be used by the adapter. (default: &Ecto.Adapters.Postgres.decoder/4)
+    `:encoder` - custom encoder to be used by the adapter. (default: &Ecto.Adapters.Postgres.encoder/3)
+
     """
 
     @behaviour Ecto.Adapter
@@ -159,9 +163,9 @@ if Code.ensure_loaded?(Postgrex.Connection) do
         worker_module: Worker ] ++ pool_opts
 
       worker_opts = worker_opts
-        |> Keyword.put(:formatter, &formatter/1)
-        |> Keyword.put(:decoder, &decoder/4)
-        |> Keyword.put(:encoder, &encoder/3)
+        |> Keyword.put_new(:formatter, &formatter/1)
+        |> Keyword.put_new(:decoder, &decoder/4)
+        |> Keyword.put_new(:encoder, &encoder/3)
         |> Keyword.put_new(:port, @default_port)
 
       {pool_opts, worker_opts}

--- a/lib/ecto/adapters/postgres/sql.ex
+++ b/lib/ecto/adapters/postgres/sql.ex
@@ -511,6 +511,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     defp type(:interval), do: "interval"
     defp type(:decimal),  do: "decimal"
     defp type(:uuid),     do: "uuid"
+    defp type(:hstore),   do: "hstore"
 
     defp type({:array, inner}), do: type(inner) <> "[]"
 

--- a/lib/ecto/adapters/postgres/worker.ex
+++ b/lib/ecto/adapters/postgres/worker.ex
@@ -13,6 +13,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     end
 
     def query!(worker, sql, params, opts) do
+      Apex.ap({:query!, worker, sql, params, opts})
       case GenServer.call(worker, {:query, sql, params, opts}, opts[:timeout]) do
         {:ok, res} -> res
         {:error, %Postgrex.Error{} = err} -> raise err
@@ -76,6 +77,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     end
 
     def handle_call({:query, sql, params, opts}, _from, %{conn: conn} = s) do
+      Apex.ap(["Querying connection with: ",conn, sql, params, opts])
       {:reply, Postgrex.Connection.query(conn, sql, params, opts), s}
     end
 

--- a/lib/ecto/model/schema.ex
+++ b/lib/ecto/model/schema.ex
@@ -345,8 +345,9 @@ defmodule Ecto.Model.Schema do
   @doc false
   def __field__(mod, name, type, opts) do
     check_type!(type)
+    Apex.ap {mod, name, type, opts}
     fields = Module.get_attribute(mod, :ecto_fields)
-
+    validate_field_options!(name, type, opts)
     if opts[:primary_key] do
       if pk = Module.get_attribute(mod, :ecto_primary_key) do
         raise ArgumentError, message: "primary key already defined as `#{pk}`"
@@ -365,6 +366,19 @@ defmodule Ecto.Model.Schema do
 
     opts = Enum.reduce([:default, :primary_key], opts, &Dict.delete(&2, &1))
     Module.put_attribute(mod, :ecto_fields, [{name, [type: type] ++ opts}|fields])
+  end
+
+  @doc false
+  def validate_field_options!(field_name, :hstore, opts) do
+    default = opts[:default]
+    unless is_nil(default) or is_map(default) do
+      raise ArgumentError, message: ":default for `#{field_name}` must be a map"
+    end
+  end
+
+  @doc false
+  def validate_field_options!(_, _, _) do
+    true
   end
 
   @doc false

--- a/lib/ecto/query/util.ex
+++ b/lib/ecto/query/util.ex
@@ -41,7 +41,7 @@ defmodule Ecto.Query.Util do
   @doc false
   defmacro types do
     ~w(boolean string integer float decimal binary datetime date time interval
-       uuid virtual)a
+       uuid virtual hstore)a
   end
 
   @doc false
@@ -106,6 +106,10 @@ defmodule Ecto.Query.Util do
     else
       {:error, "invalid type given to `array/2`: `#{inspect inner}`"}
     end
+  end
+
+  def value_to_type(value) when is_map(value) do
+     {:ok, :hstore}
   end
 
   def value_to_type(value), do: {:error, "unknown type of value `#{inspect value}`"}

--- a/mix.exs
+++ b/mix.exs
@@ -25,9 +25,10 @@ defmodule Ecto.Mixfile do
   defp deps do
     [{:poolboy, "~> 1.2"},
      {:decimal, "~> 0.2.3"},
-     {:postgrex, "~> 0.6.0", optional: true},
+     {:hstore, ">= 0.0.2", optional: true, github: "SenecaSystems/hstore"},
      {:ex_doc, "~> 0.6", only: :dev},
-     {:earmark, "~> 0.1", only: :dev}]
+     {:earmark, "~> 0.1", only: :dev},
+     {:apex, "~>0.3.0", only: :dev}]
   end
 
   defp test_paths(:pg),  do: ["integration_test/pg"]

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Ecto.Mixfile do
      {:hstore, ">= 0.0.2", optional: true, github: "SenecaSystems/hstore"},
      {:ex_doc, "~> 0.6", only: :dev},
      {:earmark, "~> 0.1", only: :dev},
-     {:apex, "~>0.3.0", only: :dev}]
+     {:apex, "~>0.3.0"}]
   end
 
   defp test_paths(:pg),  do: ["integration_test/pg"]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
-%{"decimal": {:package, "0.2.5"},
+%{"apex": {:package, "0.3.1"},
+  "decimal": {:package, "0.2.5"},
   "earmark": {:package, "0.1.10"},
   "ex_doc": {:package, "0.6.0"},
+  "hstore": {:git, "git://github.com/SenecaSystems/hstore.git", "f95c9d1554543399d40d5c036e03800c15e0d838", []},
   "poolboy": {:package, "1.3.0"},
-  "postgrex": {:package, "0.6.0"}}
+  "postgrex": {:git, "git://github.com/SenecaSystems/postgrex.git", "ff4014da842512899850a984012eac94dc3f1537", [branch: "hstore"]}}

--- a/test/ecto/adapters/postgres/sql_test.exs
+++ b/test/ecto/adapters/postgres/sql_test.exs
@@ -508,4 +508,18 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
     assert SQL.insert(model, []) ==
            {~s{INSERT INTO "model" ("id", "x", "y")\nVALUES ($1, $2, $3)}, [123, 0, 2]}
   end
+
+  defmodule HStoreModel do
+    use Ecto.Model
+
+    schema "hstore_models" do
+      field :data, :hstore, default: %{}
+    end
+  end
+
+  test "insert without a value should put in default" do
+    model = %HStoreModel{}
+    assert SQL.insert(model, [:data]) ==
+      {~s{INSERT INTO "hstore_models" ("data")\nVALUES ($1)\nRETURNING "data"}, [%{}]}
+  end
 end

--- a/test/ecto/model/schema_test.exs
+++ b/test/ecto/model/schema_test.exs
@@ -25,7 +25,7 @@ defmodule Ecto.Model.SchemaTest do
     end
   end
 
-  test "uses @schema_defauls" do
+  test "uses @schema_defaults" do
     assert %DefaultUser{uuid: "abc"}.uuid == "abc"
     assert DefaultUser.__schema__(:field, :comment_id) == [type: :string]
   end
@@ -47,8 +47,43 @@ defmodule Ecto.Model.SchemaTest do
     end
   end
 
+  defmodule Version do
+    use Ecto.Model
+
+    schema "versions" do
+      field :old_version, :hstore, default: %{}
+      field :duckets, {:array, :integer}
+    end
+  end
+
   test "imports Ecto.Query functions" do
     assert %Ecto.Query{} = MyModel.model_from
+  end
+
+  test "sets type for hstore field" do
+    assert Version.__schema__(:field, :old_version) == [type: :hstore]
+  end
+
+  test "allows defaults for hstore" do
+    assert %Version{}.old_version == %{}
+  end
+
+  test "raises an error when default is not a map" do
+    assert_raise ArgumentError, ":default for `gstore` must be a map", fn ->
+      defmodule ModelFieldNameClash do
+        use Ecto.Model
+
+        schema "stores" do
+          field :gstore, :hstore, default: "bananas"
+        end
+      end
+    end
+  end
+
+  test "hstore metadata" do
+    assert Version.__schema__(:field, :old_version) == [type: :hstore]
+    assert Version.__schema__(:field_type, :old_version) == :hstore
+    assert Version.__schema__(:keywords, %Version{ old_version: [key: "value"], duckets: {1,2,3} })
   end
 
   test "schema attributes" do


### PR DESCRIPTION
This would ease the integration of custom encoders like [geo](https://github.com/bryanjos/geo) to extend functionality.