### PR TITLE
Only drop existing indexes when reversing `create index`.

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -200,6 +200,9 @@ defmodule Ecto.Migration do
   @doc """
   Creates an index.
 
+  When reversing (in `change` running backward) indexes are only dropped if they
+  exist and no errors are raised. To enforce dropping an index use `drop/1`.
+
   ## Examples
 
       create index(:posts, [:name])

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -115,6 +115,13 @@ defmodule Ecto.Migration.Runner do
     repo.adapter.execute_ddl(repo, command, @opts)
   end
 
+  defp execute_in_direction(repo, :backward, level, {:create, %Index{}=index}) do
+    if repo.adapter.ddl_exists?(repo, index, @opts) do
+      log_ddl(level, {:drop, index})
+      repo.adapter.execute_ddl(repo, {:drop, index}, @opts)
+    end
+  end
+
   defp execute_in_direction(repo, :backward, level, command) do
     reversed = reverse(command)
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -181,6 +181,13 @@ defmodule Ecto.MigrationTest do
     assert {:drop, %Index{}} = last_command()
   end
 
+  test "backward: creates an index (does not exist)" do
+    Process.put(:ddl_exists, false)
+    create index(:posts, [:title])
+    refute last_command()
+    Process.delete(:ddl_exists)
+  end
+
   test "backward: drops an index" do
     drop index(:posts, [:title])
     assert {:create, %Index{}} = last_command()

--- a/test/support/mock_repo.exs
+++ b/test/support/mock_repo.exs
@@ -55,7 +55,7 @@ defmodule Ecto.MockAdapter do
 
   def ddl_exists?(_repo, object, _) do
     Process.put(:last_exists, object)
-    true
+    Process.get(:ddl_exists, true)
   end
 
   defp migrated_versions do


### PR DESCRIPTION
This fixes the situation where reversing a migration that adds a table
and an index would fail, because dropping the table will remove the
indexes.

Fixes #423