### PR TITLE
Fix mysql datetime and re-add microsecond precision to timestamps

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1,8 +1,11 @@
+Code.require_file "../support/date_time.exs", __DIR__
+
 defmodule Ecto.Integration.RepoTest do
   use Ecto.Integration.Case
 
   require Ecto.Integration.TestRepo, as: TestRepo
   import Ecto.Query
+  import Ecto.Integration.DateTime
 
   alias Ecto.Integration.Post
   alias Ecto.Integration.Comment
@@ -163,7 +166,9 @@ defmodule Ecto.Integration.RepoTest do
 
   test "get(!)" do
     post1 = TestRepo.insert(%Post{title: "1", text: "hai"})
+      |> round_datetime_if_needed(TestRepo.adapter_supports_microsconds?)
     post2 = TestRepo.insert(%Post{title: "2", text: "hai"})
+      |> round_datetime_if_needed(TestRepo.adapter_supports_microsconds?)
 
     assert post1 == TestRepo.get(Post, post1.id)
     assert post2 == TestRepo.get(Post, to_string post2.id) # With casting
@@ -188,7 +193,9 @@ defmodule Ecto.Integration.RepoTest do
 
   test "one(!)" do
     post1 = TestRepo.insert(%Post{title: "1", text: "hai"})
+      |> round_datetime_if_needed(TestRepo.adapter_supports_microsconds?)
     post2 = TestRepo.insert(%Post{title: "2", text: "hai"})
+      |> round_datetime_if_needed(TestRepo.adapter_supports_microsconds?)
 
     assert post1 == TestRepo.one(from p in Post, where: p.id == ^post1.id)
     assert post2 == TestRepo.one(from p in Post, where: p.id == ^to_string post2.id) # With casting
@@ -355,7 +362,9 @@ defmodule Ecto.Integration.RepoTest do
 
   test "joins" do
     p1 = TestRepo.insert(%Post{title: "1"})
+      |> round_datetime_if_needed(TestRepo.adapter_supports_microsconds?)
     p2 = TestRepo.insert(%Post{title: "2"})
+      |> round_datetime_if_needed(TestRepo.adapter_supports_microsconds?)
     c1 = TestRepo.insert(%Permalink{url: "1", post_id: p2.id})
 
     query = from(p in Post, join: c in assoc(p, :permalink), order_by: p.id, select: {p, c})
@@ -367,6 +376,7 @@ defmodule Ecto.Integration.RepoTest do
 
   test "has_many association join" do
     post = TestRepo.insert(%Post{title: "1", text: "hi"})
+      |> round_datetime_if_needed(TestRepo.adapter_supports_microsconds?)
     c1 = TestRepo.insert(%Comment{text: "hey", post_id: post.id})
     c2 = TestRepo.insert(%Comment{text: "heya", post_id: post.id})
 
@@ -376,6 +386,7 @@ defmodule Ecto.Integration.RepoTest do
 
   test "has_one association join" do
     post = TestRepo.insert(%Post{title: "1", text: "hi"})
+      |> round_datetime_if_needed(TestRepo.adapter_supports_microsconds?)
     p1 = TestRepo.insert(%Permalink{url: "hey", post_id: post.id})
     p2 = TestRepo.insert(%Permalink{url: "heya", post_id: post.id})
 
@@ -385,6 +396,7 @@ defmodule Ecto.Integration.RepoTest do
 
   test "belongs_to association join" do
     post = TestRepo.insert(%Post{title: "1"})
+      |> round_datetime_if_needed(TestRepo.adapter_supports_microsconds?)
     p1 = TestRepo.insert(%Permalink{url: "hey", post_id: post.id})
     p2 = TestRepo.insert(%Permalink{url: "heya", post_id: post.id})
 

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -12,6 +12,8 @@ Application.put_env(:ecto, TestRepo,
 
 defmodule Ecto.Integration.TestRepo do
   use Ecto.Repo, otp_app: :ecto
+
+  def adapter_supports_microsconds?, do: false
 end
 
 # Pool repo for transaction and lock tests

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -12,6 +12,8 @@ Application.put_env(:ecto, TestRepo,
 
 defmodule Ecto.Integration.TestRepo do
   use Ecto.Repo, otp_app: :ecto
+
+  def adapter_supports_microsconds?, do: true
 end
 
 # Pool repo for transaction and lock tests

--- a/integration_test/support/date_time.exs
+++ b/integration_test/support/date_time.exs
@@ -1,0 +1,14 @@
+defmodule Ecto.Integration.DateTime do
+  def round_datetime_if_needed(element, false), do: apply_datetime_rounding(element)
+  def round_datetime_if_needed(element, true), do: element
+
+  # take for instance a post and apply mysql rounding to inserted_at and updated_at
+  defp apply_datetime_rounding(element) do
+    %{element | inserted_at: datetime_rounding(element.inserted_at),
+                updated_at:  datetime_rounding(element.updated_at)}
+  end
+  # Sets usec to 0. This is how MySQl 5.5 does it. MySQL 5.6 will also round up seconds if usec >= 500000
+  defp datetime_rounding(%Ecto.DateTime{day: day, hour: hour, min: min, month: month, sec: sec, usec: _usec, year: year}) do
+    %Ecto.DateTime{day: day, hour: hour, min: min, month: month, sec: sec, usec: 0, year: year}
+  end
+end

--- a/lib/ecto/model/timestamps.ex
+++ b/lib/ecto/model/timestamps.ex
@@ -23,9 +23,15 @@ defmodule Ecto.Model.Timestamps do
     if get_change changeset, field do
       changeset
     else
-      {date, {h, m, s}} = :erlang.universaltime
-      put_change changeset, field, Ecto.Type.load!(type, {date, {h, m, s, 0}})
+      put_change changeset, field, Ecto.Type.load!(type, timestamp_tuple_with_usec)
     end
+  end
+
+  defp timestamp_tuple_with_usec do
+    erl_timestamp = :os.timestamp
+    {_, _, usec} = erl_timestamp
+    {date, {h, m, s}} =:calendar.now_to_datetime(erl_timestamp)
+    {date, {h, m, s, usec}}
   end
 
   defmacro __before_compile__(env) do


### PR DESCRIPTION
The default datetime type in MySQL does not have microsecond precision (at least in v5.6).
The first commit fixes this by using datetime(6). With this you avoid MySQL rounding up seconds when any Ecto.DateTime with e.g. usec set to 700000 is saved.

The other commit adds microsecond precision back to timestamps.

If travis runs at least MySQL 5.6, integrations test should pass.