### PR TITLE
fix port type in mysql adapter

### DIFF
--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -128,7 +128,7 @@ defmodule Ecto.Adapters.MySQL do
     end
 
     if port = database[:port] do
-      env = [{"MYSQL_TCP_PORT", port}|env]
+      env = [{"MYSQL_TCP_PORT", to_string(port)}|env]
     end
 
     host = database[:hostname] || System.get_env("MYSQL_HOST") || "localhost"


### PR DESCRIPTION
fix for the false port type:

```
** (FunctionClauseError) no function clause matching in String.to_char_list/1
    (elixir) lib/string.ex:1333: String.to_char_list(3306)
    (elixir) lib/system.ex:500: anonymous fn/1 in System.validate_env/1
    (elixir) lib/enum.ex:1041: anonymous fn/3 in Enum.map/2
    (elixir) lib/enum.ex:1383: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir) lib/enum.ex:1041: Enum.map/2
    (elixir) lib/system.ex:489: System.cmd_opts/3
    (elixir) lib/system.ex:456: System.cmd/3
    (ecto) lib/ecto/adapters/mysql.ex:109: Ecto.Adapters.MySQL.storage_down/1


18:56:33.138 [error] Error in process <0.47.0> with exit value: {#{'__exception__'=>true,'__struct__'=>'Elixir.FunctionClauseError',arity=>1,function=>to_char_list,module=>'Elixir.String'},[{'Elixir.String',to_char_list,[3306],[{file,"lib/string.ex"},{line,1333}]},{'Elixir.System','-validate_env/1-fun-0-'...
```