### PR TITLE
Ecto.Changeset.convert_params/1 bugfix or behaviour change

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -183,14 +183,12 @@ defmodule Ecto.Changeset do
   end
 
   defp convert_params(params) do
-    :maps.fold fn
-      key, _value, _acc when is_binary(key) ->
-        throw :noop
-      key, value, acc when is_atom(key) ->
-        Map.put(acc, Atom.to_string(key), value)
-    end, %{}, params
-  catch
-    :noop -> params
+    key_to_string = fn
+      {key, _val} = pair when is_binary(key) -> pair
+      {key, val} when is_atom(key)           -> {Atom.to_string(key), val}
+    end
+
+    params |> Enum.map(key_to_string) |> Enum.into(%{})
   end
 
   defp error_on_blank(type, key, value, errors) do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -48,6 +48,20 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
   end
 
+  test "cast/4: with mixed atom and string keys" do
+    params = %{:title => "hello", "body" => "world"}
+    struct = %Post{}
+
+    changeset = cast(params, struct, ["title", :body], [])
+    assert changeset.params == %{"title" => "hello", "body" => "world"}
+    assert changeset.model  == struct
+    assert changeset.changes == %{title: "hello", body: "world"}
+    assert changeset.errors == []
+    assert changeset.validations == []
+    assert changeset.required == [:title, :body]
+    assert changeset.valid?
+  end
+
   test "cast/4: missing optional is valid" do
     params = %{"title" => "hello"}
     struct = %Post{}


### PR DESCRIPTION
If the keys in the params are mixed atoms and strings, validations fail and the params with an atom key are marked as missing (if required). For example:

```elixir
defmodule MyModule do
  def changeset(instance, params \\ nil) do
    params |> cast(instance, ~w(f1 f2))
  end
end
```

If I call `changeset/2` like this:

```elixir
MyModule.changeset(%MyModule{}, %{:f1 => "v1", "f2" => "v2"})
```

it will fail saying that one of the fields is required but not present. I added a failing test in the first commit, and the fix in the second commit.

I'm not 300% sure this is a real bug (I kind of smelled something strange when I saw `throw`/`catch` in the current implementation of `Ecto.Changeset.convert_params/1`), but I figured that a bug report *with* a PR for an eventual fix (if this turns out to be a bug) is better than a bug report alone :smile: 