### PR TITLE
Composable casts

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -244,6 +244,48 @@ defmodule Ecto.Changeset do
 
   ## Working with changesets
 
+  @doc """
+  Merges two changesets.
+
+  This function merges two changesets provided they have been applied to the
+  same model (their `:model` field is equal); if the models differ, an
+  `ArgumentError` exception is raised. If one of the changesets has a `:repo`
+  field which is not `nil`, then the value of that field is used as the `:repo`
+  field of the resulting changeset; if both changesets have a non-`nil` and
+  different `:repo` field, an `ArgumentError` exception is raised.
+
+  The other fields are merged with the following criteria:
+
+  * `params` - params are merged (not deep-merged) giving precedence to the
+    params of `changeset2` in case of a conflict. If either changeset has its
+    `:params` field set to `nil`, the resulting changeset will have its params
+    set to `nil` too.
+  * `changes` - changes are merged giving precedence to the `changeset2`
+    changes.
+  * `errors` and `validations` - they are simply concatenated.
+  * `required` and `optional` - they are merged; all the fields that appear
+    in the optional list of either changesets and also in the required list of
+    the other changeset are moved to the required list of the resulting
+    changeset.
+
+  ## Examples
+
+      iex> changeset1 = cast(%{title: "Title"}, %Post{}, ~w(title), ~w(body))
+      iex> changeset2 = cast(%{title: "New title", body: "Body"}, %Post{}, ~w(title body), ~w())
+      iex> changeset = merge(changeset1, changeset2)
+      iex> changeset.changes
+      %{body: "Body", title: "New title"}
+      iex> changeset.required
+      [:title, :body]
+      iex> changeset.optional
+      []
+
+      iex> changeset1 = cast(%{title: "Title"}, %Post{body: "Body"}, ~w(title), ~w(body))
+      iex> changeset2 = cast(%{title: "New title"}, %Post{}, ~w(title), ~w())
+      iex> merge(changeset1, changeset2)
+      ** (ArgumentError) different models when merging changesets
+
+  """
   @spec merge(t, t) :: t
   def merge(changeset1, changeset2)
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -250,9 +250,7 @@ defmodule Ecto.Changeset do
 
     # Merges the :optional field of both changesets and then pulls out all the
     # fields that have now become required.
-    opt_set = Enum.into(cs1.optional ++ cs2.optional, HashSet.new)
-    req_set = Enum.into(new_required, HashSet.new)
-    new_optional = HashSet.difference(opt_set, req_set) |> HashSet.to_list
+    new_optional = Enum.uniq(cs1.optional ++ cs2.optional) -- new_required
 
     %Ecto.Changeset{params: new_params, model: model, valid?: new_errors == [],
                     errors: new_errors, changes: new_changes,

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -243,10 +243,11 @@ defmodule Ecto.Changeset do
   end
 
   defp merge_changesets(%Ecto.Changeset{model: model} = cs1, %Ecto.Changeset{model: model} = cs2) do
-    new_params   = Map.merge(cs1.params, cs2.params)
-    new_changes  = Map.merge(cs1.changes, cs2.changes)
-    new_errors   = cs1.errors ++ cs2.errors
-    new_required = Enum.uniq(cs1.required ++ cs2.required)
+    new_params      = Map.merge(cs1.params, cs2.params)
+    new_changes     = Map.merge(cs1.changes, cs2.changes)
+    new_validations = cs1.validations ++ cs2.validations
+    new_errors      = cs1.errors ++ cs2.errors
+    new_required    = Enum.uniq(cs1.required ++ cs2.required)
 
     # Merges the :optional field of both changesets and then pulls out all the
     # fields that have now become required.
@@ -254,7 +255,8 @@ defmodule Ecto.Changeset do
 
     %Ecto.Changeset{params: new_params, model: model, valid?: new_errors == [],
                     errors: new_errors, changes: new_changes,
-                    required: new_required, optional: new_optional}
+                    required: new_required, optional: new_optional,
+                    validations: new_validations}
   end
 
   ## Working with changesets

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -218,6 +218,19 @@ defmodule Ecto.ChangesetTest do
     assert Enum.sort(changeset.errors) == [body: :required, title: :required, title: :required]
   end
 
+  test "cast/4: merges validations when a changeset is passed" do
+    base_changeset = cast(%{title: "Title"}, %Post{}, ~w(title), ~w())
+                |> validate_length(:title, 1..10)
+
+    changeset = cast(%{body: "Body"}, base_changeset, ~w(body), ~w())
+                |> validate_format(:body, ~r/B/)
+
+    assert changeset.valid?
+    assert length(changeset.validations) == 2
+    assert Enum.find(changeset.validations, &match?({:body, {:format, _}}, &1))
+    assert Enum.find(changeset.validations, &match?({:title, {:length, _}}, &1))
+  end
+
   ## Changeset functions
 
   test "change/2" do


### PR DESCRIPTION
This should close #401.

This PR adds the possibility of composing casts by making `Ecto.Changeset.cast/4` accept a changeset instead of a model as its second argument:

```elixir
changeset = cast(%{title: "Title"}, %Post{}, ~w(title), ~w())
cast(%{title: "Foo", body: "Bar"}, changeset, ~w(title), ~w(body))
```

I think the nicest solution (and the one I've implemented) is to apply the new "cast" to the model in the argument changeset (in the example, `changeset.model`) and then to meticulously merge the argument changeset and the new changeset (I added the `merge_changesets/2` function for that).

Another way to implement this would have been to manually call `cast` with the model in the argument changeset and with merged title, options and params) but that way an already applied cast is just re-applied another time; maybe this solution is nicer though, so I'm more than willing to change the implementation (I could `push --force` just the second commit) if so.

Thanks! :smiley: 