### PR TITLE
Add source to has assoc

### DIFF
--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -62,6 +62,9 @@ defmodule Ecto.Query.Builder.From do
           # When a binary is used, there is no model
           {1, query(source, nil)}
 
+        {source, model} when is_binary(source) and is_atom(model) ->
+          {1, query(source, model)}
+
         other ->
           {nil, other}
       end

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -17,6 +17,9 @@ defmodule Ecto.Query.Builder.From do
       iex> escape(quote do: p in posts)
       {[p: 0], quote(do: posts)}
 
+      iex> escape(quote do: p in {"posts", MyModel})
+      {[p: 0], quote(do: {"posts", MyModel})}
+
       iex> escape(quote do: [p, q] in posts)
       {[p: 0, q: 1], quote(do: posts)}
 

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -21,6 +21,9 @@ defmodule Ecto.Query.Builder.Join do
       iex> escape(quote(do: x in Sample), [])
       {:x, {nil, {:__aliases__, [alias: false], [:Sample]}}, nil}
 
+      iex> escape(quote(do: x in {"foo", Sample}), [])
+      {:x, {"foo", {:__aliases__, [alias: false], [:Sample]}}, nil}
+
       iex> escape(quote(do: c in assoc(p, :comments)), [p: 0])
       {:c, nil, {0, :comments}}
 
@@ -38,6 +41,10 @@ defmodule Ecto.Query.Builder.Join do
 
   def escape(string, _vars) when is_binary(string) do
     {:_, {string, nil}, nil}
+  end
+
+  def escape({string, {:__aliases__, _, _} = module}, _vars) when is_binary(string) do
+    {:_, {string, module}, nil}
   end
 
   def escape({:assoc, _, [{var, _, context}, field]}, vars)
@@ -62,8 +69,10 @@ defmodule Ecto.Query.Builder.Join do
     do: {nil, expr}
   def join!(expr) when is_binary(expr),
     do: {expr, nil}
+  def join!({source, module}) when is_binary(source) and is_atom(module),
+    do: {source, module}
   def join!(expr),
