### PR TITLE
Support casting floats and integers in addition to binaries to Decimal

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -418,7 +418,7 @@ defmodule Ecto.Type do
   defp do_cast(:boolean, term) when term in ~w(true 1),  do: {:ok, true}
   defp do_cast(:boolean, term) when term in ~w(false 0), do: {:ok, false}
 
-  defp do_cast(:decimal, term) when is_binary(term) do
+  defp do_cast(:decimal, term) when is_binary(term) or is_number(term) do
     {:ok, Decimal.new(term)} # TODO: Add Decimal.parse/1
   rescue
     Decimal.Error -> :error

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -33,4 +33,10 @@ defmodule Ecto.TypeTest do
     assert dump({:array, __MODULE__}, [nil]) == {:ok, [nil]}
     assert cast({:array, __MODULE__}, [nil]) == {:ok, [nil]}
   end
+
+  test "decimal casting" do
+    assert cast(:decimal, "1.0") == {:ok, Decimal.new("1.0")}
+    assert cast(:decimal, 1.0) == {:ok, Decimal.new("1.0")}
+    assert cast(:decimal, 1) == {:ok, Decimal.new("1")}
+  end
 end


### PR DESCRIPTION
I want to use `Ecto.Changeset.cast/4` with a `:decimal` field with `params` coming from JSON. JavaScript's JSON encoding (and the JSON spec) don't distinguish between floats or integers. So using Poison or JSX to decode JSON and assign it to my changeset fails, unless `:decimal` can be casted to from floats and integers. That's what this PR enables.

```javascript
JSON.stringify({a: 1.0}) === '{"a":1}'
```