### PR TITLE
Only drop index if it exists.

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -410,7 +410,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     end
 
     def execute_ddl({:drop, %Index{}=index}) do
-      "DROP INDEX #{quote_name(index.name)}"
+      "DROP INDEX IF EXISTS #{quote_name(index.name)}"
     end
 
     def execute_ddl(default) when is_binary(default), do: default

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -434,7 +434,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "drop index" do
     drop = {:drop, %Index{name: "posts$main"}}
-    assert SQL.execute_ddl(drop) == ~s|DROP INDEX "posts$main"|
+    assert SQL.execute_ddl(drop) == ~s|DROP INDEX IF EXISTS "posts$main"|
   end
 
   test "alter table" do


### PR DESCRIPTION
I don't know if this is the best solution, but I wanted to throw something up to start a discussion about handling the following situation:

```elixir
defmodule Blog.Repo.Migrations.AddPosts do
  use Ecto.Migration

  def change do
    create table(:posts) do
      add :title, :string
      add :body,  :string
      add :slug,  :string
      timestamps
    end

    create index(:posts, [:slug])
  end
end
```

```shell
mix ecto.migrate
mix ecto.rollback

** (Postgrex.Error) ERROR (42704): index "posts_slug_index" does not exist
```

Currently the rollback will fail because dropping the table will drop the indexes, then the drop index will raise an exception.

There may be very good reasons not to add the `IF EXISTS` sql, but this seemed like the simplest approach. If there is a better/preferred approach to this (such as adding something similar to [Rail's index_exists?](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-index_exists-3F)) I am happy to take a stab at it.
