### PR TITLE
Make insert and update return a keyword list

### DIFF
--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -57,7 +57,7 @@ defmodule Ecto.Adapter do
   """
   defcallback insert(repo :: Ecto.Repo.t, source :: binary,
                      fields :: Keyword.t, returning :: [atom],
-                     opts :: Keyword.t) :: {:ok, tuple} | no_return
+                     opts :: Keyword.t) :: {:ok, Keyword.t} | no_return
 
   @doc """
   Updates a single model with the given filters.
@@ -71,7 +71,7 @@ defmodule Ecto.Adapter do
   defcallback update(repo :: Ecto.Repo.t, source :: binary,
                      filter :: Keyword.t, fields :: Keyword.t,
                      returning :: [atom], opts :: Keyword.t) ::
-                     {:ok, tuple} | {:error, :stale} | no_return
+                     {:ok, Keyword.t} | {:error, :stale} | no_return
 
   @doc """
   Deletes a sigle model with the given filters.
@@ -84,5 +84,5 @@ defmodule Ecto.Adapter do
   """
   defcallback delete(repo :: Ecto.Repo.t, source :: binary,
                      filter :: Keyword.t, opts :: Keyword.t) ::
-                     {:ok, tuple} | {:error, :stale} | no_return
+                     {:ok, Keyword.t} | {:error, :stale} | no_return
 end

--- a/test/support/mock_repo.exs
+++ b/test/support/mock_repo.exs
@@ -20,23 +20,23 @@ defmodule Ecto.MockAdapter do
   def insert(_repo, "schema_migrations", val, _, _) do
     version = Keyword.fetch!(val, :version)
     Process.put(:migrated_versions, [version|migrated_versions()])
-    {:ok, {1}}
+    {:ok, [version: 1]}
   end
 
   def insert(_repo, _source, _fields, [_], _opts),
-    do: {:ok, {1}}
+    do: {:ok, [id: 1]}
 
   def update(_repo, _source, _filter, _fields, [_], _opts),
-    do: {:ok, {1}}
+    do: {:ok, [id: 1]}
 
   def delete(_repo, "schema_migrations", val, _) do
     version = Keyword.fetch!(val, :version)
     Process.put(:migrated_versions, List.delete(migrated_versions(), version))
-    {:ok, {}}
+    {:ok, []}
   end
 
   def delete(_repo, _source, _filter, _opts),
-    do: {:ok, {}}
+    do: {:ok, []}
 
   ## Transactions
 


### PR DESCRIPTION
The motivation is to make it easier to support other adapters, such as MySQL (that doesn't support the `RETURNING` clause).