### PR TITLE
Make `Changeset.cast/4` optionals param optional

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -95,6 +95,8 @@ defmodule Ecto.Changeset do
 
   """
   @spec cast(%{binary => term} | nil, Ecto.Model.t, [String.t | atom], [String.t | atom]) :: t
+  def cast(val, model, required, optional \\ [])
+
   def cast(nil, %{__struct__: _} = model, required, optional)
       when is_list(required) and is_list(optional) do
     to_atom = fn

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -18,7 +18,7 @@ defmodule Ecto.ChangesetTest do
 
   ## cast/4
 
-  test "cast/4: on success" do
+  test "cast/4: on success is valid" do
     params = %{"title" => "hello", "body" => "world"}
     struct = %Post{}
 
@@ -33,7 +33,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
   end
 
-  test "cast/4: missing optional" do
+  test "cast/4: missing optional is valid" do
     params = %{"title" => "hello"}
     struct = %Post{}
 
@@ -45,7 +45,19 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
   end
 
-  test "cast/4: missing required" do
+  test "cast/4: no optionals passed is valid" do
+    params = %{"title" => "hello"}
+    struct = %Post{}
+
+    changeset = cast(params, struct, ~w(title))
+    assert changeset.params == params
+    assert changeset.model  == struct
+    assert changeset.changes == %{title: "hello"}
+    assert changeset.errors == []
+    assert changeset.valid?
+  end
+
+  test "cast/4: missing required is invalid" do
     params = %{"body" => "world"}
     struct = %Post{}
 
@@ -57,7 +69,7 @@ defmodule Ecto.ChangesetTest do
     refute changeset.valid?
   end
 
-  test "cast/4: no parameters" do
+  test "cast/4: no parameters is invalid" do
     changeset = cast(nil, %Post{}, ~w(title), ~w(body)a)
     assert changeset.model == %Post{}
     assert changeset.params == nil


### PR DESCRIPTION
When calling `Changeset.cast/4` you are required to pass a value to
optionals. This makes the optionals parameter default to an empty list
when not present.