### PR TITLE
Check if the current adapter supports DDL transaction

### DIFF
--- a/lib/ecto/adapter/migrations.ex
+++ b/lib/ecto/adapter/migrations.ex
@@ -26,6 +26,12 @@ defmodule Ecto.Adapter.Migrations  do
   @type ddl_object :: Table.t | Index.t
 
   @doc """
+  Checks if the adapter supports ddl transaction.
+
+  """
+  defcallback supports_ddl_transaction? :: boolean
+
+  @doc """
   Executes migration commands.
 
   ## Options

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -119,4 +119,10 @@ defmodule Ecto.Adapters.Postgres do
     args = args ++ ["--quiet", "--host", database[:hostname], "-d", "template1", "-c", sql_command]
     System.cmd("psql", args, env: env, stderr_to_stdout: true)
   end
+
+  @doc false
+
+  def supports_ddl_transaction? do
+    true
+  end
 end

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -95,10 +95,10 @@ defmodule Ecto.Migrator do
   end
 
   defp run_maybe_in_transaction(repo, module, fun) do
-    if module.__migration__[:disable_ddl_transaction] do
-      fun.()
-    else
-      repo.transaction [log: false], fun
+    cond do
+      module.__migration__[:disable_ddl_transaction] -> fun.()
+      repo.adapter.supports_ddl_transaction? -> repo.transaction [log: false], fun
+      true -> fun.()
     end
   end
 

--- a/test/support/mock_repo.exs
+++ b/test/support/mock_repo.exs
@@ -48,6 +48,10 @@ defmodule Ecto.MockAdapter do
 
   ## Migrations
 
+  def supports_ddl_transaction? do
+    Process.get(:supports_ddl_transaction?) || false
+  end
+
   def execute_ddl(_repo, command, _) do
     Process.put(:last_command, command)
     :ok


### PR DESCRIPTION
It is necessary to make it possible to add other adapters that doesn't
have this support. i.e MySQL -> http://dev.mysql.com/doc/refman/5.0/en/cannot-roll-back.html

cc/ @josevalim 