### PR TITLE
Update references example for table name clarity

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -417,8 +417,8 @@ defmodule Ecto.Migration do
 
   ## Examples
 
-      create table(:product) do
-        add :category_id, references(:category)
+      create table(:products) do
+        add :group_id, references(:groups)
       end
 
   ## Options


### PR DESCRIPTION
The table name itself must be used for `references`, it does not perform inflection to pluralize it. Using an irregular plural like "category" makes this unapparent.