### PR TITLE
Make it possible to set the storage engine for MySQL databases

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -389,7 +389,9 @@ if Code.ensure_loaded?(Mariaex.Connection) do
     end
 
     def execute_ddl({:create, %Table{} = table, columns}) do
-      "CREATE TABLE #{quote_name(table.name)} (#{column_definitions(columns)})"
+      engine = engine_expr(table.engine)
+
+      "CREATE TABLE #{quote_name(table.name)} (#{column_definitions(columns)}) " <> engine
     end
 
     def execute_ddl({:drop, %Table{name: name}}) do
@@ -477,6 +479,11 @@ if Code.ensure_loaded?(Mariaex.Connection) do
     defp reference_expr(%Reference{} = ref, foreign_key_name) do
       ", FOREIGN KEY (#{quote_name(foreign_key_name)}) REFERENCES #{quote_name(ref.table)} (#{quote_name(ref.column)})"
     end
+
+    defp engine_expr(nil),
+      do: "ENGINE = INNODB"
+    defp engine_expr(storage_engine),
+      do: String.upcase("ENGINE = #{storage_engine}")
 
     defp column_type(type, opts) do
       size      = Keyword.get(opts, :size)

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -116,8 +116,8 @@ defmodule Ecto.Migration do
     @moduledoc """
     Defines a table struct used in migrations.
     """
-    defstruct name: nil, primary_key: true
-    @type t :: %__MODULE__{name: atom, primary_key: boolean}
+    defstruct name: nil, primary_key: true, engine: nil
+    @type t :: %__MODULE__{name: atom, primary_key: boolean, engine: atom}
   end
 
   defmodule Reference do
@@ -246,6 +246,8 @@ defmodule Ecto.Migration do
   ## Options
 
     * `:primary_key` - when false, does not generate primary key on table creation
+    * `:engine` - customizes the table storage for supported databases. For MySQL,
+      the default is InnoDB
 
   """
   def table(name, opts \\ []) when is_atom(name) do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -383,7 +383,7 @@ defmodule Ecto.Adapters.MySQLTest do
 
   # DDL
 
-  import Ecto.Migration, only: [table: 1, index: 2, index: 3, references: 1]
+  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1]
 
   test "executing a string during migration" do
     assert SQL.execute_ddl("example") == "example"
@@ -395,7 +395,16 @@ defmodule Ecto.Adapters.MySQLTest do
                 {:add, :title, :string, []},
                 {:add, :created_at, :datetime, []}]}
     assert SQL.execute_ddl(create) ==
-           ~s|CREATE TABLE `posts` (`id` serial , PRIMARY KEY(`id`), `title` varchar(255), `created_at` datetime)|
+           ~s|CREATE TABLE `posts` (`id` serial , PRIMARY KEY(`id`), `title` varchar(255), `created_at` datetime) ENGINE = INNODB|
+  end
+
+  test "create table with engine" do
+    create = {:create, table(:posts, engine: :myisam),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :title, :string, []},
+                {:add, :created_at, :datetime, []}]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE `posts` (`id` serial , PRIMARY KEY(`id`), `title` varchar(255), `created_at` datetime) ENGINE = MYISAM|
   end
 
   test "create table with reference" do
@@ -403,7 +412,7 @@ defmodule Ecto.Adapters.MySQLTest do
                [{:add, :id, :serial, [primary_key: true]},
                 {:add, :category_id, references(:categories), []} ]}
     assert SQL.execute_ddl(create) ==
-           ~s|CREATE TABLE `posts` (`id` serial , PRIMARY KEY(`id`), `category_id` BIGINT UNSIGNED , FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`))|
+           ~s|CREATE TABLE `posts` (`id` serial , PRIMARY KEY(`id`), `category_id` BIGINT UNSIGNED , FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`)) ENGINE = INNODB|
   end
 
   test "create table with column options" do
@@ -417,7 +426,7 @@ defmodule Ecto.Adapters.MySQLTest do
     CREATE TABLE `posts` (`name` varchar(20) DEFAULT 'Untitled' NOT NULL,
     `price` numeric(8,2) DEFAULT expr,
     `on_hand` integer DEFAULT 0,
-    `is_active` boolean DEFAULT true)
+    `is_active` boolean DEFAULT true) ENGINE = INNODB
     """ |> String.strip |> String.replace("\n", " ")
   end
 


### PR DESCRIPTION
In MySQL database is possible to set the storage engine. This PR adds an option to set the storage engine when creating the database and when creating a table.

Closes https://github.com/elixir-lang/ecto/issues/538