### PR TITLE
Fix handling of dates before 2000-01-01; epoch offsets need to be signed...

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -309,6 +309,10 @@ defmodule Ecto.Integration.RepoTest do
     assert %Comment{id: id2} = TestRepo.insert(%Comment{})
     assert 1 = TestRepo.update_all(p in Comment, text: ^text, posted: ^date)
     assert %Comment{text: "hai", posted: ^date} = TestRepo.get(Comment, id2)
+
+    date = {{1955, 11, 12}, {6, 38, 01, 0}}
+    assert 1 = TestRepo.update_all(p in Comment, text: ^text, posted: ^date)
+    assert %Comment{text: "hai", posted: ^date} = TestRepo.get(Comment, id2)
   end
 
   test "delete all" do

--- a/lib/ecto/adapters/postgres/datetime.ex
+++ b/lib/ecto/adapters/postgres/datetime.ex
@@ -50,11 +50,11 @@ if Code.ensure_loaded?(Postgrex.Connection) do
 
     ### DECODING ###
 
-    def decode(%TypeInfo{send: "date_send"}, <<n :: 32>>, _, _),
+    def decode(%TypeInfo{send: "date_send"}, <<n :: signed-32>>, _, _),
       do: decode_date(n)
-    def decode(%TypeInfo{send: "time_send"}, <<n :: 64>>, _, _),
+    def decode(%TypeInfo{send: "time_send"}, <<n :: signed-64>>, _, _),
       do: decode_time(n)
-    def decode(%TypeInfo{send: "timestamp_send"}, <<n :: 64>>, _, _),
+    def decode(%TypeInfo{send: "timestamp_send"}, <<n :: signed-64>>, _, _),
       do: decode_timestamp(n)
 
     defp decode_date(days) do

--- a/lib/ecto/adapters/postgres/datetime.ex
+++ b/lib/ecto/adapters/postgres/datetime.ex
@@ -32,20 +32,20 @@ if Code.ensure_loaded?(Postgrex.Connection) do
 
     defp encode_date({year, month, day}) when year <= @date_max_year do
       date = {year, month, day}
-      <<:calendar.date_to_gregorian_days(date) - @gd_epoch :: 32>>
+      <<:calendar.date_to_gregorian_days(date) - @gd_epoch :: signed-32>>
     end
 
     defp encode_time({hour, min, sec, usec})
         when hour in 0..23 and min in 0..59 and sec in 0..59 and usec in 0..999_999 do
       time = {hour, min, sec}
-      <<:calendar.time_to_seconds(time) * 1_000_000 + usec::64>>
+      <<:calendar.time_to_seconds(time) * 1_000_000 + usec :: signed-64>>
     end
 
     defp encode_timestamp({{year, month, day}, {hour, min, sec, usec}})
         when year <= @timestamp_max_year and hour in 0..23 and min in 0..59 and sec in 0..59 and usec in 0..999_999 do
       datetime = {{year, month, day}, {hour, min, sec}}
       secs = :calendar.datetime_to_gregorian_seconds(datetime) - @gs_epoch
-      <<secs * 1_000_000 + usec :: 64>>
+      <<secs * 1_000_000 + usec :: signed-64>>
     end
 
     ### DECODING ###


### PR DESCRIPTION
Modifying the binary matching to return signed integers makes dates/timestamps before 2000-01-01 work correctly, and all tests still pass OK.
