### PR TITLE
Allow boolean literals as defaults.

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -464,7 +464,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       do: nil
     defp default_expr(literal) when is_binary(literal),
       do: "DEFAULT '#{escape_string(literal)}'"
-    defp default_expr(literal) when is_number(literal),
+    defp default_expr(literal) when is_number(literal) or is_boolean(literal),
       do: "DEFAULT #{literal}"
     defp default_expr({:fragment, expr}),
       do: "DEFAULT #{expr}"

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -407,12 +407,14 @@ defmodule Ecto.Adapters.PostgresTest do
     create = {:create, table(:posts),
                [{:add, :name, :string, [default: "Untitled", size: 20, null: false]},
                 {:add, :price, :numeric, [precision: 8, scale: 2, default: {:fragment, "expr"}]},
-                {:add, :on_hand, :integer, [default: 0, null: true]}]}
+                {:add, :on_hand, :integer, [default: 0, null: true]},
+                {:add, :is_active, :boolean, [default: true]}]}
 
     assert SQL.execute_ddl(create) == """
     CREATE TABLE "posts" ("name" varchar(20) DEFAULT 'Untitled' NOT NULL,
     "price" numeric(8,2) DEFAULT expr,
-    "on_hand" integer DEFAULT 0 NULL)
+    "on_hand" integer DEFAULT 0 NULL,
+    "is_active" boolean DEFAULT true)
     """ |> String.strip |> String.replace("\n", " ")
   end
 


### PR DESCRIPTION
This PR addresses the bug described in #435.

The Postgres docs say: "The key words TRUE and FALSE are the preferred (SQL-compliant) usage."

This just uses `true` and `false` (lowercased). Case doesn't really matter but I wanted to check if this should be changed.