### PR TITLE
Create indexes with USING

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -407,8 +407,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       create = "CREATE#{if index.unique, do: " UNIQUE"} INDEX"
       if index.concurrently, do: create = create <> " CONCURRENTLY"
 
+      using = if index.using do "USING #{index.using}" end
+
       assemble([create, quote_name(index.name), "ON", quote_name(index.table),
-                "(#{Enum.map_join(index.columns, ", ", &index_expr/1)})"])
+                using, "(#{Enum.map_join(index.columns, ", ", &index_expr/1)})"])
     end
 
     def execute_ddl({:drop, %Index{}=index}) do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -99,14 +99,16 @@ defmodule Ecto.Migration do
               name: nil,
               columns: [],
               unique: false,
-              concurrently: false
+              concurrently: false,
+              using: nil
 
     @type t :: %__MODULE__{
       table: atom,
       name: atom,
       columns: [atom | String.t],
       unique: boolean,
-      concurrently: boolean
+      concurrently: boolean,
+      using: atom | String.t
     }
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -268,6 +268,16 @@ defmodule Ecto.Migration do
   not be run inside a transaction. See the `Ecto.Migration` docs for more
   information on running migrations outside of a transaction.
 
+  ## Index types
+
+  PostgreSQL supports several index types like B-tree, Hash or GiST. When
+  creating an index, the index type defaults to B-tree, but it can be specified
+  with the `:using` option. The `:using` option can be an atom or a string; its
+  value is passed to the `USING` clause as is.
+
+  More information on index types can be found in the [PostgreSQL
+  docs](http://www.postgresql.org/docs/9.4/static/indexes-types.html).
+
   ## Examples
 
       # Without a name, index defaults to products_category_id_sku_index
@@ -276,8 +286,11 @@ defmodule Ecto.Migration do
       # Name can be given explicitly though
       drop index(:products, [:category_id, :sku], name: :my_special_name)
 
-      # Adding an index concurrently
+      # Indexes can be added concurrently
       create index(:products, [:category_id, :sku], concurrently: true)
+
+      # The index type can be specified
+      create index(:products, [:name], using: :hash)
 
   """
   def index(table, columns, opts \\ []) when is_atom(table) and is_list(columns) do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -442,6 +442,16 @@ defmodule Ecto.Adapters.PostgresTest do
     assert SQL.execute_ddl(create) == ~s|CREATE UNIQUE INDEX CONCURRENTLY "posts$main" ON "posts" ("permalink")|
   end
 
+  test "create an index using a different type" do
+    create = {:create, %Index{name: "posts$hash", table: :posts, columns: [:id], using: :hash}}
+    assert SQL.execute_ddl(create) == ~s|CREATE INDEX "posts$hash" ON "posts" USING hash ("id")|
+  end
+
+  test "create an index using a different type concurrently" do
+    create = {:create, %Index{name: "posts$hash", table: :posts, columns: [:id], concurrently: true, using: "gist"}}
+    assert SQL.execute_ddl(create) == ~s|CREATE INDEX CONCURRENTLY "posts$hash" ON "posts" USING gist ("id")|
+  end
+
   test "drop index" do
     drop = {:drop, %Index{name: "posts$main"}}
     assert SQL.execute_ddl(drop) == ~s|DROP INDEX "posts$main"|


### PR DESCRIPTION
This PR should close #427 since it adds support for GiST and GIN indexes in Postgres but also for all other types of indexes, since it adds support for `USING` when creating indexes.

I added docs for this option as well as a couple of unit tests (testing the generated SQL). I'm not sure if I should add any integration test or any test under `Ecto.Migration` since the change is very simple and just translates to a Postgres feature, without involving much Ecto.

Let me know what you think!