### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ To contribute you need to compile Ecto from source and test it:
 ```
 $ git clone https://github.com/elixir-lang/ecto.git
 $ cd ecto
+$ mix deps.get
 $ mix test
 ```
 

--- a/lib/ecto/model.ex
+++ b/lib/ecto/model.ex
@@ -61,7 +61,7 @@ defmodule Ecto.Model do
   end
 
   @doc """
-  Builds a structs from the given `assoc` in `model`.
+  Builds a struct from the given `assoc` in `model`.
 
   ## Examples
 
@@ -71,7 +71,7 @@ defmodule Ecto.Model do
 
       iex> post = Repo.get(Post, 13)
       %Post{id: 13}
-      iex> build(post, :comment)
+      iex> build(post, :comments)
       %Comment{id: nil, post_id: 13}
 
   Note though it doesn't happen with belongs to cases, as the
@@ -128,7 +128,7 @@ defmodule Ecto.Model do
 
   defp assert_struct!(model, %{__struct__: struct}) do
     if struct != model do
-      raise ArgumentError, "expected an homogeneous list containing the same struct, " <>
+      raise ArgumentError, "expected a homogeneous list containing the same struct, " <>
                            "got: #{inspect model} and #{inspect struct}"
     else
       true

--- a/test/ecto/associations_test.exs
+++ b/test/ecto/associations_test.exs
@@ -209,7 +209,7 @@ defmodule Ecto.AssociationsTest do
   end
 
   test "assoc/2 fails on heterogeneous collections" do
-    assert_raise ArgumentError, ~r"expected an homogeneous list containing the same struct", fn ->
+    assert_raise ArgumentError, ~r"expected a homogeneous list containing the same struct", fn ->
       assoc([%Post{}, %Comment{}], :comments)
     end
   end


### PR DESCRIPTION
- Adds missing `mix deps.get` step to "Contributing" section of the README
- Fixes some grammatical pluralization typos