### PR TITLE
Add microseconds to "Ecto.Schema.timestamps/0" timestamps.

### DIFF
--- a/lib/ecto/model/timestamps.ex
+++ b/lib/ecto/model/timestamps.ex
@@ -23,9 +23,15 @@ defmodule Ecto.Model.Timestamps do
     if get_change changeset, field do
       changeset
     else
-      {date, {h, m, s}} = :erlang.universaltime
-      put_change changeset, field, Ecto.Type.load!(type, {date, {h, m, s, 0}})
+      put_change changeset, field, Ecto.Type.load!(type, timestamp_tuple_with_usec)
     end
+  end
+
+  defp timestamp_tuple_with_usec do
+    erl_timestamp = :os.timestamp
+    {_, _, usec} = erl_timestamp
+    {date, {h, m, s}} =:calendar.now_to_datetime(erl_timestamp)
+    {date, {h, m, s, usec}}
   end
 
   defmacro __before_compile__(env) do


### PR DESCRIPTION
For "Ecto.Schema.timestamps/0": Use timestamps with microseconds instead of always setting microseconds to 0.