### PR TITLE
Make test transaction functions idempotent

### DIFF
--- a/lib/ecto/adapters/sql/worker.ex
+++ b/lib/ecto/adapters/sql/worker.ex
@@ -163,11 +163,19 @@ defmodule Ecto.Adapters.SQL.Worker do
     end
   end
 
+  def handle_call({:begin_test_transaction, _opts}, _from, %{sandbox: true} = s) do
+    {:reply, :ok, s}
+  end
+
   def handle_call({:begin_test_transaction, _opts}, _from, %{transactions: 0} = s) do
     case begin_sandbox(%{s | sandbox: true}) do
       {:ok, s}      -> {:reply, :ok, s}
       {:error, err} -> {:reply, {:error, err}, s}
     end
+  end
+
+  def handle_call({:restart_test_transaction, _opts}, _from, %{sandbox: false} = s) do
+    {:reply, :ok, s}
   end
 
   def handle_call({:restart_test_transaction, opts}, _from, %{transactions: 1} = s) do
@@ -180,6 +188,10 @@ defmodule Ecto.Adapters.SQL.Worker do
         GenServer.reply(err)
         wipe_state(s)
     end
+  end
+
+  def handle_call({:rollback_test_transaction, _opts}, _from, %{sandbox: false} = s) do
+    {:reply, :ok, s}
   end
 
   def handle_call({:rollback_test_transaction, opts}, _from, %{transactions: 1} = s) do


### PR DESCRIPTION
This will make the three test transaction functions idempotent. Previous to this change a `FunctionClauseError` exception would be raised when any of the three functions were called out of order or multiple times.

This is especially useful in an umbrella application where one application is dependent upon another for testing purposes. If one or more applications within the umbrella attempt to call begin test transaction the test suite will shutdown in error.