### PR TITLE
Removing `validate_number` from Ecto lib docs.

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -155,7 +155,6 @@ defmodule Ecto do
           user
           |> cast(params, ~w(name email), ~w(age))
           |> validate_format(:email, ~r/@/)
-          |> validate_number(:age, more_than: 18)
           |> validate_unique(:email, Repo)
         end
       end

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -155,6 +155,7 @@ defmodule Ecto do
           user
           |> cast(params, ~w(name email), ~w(age))
           |> validate_format(:email, ~r/@/)
+          |> validate_inclusion(:age, 0..130)
           |> validate_unique(:email, Repo)
         end
       end


### PR DESCRIPTION
As the function no longer exists (for now).

I've added in an example for `validate_inclusion` instead so that the :age related comment in the prose below still makes sense.