### PR TITLE
Problem: No console output when migration is already up/down

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -20,6 +20,8 @@ defmodule Ecto.Migrator do
 
   """
 
+  require Logger
+
   alias Ecto.Migration.Runner
   alias Ecto.Migration.SchemaMigration
 
@@ -193,6 +195,11 @@ defmodule Ecto.Migrator do
   end
 
   defp migrate(migrations, direction, repo, opts) do
+    if Enum.empty? migrations do
+      level = Keyword.get(opts, :log, :info)
+      log(level, "Already #{direction}")
+    end
+
     ensure_no_duplication(migrations)
 
     Enum.map migrations, fn {version, file} ->
@@ -223,4 +230,8 @@ defmodule Ecto.Migrator do
   defp raise_no_migration_in_file(file) do
     raise Ecto.MigrationError, message: "file #{Path.relative_to_cwd(file)} does not contain any Ecto.Migration"
   end
+
+  defp log(false, _msg), do: :ok
+  defp log(level, msg),  do: Logger.log(level, msg)
+
 end


### PR DESCRIPTION
If you are already at the highest/lowest migration and run ```mix ecto.migrate``` or ```mix ecto.rollback```, the command returns without any output. That might lead to some confusion for the user.

Technically that might be correct, because the task has not done anything. But it would be more user-friendly to display at least the information that there is no higher/lower version to migrate/rollback to.