### PR TITLE
Add usec as option to timestamps

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -5,6 +5,7 @@ defmodule Ecto.Integration.RepoTest do
   import Ecto.Query
 
   alias Ecto.Integration.Post
+  alias Ecto.Integration.PostUsecTimestamps
   alias Ecto.Integration.Comment
   alias Ecto.Integration.Permalink
   alias Ecto.Integration.User
@@ -474,5 +475,11 @@ defmodule Ecto.Integration.RepoTest do
     cs_stale = cast(base_post, %{"url" => "http://foo.baz"}, ~w(url), ~w())
     assert_raise Ecto.StaleModelError, fn -> TestRepo.update(cs_stale) end
     assert_raise Ecto.StaleModelError, fn -> TestRepo.delete(cs_stale) end
+  end
+
+  @tag :uses_usec
+  test "insert and fetch a model with timestamps with usec" do
+    p1 = TestRepo.insert(%PostUsecTimestamps{title: "hello"})
+    assert [p1] == TestRepo.all(PostUsecTimestamps)
   end
 end

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -1,5 +1,5 @@
 Logger.configure(level: :info)
-ExUnit.start exclude: [:array_type, :read_after_writes, :case_sensitive]
+ExUnit.start exclude: [:array_type, :read_after_writes, :case_sensitive, :uses_usec]
 
 # Basic test repo
 alias Ecto.Integration.TestRepo

--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -85,7 +85,7 @@ defmodule Ecto.Integration.Migration do
     false = exists? index
   end
 
-  # For the permalinks table, let's create a table
+  # For the permalinks table, let's create a table,
   # drop it, and get a new one.
   #
   #     create table(:permalinks) do

--- a/integration_test/support/models.exs
+++ b/integration_test/support/models.exs
@@ -20,6 +20,14 @@ defmodule Ecto.Integration.Post do
   end
 end
 
+defmodule Ecto.Integration.PostUsecTimestamps do
+  use Ecto.Model
+  schema "posts" do
+    field :title, :string
+    timestamps usec: true
+  end
+end
+
 defmodule Ecto.Integration.Comment do
   use Ecto.Model
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -55,6 +55,9 @@ defmodule Ecto.Schema do
     * `@timestamps_type` - configures the default timestamps type
       used by `timestamps`. Defaults to `Ecto.DateTime`;
 
+    * `@timestamps_use_usec` - configures the default timestamp use
+      of microseconds. Defaults to `false`.
+
     * `@derive` - the same as `@derive` available in `Kernel.defstruct/1`
       as the schema defines a struct behind the scenes;
 
@@ -195,6 +198,7 @@ defmodule Ecto.Schema do
       import Ecto.Schema, only: [schema: 2]
       @primary_key {:id, :integer, read_after_writes: true}
       @timestamps_type Ecto.DateTime
+      @timestamps_use_usec false
       @foreign_key_type :integer
     end
   end
@@ -291,6 +295,9 @@ defmodule Ecto.Schema do
 
     * `:type` - the timestamps type, defaults to `Ecto.DateTime`.
       Can also be set via the `@timestamps_type` attribute
+    * `:usec` - boolean, sets whether microseconds are used in timestamps.
+      Microseconds will be 0 if false. Defaults to false.
+      Can also be set via the `@timestamps_use_usec` attribute
     * `:inserted_at` - the name of the column for insertion times or `false`
     * `:updated_at` - the name of the column for update times or `false`
 
@@ -299,6 +306,7 @@ defmodule Ecto.Schema do
     quote bind_quoted: binding do
       timestamps = Keyword.merge [inserted_at: :inserted_at,
                                   updated_at: :updated_at,
+                                  usec: @timestamps_use_usec,
                                   type: @timestamps_type], opts
 
       if inserted_at = Keyword.fetch!(timestamps, :inserted_at) do


### PR DESCRIPTION
Adds an option to timestamps for using microseconds.

This defaults to true, but we could change it to false if necessary.

I think true is good because this is the best option for users of Postgres and MSSQL. This is why it was decided to merge the timestamps-with-microseconds as default originally.

With MySQL things will still work with the default being true, although the results can be slightly different depending on the setup. MySQL 5.6 users can set their migrations to use datetime(6) and enjoy the microseconds or set usec to false. Or do nothing and rounding will occur. MySQL 5.5 users can set it to false or do nothing and microseconds will just be saved as 0.

The tests are still clean regardless of the default being true or false.