### PR TITLE
[WIP] Add support for microseconds in `Ecto.Time` and `Ecto.DateTime`

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -13,7 +13,8 @@ defmodule Ecto.Integration.TypeTest do
     text     = <<0,1>>
     uuid     = <<0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15>>
     decimal  = Decimal.new("1.0")
-    datetime = %Ecto.DateTime{year: 2014, month: 1, day: 16, hour: 20, min: 26, sec: 51}
+    datetime = %Ecto.DateTime{year: 2014, month: 1, day: 16, hour: 20, min: 26,
+      sec: 51, usec: 0}
 
     TestRepo.insert(%Post{text: text, uuid: uuid, public: true, visits: integer,
                           inserted_at: datetime, cost: decimal, intensity: float})
@@ -69,7 +70,7 @@ defmodule Ecto.Integration.TypeTest do
     assert [1] = TestRepo.all(from Post, select: type(^"1", Elixir.Custom.Permalink))
 
     # Custom types
-    datetime = %Ecto.DateTime{year: 2014, month: 1, day: 16, hour: 20, min: 26, sec: 51}
+    datetime = %Ecto.DateTime{year: 2014, month: 1, day: 16, hour: 20, min: 26, sec: 51, usec: 0}
     assert [^datetime] = TestRepo.all(from Post, select: type(^datetime, Ecto.DateTime))
   end
 

--- a/lib/ecto/adapters/postgres/datetime.ex
+++ b/lib/ecto/adapters/postgres/datetime.ex
@@ -35,17 +35,17 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       <<:calendar.date_to_gregorian_days(date) - @gd_epoch :: 32>>
     end
 
-    defp encode_time({hour, min, sec, msec})
-        when hour in 0..23 and min in 0..59 and sec in 0..59 and msec in 0..999_999 do
+    defp encode_time({hour, min, sec, usec})
+        when hour in 0..23 and min in 0..59 and sec in 0..59 and usec in 0..999_999 do
       time = {hour, min, sec}
-      <<:calendar.time_to_seconds(time) * 1_000_000 + msec :: 64>>
+      <<:calendar.time_to_seconds(time) * 1_000_000 + usec::64>>
     end
 
-    defp encode_timestamp({{year, month, day}, {hour, min, sec, msec}})
-        when year <= @timestamp_max_year and hour in 0..23 and min in 0..59 and sec in 0..59 and msec in 0..999_999 do
+    defp encode_timestamp({{year, month, day}, {hour, min, sec, usec}})
+        when year <= @timestamp_max_year and hour in 0..23 and min in 0..59 and sec in 0..59 and usec in 0..999_999 do
       datetime = {{year, month, day}, {hour, min, sec}}
       secs = :calendar.datetime_to_gregorian_seconds(datetime) - @gs_epoch
-      <<secs * 1_000_000 + msec :: 64>>
+      <<secs * 1_000_000 + usec :: 64>>
     end
 
     ### DECODING ###

--- a/test/ecto/datetime_test.exs
+++ b/test/ecto/datetime_test.exs
@@ -102,11 +102,15 @@ defmodule Ecto.DateTimeTest do
   use ExUnit.Case, async: true
 
   @test_datetime "2015-01-23T23:50:07"
-  @test_ecto_datetime %Ecto.DateTime{year: 2015, month: 1, day: 23, hour: 23, min: 50, sec: 07}
-  @test_ecto_datetime_zero %Ecto.DateTime{year: 2015, month: 1, day: 23, hour: 23, min: 50, sec: 0}
+  @test_ecto_datetime %Ecto.DateTime{year: 2015, month: 1, day: 23, hour: 23, min: 50, sec: 07, usec: 0}
+  @test_ecto_datetime_zero %Ecto.DateTime{year: 2015, month: 1, day: 23, hour: 23, min: 50, sec: 0, usec: 0}
+
+  @test_usec_datetime "2015-01-23T23:50:07.008"
+  @test_ecto_usec_datetime %Ecto.DateTime{year: 2015, month: 1, day: 23, hour: 23, min: 50, sec: 07, usec: 8000}
 
   test "cast itself" do
     assert Ecto.DateTime.cast(@test_ecto_datetime) == {:ok, @test_ecto_datetime}
+    assert Ecto.DateTime.cast(@test_ecto_usec_datetime) == {:ok, @test_ecto_usec_datetime}
   end
 
   test "cast strings" do
@@ -115,6 +119,9 @@ defmodule Ecto.DateTimeTest do
     assert Ecto.DateTime.cast("2015-01-23T23:50:07Z") == {:ok, @test_ecto_datetime}
     assert Ecto.DateTime.cast("2015-01-23T23:50:07.000Z") == {:ok, @test_ecto_datetime}
     assert Ecto.DateTime.cast("2015-01-23P23:50:07") == :error
