### PR TITLE
Support timestamptz

### DIFF
--- a/lib/ecto/adapters/postgres/datetime.ex
+++ b/lib/ecto/adapters/postgres/datetime.ex
@@ -16,7 +16,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       do: :ok
 
     def matching(_),
-      do: [send: "date_send", send: "time_send", send: "timestamp_send"]
+      do: [send: "date_send", send: "time_send", send: "timestamp_send", send: "timestamptz_send"]
 
     def format(_),
       do: :binary
@@ -28,6 +28,8 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     def encode(%TypeInfo{send: "time_send"}, time, _, _),
       do: encode_time(time)
     def encode(%TypeInfo{send: "timestamp_send"}, timestamp, _, _),
+      do: encode_timestamp(timestamp)
+    def encode(%TypeInfo{send: "timestamptz_send"}, timestamp, _, _),
       do: encode_timestamp(timestamp)
 
     defp encode_date({year, month, day}) when year <= @date_max_year do
@@ -55,6 +57,8 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     def decode(%TypeInfo{send: "time_send"}, <<n :: 64>>, _, _),
       do: decode_time(n)
     def decode(%TypeInfo{send: "timestamp_send"}, <<n :: 64>>, _, _),
+      do: decode_timestamp(n)
+    def decode(%TypeInfo{send: "timestamptz_send"}, <<n :: 64>>, _, _),
       do: decode_timestamp(n)
 
     defp decode_date(days) do


### PR DESCRIPTION
Not ready to be merged, lacks tests. Depends on #535.

I don't know enough about how Postgrex Extensions and Ecto Types play together yet, is it possible to refactor this to use Postgrex de-/encoding of the types instead of duplicating the code?