### PR TITLE
Move case sensitive tests to @tag :case_sensitive

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -128,9 +128,6 @@ defmodule Ecto.Integration.RepoTest do
     import Ecto.Changeset
     post = TestRepo.insert(%Post{title: "HELLO"})
 
-    on_insert = cast(%{"title" => "hello"}, %Post{}, ~w(title), ~w())
-    assert validate_unique(on_insert, :title, on: TestRepo).errors == []
-
     on_insert = cast(%{"title" => "HELLO"}, %Post{}, ~w(title), ~w())
     assert validate_unique(on_insert, :title, on: TestRepo).errors != []
 
@@ -145,6 +142,13 @@ defmodule Ecto.Integration.RepoTest do
 
     on_update = cast(%{"title" => "HELLO"}, %{post | id: post.id + 1}, ~w(title), ~w())
     assert validate_unique(on_update, :title, on: TestRepo).errors != []
+  end
+
+  @tag :case_sensitive
+  test "validate_unique/3 case sensitive" do
+    on_insert = cast(%{"title" => "hello"}, %Post{}, ~w(title), ~w())
+    assert validate_unique(on_insert, :title, on: TestRepo).errors == []
+
   end
 
   test "get(!)" do


### PR DESCRIPTION
You mentioned there were 2, but this is the only one failing for me. 