### PR TITLE
Make Ecto.Changeset.change/2 accept changesets too

### DIFF
--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -249,7 +249,7 @@ defmodule Ecto.ChangesetTest do
     end
   end
 
-  test "change/2" do
+  test "change/2 with a model" do
     changeset = change(%Post{})
     assert changeset.valid?
     assert changeset.model == %Post{}
@@ -264,6 +264,21 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
     assert changeset.model == %Post{}
     assert changeset.changes == %{body: "bar"}
+  end
+
+  test "change/2 with a changeset" do
+    base_changeset = cast(%Post{}, %{title: "title"}, ~w(title), ~w())
+
+    assert change(base_changeset) == base_changeset
+
+    changeset = change(base_changeset, %{body: "body"})
+    assert changeset.changes == %{title: "title", body: "body"}
+
+    changeset = change(base_changeset, %{title: "new title"})
+    assert changeset.changes == %{title: "new title"}
+
+    changeset = change(base_changeset, title: "new title")
+    assert changeset.changes == %{title: "new title"}
   end
 
   test "fetch_field/2" do


### PR DESCRIPTION
`Ecto.Changeset.change/2` now accepts a changeset as the first argument (other than a model).

I added documentation for this change as well as updated the spec for this function. I also slightly refactored the code for when a keyword list is passed to `change/2` so that it converts it into a map and then calls itself.