### PR TITLE
update deps in README so that postgrex and ecto are compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Add Ecto as a dependency in your `mix.exs` file. If you are using PostgreSQL, yo
 
 ```elixir
 defp deps do
-  [{:postgrex, ">= 0.0.0"},
-   {:ecto, "~> 0.7"}]
+  [{:postgrex, "0.7.0"},
+   {:ecto, "~> 0.8.1"}]
 end
 ```
 


### PR DESCRIPTION
If you use [{:postgrex, ">= 0.0.0"},  {:ecto, "~> 0.7"}] an incompatible postgrex version will be used. This fixes it at least in the readme.