### PR TITLE
Use :full and :full_join in Inspect implementation

### DIFF
--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -159,7 +159,7 @@ defimpl Inspect, for: Ecto.Query do
   defp join_qual(:inner), do: :join
   defp join_qual(:left),  do: :left_join
   defp join_qual(:right), do: :right_join
-  defp join_qual(:outer), do: :outer_join
+  defp join_qual(:full),  do: :full_join
 
   defp collect_sources(query) do
     from_sources(query.from) ++ join_sources(query.joins)

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -36,14 +36,14 @@ defmodule Ecto.Query.InspectTest do
     assert i(from(x in Post, join: y in Comment, on: x.id == y.id)) ==
            ~s{from p in Inspect.Post, join: c in Inspect.Comment, on: p.id == c.id}
 
-    assert i(from(x in Post, join: y in assoc(x, :comments))) ==
-           ~s{from p in Inspect.Post, join: c in assoc(p, :comments)}
-
-    assert i(from(x in Post, join: y in assoc(x, :post), join: z in assoc(y, :post))) ==
-           ~s{from p0 in Inspect.Post, join: p1 in assoc(p0, :post), join: p2 in assoc(p1, :post)}
+    assert i(from(x in Post, full_join: y in Comment, on: x.id == y.id)) ==
+           ~s{from p in Inspect.Post, full_join: c in Inspect.Comment, on: p.id == c.id}
 
     assert i(from(x in Post, left_join: y in assoc(x, :comments))) ==
            ~s{from p in Inspect.Post, left_join: c in assoc(p, :comments)}
+
+    assert i(from(x in Post, right_join: y in assoc(x, :post), join: z in assoc(y, :post))) ==
+           ~s{from p0 in Inspect.Post, right_join: p1 in assoc(p0, :post), join: p2 in assoc(p1, :post)}
   end
 
   test "where" do


### PR DESCRIPTION
The same names are used in queries.