### PR TITLE
Update the version of the deps in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add Ecto as a dependency in your `mix.exs` file. If you are using PostgreSQL, yo
 ```elixir
 defp deps do
   [{:postgrex, ">= 0.0.0"},
-   {:ecto, "~> 0.5"}]
+   {:ecto, "~> 0.7"}]
 end
 ```
 


### PR DESCRIPTION
I upgraded the version of the postgrex and Ecto dependencies shown in the README "Usage" section, since that is probably where people look at when they're adding Ecto to their deps.