### PR TITLE
Fix mysql port configuration method

### DIFF
--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -127,12 +127,9 @@ defmodule Ecto.Adapters.MySQL do
       env = [{"MYSQL_PWD", password}|env]
     end
 
-    if port = database[:port] do
-      env = [{"MYSQL_TCP_PORT", to_string(port)}|env]
-    end
-
     host = database[:hostname] || System.get_env("MYSQL_HOST") || "localhost"
-    args = ["--silent", "-u", database[:username], "-h", host, "-e", sql_command]
+    port = database[:port] || System.get_env("MYSQL_TCP_PORT") || "3306"
+    args = ["--silent", "-u", database[:username], "-h", host, "-P", to_string(port), "-e", sql_command]
     System.cmd("mysql", args, env: env, stderr_to_stdout: true)
   end
 


### PR DESCRIPTION
mysql client uses the following priority on port configuration:
1) --port option of the mysql binary
2) "port" option in the [client] section of my.cnf
3) system env MYSQL_TCP_PORT

So, if it's defined in my.cnf, ecto port configuration don't works.