### PR TITLE
Cast integers to float.

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -343,6 +343,8 @@ defmodule Ecto.Type do
 
       iex> cast(:float, 1.0)
       {:ok, 1.0}
+      iex> cast(:float, 1)
+      {:ok, 1.0}
       iex> cast(:float, "1")
       {:ok, 1.0}
       iex> cast(:float, "1.0")
@@ -414,6 +416,8 @@ defmodule Ecto.Type do
       _           -> :error
     end
   end
+
+  defp do_cast(:float, term) when is_integer(term), do: {:ok, term + 0.0}
 
   defp do_cast(:boolean, term) when term in ~w(true 1),  do: {:ok, true}
   defp do_cast(:boolean, term) when term in ~w(false 0), do: {:ok, false}

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -41,4 +41,19 @@ defmodule Ecto.TypeTest do
     assert cast(:decimal, 1.0) == {:ok, Decimal.new("1.0")}
     assert cast(:decimal, 1) == {:ok, Decimal.new("1")}
   end
+
+  test "integer casting" do
+    assert cast(:integer, 1) == {:ok, 1}
+    assert cast(:integer, "1") == {:ok, 1}
+    assert cast(:integer, "1.0") == :error
+    assert cast(:integer, "1-nope") == :error
+  end
+
+  test "float casting" do
+    assert cast(:float, 1.0) == {:ok, 1.0}
+    assert cast(:float, 1) == {:ok, 1.0}
+    assert cast(:float, "1.0") == {:ok, 1.0}
+    assert cast(:float, "1") == {:ok, 1.0}
+    assert cast(:float, "1.err") == :error
+  end
 end


### PR DESCRIPTION
This is important when JavaScript is building requests because JS only
has floats, but represents 2.0 as 2 when serializing.