### PR TITLE
Support maps in `Query.select/3`

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -81,6 +81,13 @@ defmodule Ecto.Integration.TypeTest do
 
     assert [["1", "hai"]] ==
            TestRepo.all(from p in Post, select: [p.title, p.text])
+
+    assert [%{:title => "1", 3 => "hai", "text" => "hai"}] ==
+           TestRepo.all(from p in Post, select: %{
+             :title => p.title,
+             "text" => p.text,
+             3 => p.text
+           })
   end
 
   @tag :array_type

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -376,8 +376,10 @@ defmodule Ecto.Query do
   There can only be one select expression in a query, if the select expression
   is omitted, the query will by default select the full model.
 
-  The sub-expressions in the query can be wrapped in lists or tuples as shown in
-  the examples. A full model can also be selected.
+  The sub-expressions in the query can be wrapped in lists, tuples or maps as
+  shown in the examples. A full model can also be selected. Note that map keys
+  can only be atoms, binaries, integers or floats otherwise an `ArgumentError`
+  exception is raised at compile-time.
 
   ## Keywords examples
 
@@ -385,11 +387,13 @@ defmodule Ecto.Query do
       from(c in City, select: {c.name, c.population})
       from(c in City, select: [c.name, c.county])
       from(c in City, select: {c.name, ^to_binary(40 + 2), 43})
+      from(c in City, select: %{n: c.name, answer: 42})
 
   ## Expressions examples
 
       City |> select([c], c)
       City |> select([c], {c.name, c.country})
+      City |> select([c], %{"name" => c.name})
 
   """
   defmacro select(query, binding, expr) do

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -378,8 +378,8 @@ defmodule Ecto.Query do
 
   The sub-expressions in the query can be wrapped in lists, tuples or maps as
   shown in the examples. A full model can also be selected. Note that map keys
-  can only be atoms, binaries, integers or floats otherwise an `ArgumentError`
-  exception is raised at compile-time.
+  can only be atoms, binaries, integers or floats otherwise an
+  `Ecto.Query.CompileError` exception is raised at compile-time.
 
   ## Keywords examples
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -251,13 +251,22 @@ defmodule Ecto.Query.Builder do
   @doc """
   Escapes a list of bindings as a list of atoms.
 
+  Only variables or `{:atom, value}` tuples are allowed in the `bindings` list,
+  otherwise an `Ecto.Query.CompileError` is raised.
+
   ## Examples
 
       iex> escape_binding(quote do: [x, y, z])
       [x: 0, y: 1, z: 2]
 
+      iex> escape_binding(quote do: [x: 0, z: 2])
+      [x: 0, z: 2]
+
       iex> escape_binding(quote do: [x, y, x])
       ** (Ecto.Query.CompileError) variable `x` is bound twice
+
+      iex> escape_binding(quote do: [a, b, :foo])
+      ** (Ecto.Query.CompileError) binding list should contain only variables, got: :foo
 
   """
   @spec escape_binding(list) :: Keyword.t

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -41,6 +41,17 @@ defmodule Ecto.Query.Builder.Select do
     {expr, params}
   end
 
+  # Map
+  defp escape({:%{}, _, pairs}, params, vars) do
+    {pairs, params} = Enum.map_reduce pairs, params, fn({k, v}, acc) ->
+      {expr, params} = escape(v, acc, vars)
+      {{k, expr}, params}
+    end
+
+    expr = {:{}, [], [:%{}, [], pairs]}
+    {expr, params}
+  end
+
   # List
   defp escape(list, params, vars) when is_list(list) do
     Enum.map_reduce(list, params, &escape(&1, &2, vars))

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -45,7 +45,7 @@ defmodule Ecto.Query.Builder.Select do
   defp escape({:%{}, _, pairs}, params, vars) do
     {pairs, params} = Enum.map_reduce pairs, params, fn({k, v}, acc) ->
       unless is_atom(k) or is_binary(k) or is_number(k) do
-        raise ArgumentError, "keys can only be atoms/binaries/integers/floats"
+				Builder.error! "keys can only be atoms/binaries/integers/floats"
       end
       {expr, params} = escape(v, acc, vars)
       {{k, expr}, params}

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -44,6 +44,9 @@ defmodule Ecto.Query.Builder.Select do
   # Map
   defp escape({:%{}, _, pairs}, params, vars) do
     {pairs, params} = Enum.map_reduce pairs, params, fn({k, v}, acc) ->
+      unless is_atom(k) or is_binary(k) or is_number(k) do
+        raise ArgumentError, "keys can only be atoms/binaries/integers/floats"
+      end
       {expr, params} = escape(v, acc, vars)
       {{k, expr}, params}
     end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -421,6 +421,8 @@ defmodule Ecto.Query.Planner do
     do: collect_fields(query, [left, right], from?)
   defp collect_fields(query, {:{}, _, elems}, from?),
     do: collect_fields(query, elems, from?)
+  defp collect_fields(query, {:%{}, _, pairs}, from?),
+    do: collect_fields(query, Enum.map(pairs, &elem(&1, 1)), from?)
   defp collect_fields(query, list, from?) when is_list(list),
     do: Enum.flat_map_reduce(list, from?, &collect_fields(query, &1, &2))
   defp collect_fields(_query, expr, from?),

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -135,6 +135,15 @@ defmodule Ecto.Repo.Queryable do
     {{left, right}, values}
   end
 
+  defp transform_row({:%{}, _, pairs}, from, values) do
+    {result, values} = Enum.map_reduce pairs, values, fn({k, v}, acc) ->
+      {v, values} = transform_row(v, from, acc)
+      {{k, v}, values}
+    end
+
+    {Enum.into(result, %{}), values}
+  end
+
   defp transform_row(list, from, values) when is_list(list) do
     Enum.map_reduce(list, values, &transform_row(&1, from, &2))
   end

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -136,12 +136,10 @@ defmodule Ecto.Repo.Queryable do
   end
 
   defp transform_row({:%{}, _, pairs}, from, values) do
-    {result, values} = Enum.map_reduce pairs, values, fn({k, v}, acc) ->
-      {v, values} = transform_row(v, from, acc)
-      {{k, v}, values}
+    Enum.reduce pairs, {%{}, values}, fn({key, value}, {map, values_acc}) ->
+      {value, new_values} = transform_row(value, from, values_acc)
+      {Map.put(map, key, value), new_values}
     end
-
-    {Enum.into(result, %{}), values}
   end
 
   defp transform_row(list, from, values) when is_list(list) do

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -15,6 +15,9 @@ defmodule Ecto.Query.Builder.SelectTest do
     assert {{:{}, [], [:{}, [], [0, 1, 2]]}, %{}} ==
            escape(quote do {0, 1, 2} end, [])
 
+    assert {{:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}, %{}} ==
+           escape(quote do %{a: a} end, [a: 0])
+
     assert {[Macro.escape(quote do &0.y end), Macro.escape(quote do &0.z end)], %{}} ==
            escape(quote do [x.y, x.z] end, [x: 0])
 


### PR DESCRIPTION
This PR implements the feature discussed in #305. It adds support for passing maps (other than tuples, lists and values) to selects:

```elixir
from(p in Post) |> select([p], %{title: p.title, answer: 42})
```

This PR is absolutely **not ready for merging**, but I'm opening it with just a few commits only to know if I'm on the right track.

Some basic things that are still missing (other than some refactoring here and there):

- [x] Documentation for this new feature
- [x] Tests that test the actual usage of maps in selects (I'm still not 100% sure where to place such tests)

Let me know what you think for now!