### PR TITLE
Added ability to specify database options in repo config

### DIFF
--- a/integration_test/pg/storage_test.exs
+++ b/integration_test/pg/storage_test.exs
@@ -7,14 +7,24 @@ defmodule Ecto.Integration.StorageTest do
     [database: "storage_mgt",
      username: "postgres",
      password: "postgres",
-     hostname: "localhost"]
+     hostname: "localhost",
+     template: "template0",
+     encoding: "UTF8",
+     lc_collate: System.get_env["LANG"],
+     lc_ctype: System.get_env["LANG"]
+    ]
   end
 
   def wrong_user do
     [database: "storage_mgt",
      username: "randomuser",
      password: "password1234",
-     hostname: "localhost"]
+     hostname: "localhost",
+     template: "template0",
+     encoding: "UTF8",
+     lc_collate: System.get_env["LANG"],
+     lc_ctype: System.get_env["LANG"]
+    ]
   end
 
   def drop_database do

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -389,8 +389,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
 
     @doc false
     def storage_up(opts) do
-      # TODO: allow the user to specify those options either in the Repo or on command line
-      database_options = ~s(TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8')
+      database_options = ~s(TEMPLATE=#{opts[:template]} ENCODING='#{opts[:encoding]}' LC_COLLATE='#{opts[:lc_collate]}' LC_CTYPE='#{opts[:lc_ctype]}')
 
       output = run_with_psql opts, "CREATE DATABASE #{opts[:database]} " <> database_options
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -62,7 +62,7 @@ defmodule Ecto.Repo do
       @env unquote(env)
       require Logger
 
-      import Ecto.Utils, only: [parse_url: 1]
+      import Ecto.Utils, only: [parse_url: 1, parse_url: 2]
       import Application, only: [app_dir: 2]
 
       if @env do

--- a/lib/ecto/utils.ex
+++ b/lib/ecto/utils.ex
@@ -1,13 +1,21 @@
 defmodule Ecto.Utils do
   @doc """
   Parses an Ecto URL of the following format:
-  `ecto://username:password@hostname:port/database?opts=123` where all options
+  `ecto://username:password@hostname:port/database?opts=123`, %{} where all options
   but the database is optional.
+
+  Second parameters is for database options:
+    %{template: ~s(template0),
+      encoding: ~s(UTF8),
+      lc_collate: ~s(en_US.UTF-8),
+      lc_ctype: ~s(en_US.UTF-8)
+    }
+
 
   If `username` is not specified, `$PGUSER` or `$USER` will be used. `password`
   defaults to `$PGPASS`. `hostname` defaults to `$PGHOST` or `localhost`.
   """
-  def parse_url(url) do
+  def parse_url(url, db_opt\\ %{}) do
     unless String.match? url, ~r/^[^:\/?#\s]+:\/\// do
       raise Ecto.InvalidURLError, url: url, message: "url should start with a scheme, host should start with //"
     end
@@ -32,7 +40,15 @@ defmodule Ecto.Utils do
              port:     info.port ]
 
     opts = Enum.reject(opts, fn {_k, v} -> is_nil(v) end)
-    opts ++ query
+    opts ++ query ++ db_opts_mearge(db_opt)
+  end
+
+  def db_opts_mearge(opt\\ %{}) do
+    %{template: ~s(template0),
+      encoding: ~s(UTF8),
+      lc_collate: ~s(en_US.UTF-8),
+      lc_ctype: ~s(en_US.UTF-8)
+    } |> Map.merge(opt) |> Map.to_list
   end
 
   defp atomize_keys(dict) do

--- a/lib/ecto/utils.ex
+++ b/lib/ecto/utils.ex
@@ -2,20 +2,19 @@ defmodule Ecto.Utils do
   @doc """
   Parses an Ecto URL of the following format:
   `ecto://username:password@hostname:port/database?opts=123`, %{} where all options
-  but the database is optional.
 
-  Second parameters is for database options:
+  If `username` is not specified, `$PGUSER` or `$USER` will be used. `password`
+  defaults to `$PGPASS`. `hostname` defaults to `$PGHOST` or `localhost`.
+
+  You also can pass a second optional parameter as a map of database options where you can specify database options in following format:
     %{template: ~s(template0),
       encoding: ~s(UTF8),
       lc_collate: ~s(en_US.UTF-8),
       lc_ctype: ~s(en_US.UTF-8)
     }
 
-
-  If `username` is not specified, `$PGUSER` or `$USER` will be used. `password`
-  defaults to `$PGPASS`. `hostname` defaults to `$PGHOST` or `localhost`.
   """
-  def parse_url(url, db_opt\\ %{}) do
+  def parse_url(url,  db_options \\ %{}) do
     unless String.match? url, ~r/^[^:\/?#\s]+:\/\// do
       raise Ecto.InvalidURLError, url: url, message: "url should start with a scheme, host should start with //"
     end
@@ -40,10 +39,10 @@ defmodule Ecto.Utils do
              port:     info.port ]
 
     opts = Enum.reject(opts, fn {_k, v} -> is_nil(v) end)
-    opts ++ query ++ db_opts_mearge(db_opt)
+    opts ++ query ++ merge_db_options(db_options)
   end
 
-  def db_opts_mearge(opt\\ %{}) do
+  def merge_db_options(opt\\ %{}) do
     %{template: ~s(template0),
       encoding: ~s(UTF8),
       lc_collate: ~s(en_US.UTF-8),

--- a/lib/ecto/utils.ex
+++ b/lib/ecto/utils.ex
@@ -45,8 +45,8 @@ defmodule Ecto.Utils do
   def merge_db_options(opt\\ %{}) do
     %{template: ~s(template0),
       encoding: ~s(UTF8),
-      lc_collate: ~s(en_US.UTF-8),
-      lc_ctype: ~s(en_US.UTF-8)
+      lc_collate: System.get_env["LANG"],
+      lc_ctype: System.get_env["LANG"]
     } |> Map.merge(opt) |> Map.to_list
   end
 

--- a/test/ecto/utils_test.exs
+++ b/test/ecto/utils_test.exs
@@ -14,6 +14,34 @@ defmodule Ecto.UtilsTest do
     assert {:a, "b"} in url
   end
 
+  test "parse_url return list with db options" do
+    opt = parse_url("ecto://eric:hunter2@host:12345/mydb?size=10&a=b", %{lc_collate: "en_IE.UTF-8"})
+    assert {:encoding, "UTF8"} in opt
+    assert {:lc_collate, "en_IE.UTF-8"} in opt
+  end
+
+  test "db_opts_mearge" do
+    new_opt = %{lc_collate: "en_IE.UTF-8", lc_ctype: "en_IE.UTF-8"}
+    opt = db_opts_mearge(new_opt)
+
+    assert opt[:lc_collate] == new_opt[:lc_collate]
+    assert opt[:lc_ctype] == new_opt[:lc_ctype]
+    assert is_list opt
+  end
+
+  test "when db_opts_mearge is empty " do
+    default_val = %{template: ~s(template0),
+      encoding: ~s(UTF8),
+      lc_collate: ~s(en_US.UTF-8),
+      lc_ctype: ~s(en_US.UTF-8)
+    }
+
+    opt = db_opts_mearge
+    assert opt[:lc_collate] == default_val[:lc_collate]
+    assert opt[:lc_ctype] == default_val[:lc_ctype]
+    assert is_list opt
+  end
+
   test "parse_urls empty username/password" do
     url = parse_url("ecto://host:12345/mydb?size=10&a=b")
     assert !Dict.has_key?(url, :username)

--- a/test/ecto/utils_test.exs
+++ b/test/ecto/utils_test.exs
@@ -20,23 +20,23 @@ defmodule Ecto.UtilsTest do
     assert {:lc_collate, "en_IE.UTF-8"} in opt
   end
 
-  test "db_opts_mearge" do
+  test "merge_db_options" do
     new_opt = %{lc_collate: "en_IE.UTF-8", lc_ctype: "en_IE.UTF-8"}
-    opt = db_opts_mearge(new_opt)
+    opt = merge_db_options(new_opt)
 
     assert opt[:lc_collate] == new_opt[:lc_collate]
     assert opt[:lc_ctype] == new_opt[:lc_ctype]
     assert is_list opt
   end
 
-  test "when db_opts_mearge is empty " do
+  test "when merge_db_options is empty " do
     default_val = %{template: ~s(template0),
       encoding: ~s(UTF8),
       lc_collate: ~s(en_US.UTF-8),
       lc_ctype: ~s(en_US.UTF-8)
     }
 
-    opt = db_opts_mearge
+    opt = merge_db_options
     assert opt[:lc_collate] == default_val[:lc_collate]
     assert opt[:lc_ctype] == default_val[:lc_ctype]
     assert is_list opt

--- a/test/ecto/utils_test.exs
+++ b/test/ecto/utils_test.exs
@@ -21,7 +21,7 @@ defmodule Ecto.UtilsTest do
   end
 
   test "merge_db_options" do
-    new_opt = %{lc_collate: "en_IE.UTF-8", lc_ctype: "en_IE.UTF-8"}
+    new_opt = %{lc_collate: "lv_IE.UTF-8", lc_ctype: "lv_IE.UTF-8"}
     opt = merge_db_options(new_opt)
 
     assert opt[:lc_collate] == new_opt[:lc_collate]
@@ -32,8 +32,8 @@ defmodule Ecto.UtilsTest do
   test "when merge_db_options is empty " do
     default_val = %{template: ~s(template0),
       encoding: ~s(UTF8),
-      lc_collate: ~s(en_US.UTF-8),
-      lc_ctype: ~s(en_US.UTF-8)
+      lc_collate: System.get_env["LANG"],
+      lc_ctype: System.get_env["LANG"]
     }
 
     opt = merge_db_options


### PR DESCRIPTION
Hey guys,
@DainisL found that there is no ability to add database options to repo. Here is a fix for that. Let us know if there are any adjustments needed.

Thanks