-    do: Builder.error!("expected join to be a string or atom, got: `#{inspect expr}`")
+    do: Builder.error!("expected join to be a string, atom or {string, atom}, got: `#{inspect expr}`")
 
   @doc """
   Builds a quoted expression.

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -24,6 +24,9 @@ defmodule Ecto.Query.Builder.Join do
       iex> escape(quote(do: x in {"foo", Sample}), [])
       {:x, {"foo", {:__aliases__, [alias: false], [:Sample]}}, nil}
 
+      iex> escape(quote(do: x in {"foo", :sample}), [])
+      {:x, {"foo", :sample}, nil}
+
       iex> escape(quote(do: c in assoc(p, :comments)), [p: 0])
       {:c, nil, {0, :comments}}
 
@@ -45,6 +48,10 @@ defmodule Ecto.Query.Builder.Join do
 
   def escape({string, {:__aliases__, _, _} = module}, _vars) when is_binary(string) do
     {:_, {string, module}, nil}
+  end
+
+  def escape({string, atom}, _vars) when is_binary(string) and is_atom(atom) do
+    {:_, {string, atom}, nil}
   end
 
   def escape({:assoc, _, [{var, _, context}, field]}, vars)

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -55,7 +55,8 @@ defimpl Inspect, for: Ecto.Query do
   defp bound_from(from, name), do: ["from #{name} in #{unbound_from from}"]
 
   defp unbound_from({source, nil}),    do: inspect source
-  defp unbound_from({_source, model}), do: inspect model
+  defp unbound_from({nil, model}), do: inspect model
+  defp unbound_from(from = {source, model}), do: inspect from
   defp unbound_from(nil),              do: "query"
 
   defp joins(joins, names) do

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -55,15 +55,11 @@ defimpl Inspect, for: Ecto.Query do
   defp bound_from(from, name), do: ["from #{name} in #{unbound_from from}"]
 
   defp unbound_from({source, nil}),    do: inspect source
-
+  defp unbound_from({nil, model}),    do: inspect model
   defp unbound_from(from = {source, model}) do
-    if source == model.__schema__(:source) do
-      inspect model
-    else
-      inspect from
-    end
+    inspecting = if source == model.__schema__(:source), do: model, else: from
+    inspect inspecting
   end
-
   defp unbound_from(nil),              do: "query"
 
   defp joins(joins, names) do
@@ -78,7 +74,7 @@ defimpl Inspect, for: Ecto.Query do
   end
 
   defp join(%JoinExpr{qual: qual, source: {source, model}, on: on}, name, names) do
-    string = "#{name} in #{inspect model || source}"
+    string = "#{name} in #{unbound_from {source, model}}"
     [{join_qual(qual), string}, on: expr(on, names)]
   end
 

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -55,8 +55,15 @@ defimpl Inspect, for: Ecto.Query do
   defp bound_from(from, name), do: ["from #{name} in #{unbound_from from}"]
 
   defp unbound_from({source, nil}),    do: inspect source
-  defp unbound_from({nil, model}), do: inspect model
-  defp unbound_from(from = {source, model}), do: inspect from
+
+  defp unbound_from(from = {source, model}) do
+    if source == model.__schema__(:source) do
+      inspect model
+    else
+      inspect from
+    end
+  end
+
   defp unbound_from(nil),              do: "query"
 
   defp joins(joins, names) do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -241,9 +241,9 @@ defmodule Ecto.Query.Planner do
     prepare_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset)
   end
 
-  defp prepare_joins([%JoinExpr{source: {_, model}} = join|t],
+  defp prepare_joins([%JoinExpr{source: {source, model}} = join|t],
                      query, joins, sources, tail_sources, counter, offset) when is_atom(model) do
-    source = {model.__schema__(:source), model}
+    source = if is_binary(source), do: {source, model}, else: {model.__schema__(:source), model}
     join   = %{join | source: source, ix: counter}
     prepare_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset)
   end

--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -37,3 +37,8 @@ defimpl Ecto.Queryable, for: Atom do
     end
   end
 end
+
+defimpl Ecto.Queryable, for: Tuple do
+  def to_query(from = {source, model}) when is_binary(source) and is_atom(model),
+    do: %Ecto.Query{from: from}
+end

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -14,7 +14,7 @@ defmodule Ecto.Query.Builder.JoinTest do
     end
 
     assert_raise Ecto.Query.CompileError,
-                 "expected join to be a string or atom, got: `123`", fn ->
+                 "expected join to be a string, atom or {string, atom}, got: `123`", fn ->
       source = 123
       join("posts", :left, [p], c in ^source, true)
     end
@@ -29,6 +29,11 @@ defmodule Ecto.Query.Builder.JoinTest do
     qual = :right
     source = Comment
     assert %{joins: [%{source: {nil, Comment}}]} =
+            join("posts", qual, [p], c in ^source, true)
+
+    qual = :right
+    source = {"user_comments", Comment}
+    assert %{joins: [%{source: {"user_comments", Comment}}]} =
             join("posts", qual, [p], c in ^source, true)
   end
 end

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -30,6 +30,9 @@ defmodule Ecto.Query.InspectTest do
 
     assert i(from(x in "posts", [])) ==
            ~s{from p in "posts"}
+
+    assert i(from(x in {"user_posts", Post}, [])) ==
+           ~s[from p in {"user_posts", Inspect.Post}]
   end
 
   test "join" do
@@ -38,6 +41,9 @@ defmodule Ecto.Query.InspectTest do
 
     assert i(from(x in Post, full_join: y in Comment, on: x.id == y.id)) ==
            ~s{from p in Inspect.Post, full_join: c in Inspect.Comment, on: p.id == c.id}
+
+    assert i(from(x in Post, full_join: y in {"user_comments", Comment}, on: x.id == y.id)) ==
+           ~s[from p in Inspect.Post, full_join: c in {"user_comments", Inspect.Comment}, on: p.id == c.id]
 
     assert i(from(x in Post, left_join: y in assoc(x, :comments))) ==
            ~s{from p in Inspect.Post, left_join: c in assoc(p, :comments)}

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -132,6 +132,9 @@ defmodule Ecto.Query.PlannerTest do
 
     query = from(p in Post, join: c in Comment) |> prepare |> elem(0)
     assert hd(query.joins).source == {"comments", Comment}
+
+    query = from(p in Post, join: c in {"post_comments", Comment}) |> prepare |> elem(0)
+    assert hd(query.joins).source == {"post_comments", Comment}
   end
 
   test "prepare: joins associations" do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -55,6 +55,10 @@ defmodule Ecto.QueryTest do
     assert %Query{from: {"posts", nil}} = from(p in "posts", []) |> select([p], p.title)
   end
 
+  test "string source and atom query" do
+    assert %Query{from: {"user_posts", Post}} = from(p in {"user_posts", Post}, []) |> select([p], p.title)
+  end
+
   test "normalize from expression" do
     quote_and_eval(from("posts", []))
 
@@ -98,6 +102,7 @@ defmodule Ecto.QueryTest do
     # queries need to be on the same line or == wont work
     assert from(p in "posts", select: 1<2) == from(p in "posts", []) |> select([p], 1<2)
     assert from(p in "posts", where: 1<2)  == from(p in "posts", []) |> where([p], 1<2)
+    assert from(p in {"posts", Post}, where: 1<2)  == from(p in {"posts", Post}, []) |> where([p], 1<2)
 
     query = "posts"
     assert (query |> select([p], p.title)) == from(p in query, select: p.title)
@@ -135,6 +140,7 @@ defmodule Ecto.QueryTest do
 
   test "join on keyword query" do
     from(c in "comments", join: p in "posts", on: c.text == "", select: c)
+    from(c in "comments", join: p in {"user_posts", Post}, on: c.text == "", select: c)
     from(p in "posts", join: c in assoc(p, :comments), select: p)
 
     message = ~r"`on` keyword must immediately follow a join"


### PR DESCRIPTION
resolve #478

Please review @josevalim . There's a problem: `source` must implement Ecto.Queryable, but I don't know how to judge this. Is there a way for this? Or should we just limit `source` to be a string?