### PR TITLE
Fix a test in `Ecto.DateTimeTest`

### DIFF
--- a/test/ecto/datetime_test.exs
+++ b/test/ecto/datetime_test.exs
@@ -62,11 +62,11 @@ defmodule Ecto.TimeTest do
     assert Ecto.Time.cast(@test_time <> ".000123Z")
       == {:ok, %{@test_ecto_time | usec: 123}}
 
-    assert Ecto.Date.cast("24:01:01") == :error
-    assert Ecto.Date.cast("00:61:00") == :error
-    assert Ecto.Date.cast("00:00:61") == :error
-    assert Ecto.Date.cast("00:00:009") == :error
-    assert Ecto.Date.cast("00:00:00.A00") == :error
+    assert Ecto.Time.cast("24:01:01") == :error
+    assert Ecto.Time.cast("00:61:00") == :error
+    assert Ecto.Time.cast("00:00:61") == :error
+    assert Ecto.Time.cast("00:00:009") == :error
+    assert Ecto.Time.cast("00:00:00.A00") == :error
   end
 
   test "cast maps" do


### PR DESCRIPTION
Dates were mistakenly tested instead of times. The error went unnoticed since an error was actually being tested: the tested times should have been invalid times but they also were invalid dates, so `Ecto.Date.cast/1` still returned `:error` on them.