### PR TITLE
fix the "fail invalid default" test

### DIFF
--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -127,11 +127,11 @@ defmodule Ecto.SchemaTest do
   end
 
   test "fail invalid default" do
-    assert_raise ArgumentError, "schema source must be a string, got: :hello", fn ->
-      defmodule SchemaFail do
+    assert_raise ArgumentError, "invalid default argument `13` for `:string`", fn ->
+      defmodule DefaultFail do
         use Ecto.Model
 
-        schema :hello do
+        schema "hello" do
           field :x, :string, default: 13
         end
       end


### PR DESCRIPTION
This test is meant to test invalid default, but it just tests same thing with "fail invalid schema" test.