+
+    assert Ecto.DateTime.cast(@test_usec_datetime) == {:ok, @test_ecto_usec_datetime}
+    assert Ecto.DateTime.cast(@test_usec_datetime <> "Z") == {:ok, @test_ecto_usec_datetime}
   end
 
   test "cast maps" do
@@ -143,5 +150,8 @@ defmodule Ecto.DateTimeTest do
   test "to_string" do
     assert to_string(@test_ecto_datetime) == @test_datetime <> "Z"
     assert Ecto.DateTime.to_string(@test_ecto_datetime) == @test_datetime <> "Z"
+
+    assert to_string(@test_ecto_usec_datetime) == @test_usec_datetime <> "000Z"
+    assert Ecto.DateTime.to_string(@test_ecto_usec_datetime) == @test_usec_datetime <> "000Z"
   end
 end

--- a/test/ecto/datetime_test.exs
+++ b/test/ecto/datetime_test.exs
@@ -78,6 +78,10 @@ defmodule Ecto.TimeTest do
            {:ok, @test_ecto_time_zero}
     assert Ecto.Time.cast(%{hour: 23, min: 50}) ==
            {:ok, @test_ecto_time_zero}
+    assert Ecto.Time.cast(%{hour: 12, min: 40, sec: 33, usec: 30_000}) ==
+           {:ok, @test_ecto_usec_time}
+    assert Ecto.Time.cast(%{"hour" => 12, "min" => 40, "sec" => 33, "usec" => 30_000}) ==
+           {:ok, @test_ecto_usec_time}
     assert Ecto.Time.cast(%{"hour" => "", "min" => "50"}) ==
            :error
     assert Ecto.Time.cast(%{hour: 23, min: nil}) ==
@@ -88,13 +92,13 @@ defmodule Ecto.TimeTest do
     assert to_string(@test_ecto_time) == @test_time
     assert Ecto.Time.to_string(@test_ecto_time) == @test_time
 
-    assert to_string(@test_ecto_usec_time) == @test_usec_time <> "000"
-    assert Ecto.Time.to_string(@test_ecto_usec_time) == @test_usec_time <> "000"
+    assert to_string(@test_ecto_usec_time) == @test_usec_time <> "000Z"
+    assert Ecto.Time.to_string(@test_ecto_usec_time) == @test_usec_time <> "000Z"
 
     assert to_string(%Ecto.Time{hour: 1, min: 2, sec: 3, usec: 4})
-      == "01:02:03.000004"
+           == "01:02:03.000004Z"
     assert Ecto.Time.to_string(%Ecto.Time{hour: 1, min: 2, sec: 3, usec: 4})
-      == "01:02:03.000004"
+           == "01:02:03.000004Z"
   end
 end
 
@@ -138,6 +142,15 @@ defmodule Ecto.DateTimeTest do
 
     assert Ecto.DateTime.cast(%{year: 2015, month: 1, day: 23, hour: 23, min: 50}) ==
            {:ok, @test_ecto_datetime_zero}
+
+    assert Ecto.DateTime.cast(%{year: 2015, month: 1, day: 23, hour: 23,
+                                min: 50, sec: 07, usec: 8_000}) ==
+           {:ok, @test_ecto_usec_datetime}
+
+    assert Ecto.DateTime.cast(%{"year" => 2015, "month" => 1, "day" => 23,
+                                "hour" => 23, "min" => 50, "sec" => 07,
+                                "usec" => 8_000}) ==
+           {:ok, @test_ecto_usec_datetime}
 
     assert Ecto.DateTime.cast(%{"year" => "2015", "month" => "1", "day" => "23",
                                 "hour" => "", "min" => "50"}) ==

--- a/test/ecto/datetime_test.exs
+++ b/test/ecto/datetime_test.exs
@@ -39,19 +39,29 @@ defmodule Ecto.TimeTest do
   use ExUnit.Case, async: true
 
   @test_time "23:50:07"
-  @test_ecto_time %Ecto.Time{hour: 23, min: 50, sec: 07}
-  @test_ecto_time_zero %Ecto.Time{hour: 23, min: 50, sec: 0}
+  @test_ecto_time %Ecto.Time{hour: 23, min: 50, sec: 07, usec: 0}
+  @test_ecto_time_zero %Ecto.Time{hour: 23, min: 50, sec: 0, usec: 0}
+
+  @test_usec_time "12:40:33.030"
+  @test_ecto_usec_time %Ecto.Time{hour: 12, min: 40, sec: 33, usec: 30_000}
 
   test "cast itself" do
     assert Ecto.Time.cast(@test_ecto_time) == {:ok, @test_ecto_time}
