### PR TITLE
Update the docs for Ecto.Model.OptimisticLock

### DIFF
--- a/lib/ecto/model.ex
+++ b/lib/ecto/model.ex
@@ -19,7 +19,7 @@ defmodule Ecto.Model do
     * `use Ecto.Model.Callbacks` - provides lifecycle callbacks
     * `use Ecto.Model.Timestamps` - automatically set `inserted_at` and
       `updated_at` fields declared via `Ecto.Schema.timestamps/1`
-    * `import Ecto.Model.OptimisticLock` - makes the `optimistic_lock/1` macro
+    * `use Ecto.Model.OptimisticLock` - makes the `optimistic_lock/1` macro
       available
 
   However, you can avoid using `Ecto.Model` altogether in favor

--- a/lib/ecto/model/optimistic_lock.ex
+++ b/lib/ecto/model/optimistic_lock.ex
@@ -51,9 +51,9 @@ defmodule Ecto.Model.OptimisticLock do
 
   Note that the `optimistic_lock/1` macro is defined in this module, which is
   imported when `Ecto.Model` is used. To use the `optimistic_lock/1` macro
-  without using `Ecto.Model`, just import or require
-  `Ecto.Model.OptimisticLock` but be sure to use `Ecto.Model.Callbacks` as well
-  since it's used by `Ecto.Model.OptimisticLock` under the hood.
+  without using `Ecto.Model`, just use `Ecto.Model.OptimisticLock` but be sure
+  to use `Ecto.Model.Callbacks` as well since it's used by
+  `Ecto.Model.OptimisticLock` under the hood.
 
   When a conflict happens (a record which has been previously fetched is being
   updated, but that same record has been modified since it was fetched), an


### PR DESCRIPTION
This PR updates the docs for the changes in f1f86a9316654f9bf419b550ca2ea33cd793aafb. Before, the `Ecto.Model.OptimisticLock` module needed to be `import`'ed but now it needs to be `use`'d.