### PR TITLE
Add support for adding/dropping indexes concurrently with Postgres

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -404,8 +404,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     end
 
     def execute_ddl({:create, %Index{}=index}) do
-      assemble(["CREATE#{if index.unique, do: " UNIQUE"} INDEX",
-                quote_name(index.name), "ON", quote_name(index.table),
+      create = "CREATE#{if index.unique, do: " UNIQUE"} INDEX"
+      if index.concurrently, do: create = create <> " CONCURRENTLY"
+
+      assemble([create, quote_name(index.name), "ON", quote_name(index.table),
                 "(#{Enum.map_join(index.columns, ", ", &index_expr/1)})"])
     end
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -412,7 +412,11 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     end
 
     def execute_ddl({:drop, %Index{}=index}) do
-      "DROP INDEX #{quote_name(index.name)}"
+      assemble([
+        "DROP INDEX",
+        if(index.concurrently, do: "CONCURRENTLY"),
+        quote_name(index.name),
+      ])
     end
 
     def execute_ddl(default) when is_binary(default), do: default

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -69,8 +69,19 @@ defmodule Ecto.Migration do
     @moduledoc """
     Defines an index struct used in migrations.
     """
-    defstruct table: nil, name: nil, columns: [], unique: false
-    @type t :: %__MODULE__{table: atom, name: atom, columns: [atom | String.t], unique: boolean}
+    defstruct table: nil,
+              name: nil,
+              columns: [],
+              unique: false,
+              concurrently: false
+
+    @type t :: %__MODULE__{
+      table: atom,
+      name: atom,
+      columns: [atom | String.t],
+      unique: boolean,
+      concurrently: boolean
+    }
   end
 
   defmodule Table do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -106,7 +106,6 @@ defmodule Ecto.Migration do
   defmacro __using__(_) do
     quote location: :keep do
       import Ecto.Migration
-      def __migration__, do: true
       @disable_ddl_transaction false
       @before_compile Ecto.Migration
     end
@@ -115,7 +114,8 @@ defmodule Ecto.Migration do
   @doc false
   defmacro __before_compile__(_env) do
     quote do
-      def __disable_ddl_transaction__, do: @disable_ddl_transaction
+      def __migration__,
+        do: [disable_ddl_transaction: @disable_ddl_transaction]
     end
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -107,6 +107,15 @@ defmodule Ecto.Migration do
     quote location: :keep do
       import Ecto.Migration
       def __migration__, do: true
+      @disable_ddl_transaction false
+      @before_compile Ecto.Migration
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(_env) do
+    quote do
+      def __disable_ddl_transaction__, do: @disable_ddl_transaction
     end
   end
 

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -63,7 +63,7 @@ defmodule Ecto.Migrator do
       SchemaMigration.up(repo, version)
     end
 
-    if module.__disable_ddl_transaction__ do
+    if module.__migration__[:disable_ddl_transaction] do
       run_attempts.()
     else
       repo.transaction [log: false], run_attempts
@@ -99,7 +99,7 @@ defmodule Ecto.Migrator do
       SchemaMigration.down(repo, version)
     end
 
-    if module.__disable_ddl_transaction__ do
+    if module.__migration__[:disable_ddl_transaction] do
       run_attempts.()
     else
       repo.transaction [log: false], run_attempts

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -432,6 +432,16 @@ defmodule Ecto.Adapters.PostgresTest do
     assert SQL.execute_ddl(create) == ~s|CREATE UNIQUE INDEX "posts$main" ON "posts" ("permalink")|
   end
 
+  test "create index concurrently" do
+    create = {:create, %Index{name: "posts$main", table: :posts, columns: [:permalink], concurrently: true}}
+    assert SQL.execute_ddl(create) == ~s|CREATE INDEX CONCURRENTLY "posts$main" ON "posts" ("permalink")|
+  end
+
+  test "create unique index concurrently" do
+    create = {:create, %Index{name: "posts$main", table: :posts, columns: [:permalink], concurrently: true, unique: true}}
+    assert SQL.execute_ddl(create) == ~s|CREATE UNIQUE INDEX CONCURRENTLY "posts$main" ON "posts" ("permalink")|
+  end
+
   test "drop index" do
     drop = {:drop, %Index{name: "posts$main"}}
     assert SQL.execute_ddl(drop) == ~s|DROP INDEX "posts$main"|

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -447,6 +447,11 @@ defmodule Ecto.Adapters.PostgresTest do
     assert SQL.execute_ddl(drop) == ~s|DROP INDEX "posts$main"|
   end
 
+  test "drop index concurrently" do
+    drop = {:drop, %Index{name: "posts$main", concurrently: true}}
+    assert SQL.execute_ddl(drop) == ~s|DROP INDEX CONCURRENTLY "posts$main"|
+  end
+
   test "alter table" do
     alter = {:alter, %Table{name: :posts},
                [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},


### PR DESCRIPTION
I added support for adding/dropping indexes concurrently as specified in #391.

I'm not sure this PR is ready to merge, I think I need a short review first.

The most straightforward part has been adding `@disable_ddl_transaction` to `Ecto.Migration`: what I did was adding a `@before_compile` hook in `Ecto.Migration.__using__/1` in order to define a `__disable_ddl_transaction__/0` function on the migration module. This way, I can retrieve that value in `Ecto.Migrator` and avoid wrapping everything inside a transaction if that's the case.

The part I'm the least sure about is actually adding the `CONCURRENTLY` keyword to the query. I added the `:concurrently` field to the `Ecto.Migration.Index` struct and added the `CONCURRENTLY` only for the Postgres adapter (since only Postgres supports this option AFAIK), but didn't take any measure to ensure that the `:concurrently` field is ignored (or raised against) by other adapters.

What do you think for now?

**PS** I'd also love a small review to the unit test I wrote; I have to check that no transactions are run, but the schema migrator runs one so I can't just do `refute_receive {:transaction, _}`. Let me know!