+    assert Ecto.Time.cast(@test_ecto_time_zero) ==  {:ok, @test_ecto_time_zero}
   end
 
   test "cast strings" do
     assert Ecto.Time.cast(@test_time) == {:ok, @test_ecto_time}
     assert Ecto.Time.cast(@test_time <> "Z") == {:ok, @test_ecto_time}
-    assert Ecto.Time.cast(@test_time <> ".030") == {:ok, @test_ecto_time}
-    assert Ecto.Time.cast(@test_time <> ".030Z") == {:ok, @test_ecto_time}
-    assert Ecto.Time.cast(@test_time <> ".030231Z") == {:ok, @test_ecto_time}
+    assert Ecto.Time.cast(@test_usec_time) == {:ok, @test_ecto_usec_time}
+    assert Ecto.Time.cast(@test_usec_time <> "Z") == {:ok, @test_ecto_usec_time}
+    assert Ecto.Time.cast(@test_time <> ".123456")
+      == {:ok, %{@test_ecto_time | usec: 123456}}
+    assert Ecto.Time.cast(@test_time <> ".123456Z")
+      == {:ok, %{@test_ecto_time | usec: 123456}}
+    assert Ecto.Time.cast(@test_time <> ".000123Z")
+      == {:ok, %{@test_ecto_time | usec: 123}}
+
     assert Ecto.Date.cast("24:01:01") == :error
     assert Ecto.Date.cast("00:61:00") == :error
     assert Ecto.Date.cast("00:00:61") == :error
@@ -77,6 +87,14 @@ defmodule Ecto.TimeTest do
   test "to_string" do
     assert to_string(@test_ecto_time) == @test_time
     assert Ecto.Time.to_string(@test_ecto_time) == @test_time
+
+    assert to_string(@test_ecto_usec_time) == @test_usec_time <> "000"
+    assert Ecto.Time.to_string(@test_ecto_usec_time) == @test_usec_time <> "000"
+
+    assert to_string(%Ecto.Time{hour: 1, min: 2, sec: 3, usec: 4})
+      == "01:02:03.000004"
+    assert Ecto.Time.to_string(%Ecto.Time{hour: 1, min: 2, sec: 3, usec: 4})
+      == "01:02:03.000004"
   end
 end
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -93,7 +93,7 @@ defmodule Ecto.Query.PlannerTest do
   end
 
   test "prepare: casts and dumps custom types" do
-    datetime = %Ecto.DateTime{year: 2015, month: 1, day: 7, hour: 21, min: 18, sec: 13}
+    datetime = %Ecto.DateTime{year: 2015, month: 1, day: 7, hour: 21, min: 18, sec: 13, usec: 0}
     {_query, params} = prepare(Comment |> where([c], c.posted == ^datetime))
     assert params == [{{2015, 1, 7}, {21, 18, 13, 0}}]
 
@@ -103,7 +103,7 @@ defmodule Ecto.Query.PlannerTest do
   end
 
   test "prepare: casts and dumps custom types in in-expressions" do
-    datetime = %Ecto.DateTime{year: 2015, month: 1, day: 7, hour: 21, min: 18, sec: 13}
+    datetime = %Ecto.DateTime{year: 2015, month: 1, day: 7, hour: 21, min: 18, sec: 13, usec: 0}
     {_query, params} = prepare(Comment |> where([c], c.posted in ^[datetime]))
     assert params == [{{2015, 1, 7}, {21, 18, 13, 0}}]
 
@@ -111,7 +111,7 @@ defmodule Ecto.Query.PlannerTest do
     {_query, params} = prepare(Post |> where([p], p.id in ^[permalink]))
     assert params == [1]
 
-    datetime = %Ecto.DateTime{year: 2015, month: 1, day: 7, hour: 21, min: 18, sec: 13}
+    datetime = %Ecto.DateTime{year: 2015, month: 1, day: 7, hour: 21, min: 18, sec: 13, usec: 0}
     {_query, params} = prepare(Comment |> where([c], c.posted in [^datetime]))
     assert params == [{{2015, 1, 7}, {21, 18, 13, 0}}]
 


### PR DESCRIPTION
This PR implements support for microseconds (`usec`) in the `Ecto.Time` and `Ecto.DateTime` structs, as discussed in #491.

I'd like a small review to see if I'm headed in the right direction. For example, `:usec` would be a field for which a `0` default would make sense, but I'm not sure so I'd like additional opinions :). I'd also like to refactor a bit (I can do that in another PR if necessary).

Thanks so much!