### PR TITLE
Normalized ports to convert integer strings as real integers

### DIFF
--- a/integration_test/pg/port_test.exs
+++ b/integration_test/pg/port_test.exs
@@ -1,0 +1,16 @@
+defmodule Ecto.Integration.PortTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Adapters.Postgres.Connection
+
+  test "port as integer" do
+    {mode, _} = Connection.connect([port: 5432, database: "postgres"])
+    assert mode == :ok
+  end
+
+  test "port as string" do
+    {mode, _} = Connection.connect([port: "5432", database: "postgres"])
+    assert mode == :ok
+  end
+
+end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -10,12 +10,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
 
     def connect(opts) do
       extensions = [{Ecto.Adapters.Postgres.DateTime, []}]
-      port = (opts[:port] || @default_port) |> normalize_port
-
       opts =
         opts
         |> Keyword.update(:extensions, extensions, &(&1 ++ extensions))
-        |> Keyword.put(:port, port)
+        |> Keyword.update(:port, @default_port, &normalize_port/1)
 
       Postgrex.Connection.start_link(opts)
     end
@@ -45,9 +43,14 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     Ensures a port is represented as an integer.  This
     allows for configuration to grab data from the ENV without
     having to convert it to an integer directly.
+
+    An exception
+    will be thrown if the the provided string isn't an integer
+    e.g.  ** (ArgumentError) argument error
+          :erlang.binary_to_integer("a")
     """
-    def normalize_port(port) when is_binary(port), do: to_int(port, Integer.parse(port))
-    def normalize_port(port), do: port
+    def normalize_port(port) when is_binary(port), do: String.to_integer(port)
+    def normalize_port(port) when is_integer(port), do: port
 
     ## Transaction
 
@@ -573,10 +576,6 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     defp ecto_to_db(:datetime),   do: "timestamp"
     defp ecto_to_db(:binary),     do: "bytea"
     defp ecto_to_db(other),       do: Atom.to_string(other)
-
-    defp to_int(original, :error), do: original
-    defp to_int(_, {num, ""}),     do: num
-
   end
 
 end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -517,7 +517,9 @@ defmodule Ecto.Adapters.PostgresTest do
     assert SQL.normalize_port("9876") == 9876
   end
 
-  test "normalize_port leaves it as-if if it is not an integer" do
-    assert SQL.normalize_port("abc") == "abc"
+  test "normalize_port should throw an exception if the string isn't an integer" do
+    assert_raise ArgumentError, "argument error", fn ->
+      SQL.normalize_port("abc")
+    end
   end
 end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -508,4 +508,16 @@ defmodule Ecto.Adapters.PostgresTest do
     drop = {:drop, index(:posts, [:id], name: "posts$main", concurrently: true)}
     assert SQL.execute_ddl(drop) == ~s|DROP INDEX CONCURRENTLY "posts$main"|
   end
+
+  test "normalize_port when already an integer" do
+    assert SQL.normalize_port(1234) == 1234
+  end
+
+  test "normalize_port converts a string to an integer" do
+    assert SQL.normalize_port("9876") == 9876
+  end
+
+  test "normalize_port leaves it as-if if it is not an integer" do
+    assert SQL.normalize_port("abc") == "abc"
+  end
 end


### PR DESCRIPTION
The underlying erlang function being called when establishing a connection does not support strings for port numbers.  In my phoenix app the DB configs are grabbed from the env variables so I thought it would be better to have the underlying ecto manage the conversion.

A few comments

1) I only added it to the postgres adapter, but this could be added more generically (e.g. for mysql as well through a common module like Ecto.Repo.Config)

2) If the port isn't an integer, I kept it as-is so that the exception would be meaningful (i.e. port: "ABC" versus a failure, for example to connect to  port: 0)

3) I also see a point not to include it in this project, but I thought I would elicit feedback through PR, as it wasn't much effort.  Is that the preferred approach, or should I have raised an issue / feature request first?

Here's the exception from inet_tcp
```elixir
** (exit) exited in: GenServer.call(#PID<0.153.0>, :query, :infinity)
    ** (EXIT) exited in: GenServer.call(#PID<0.154.0>, {:connect, [timeout: 5000, otp_app: :******, adapter: Ecto.Adapters.Postgres, username: "******", hostname: "1.1.1.1", port: "5432", password: "******", database: "******", extensions: [{Ecto.Adapters.Postgres.DateTime, []}]]}, 5000)
        ** (EXIT) an exception was raised:
            ** (FunctionClauseError) no function clause matching in :inet_tcp.getserv/1
                (kernel) inet_tcp.erl:35: :inet_tcp.getserv("5432")
                (kernel) gen_tcp.erl:154: :gen_tcp.connect1/4
                (kernel) gen_tcp.erl:141: :gen_tcp.connect/4
                lib/postgrex/connection.ex:356: Postgrex.Connection.connect/3
                (stdlib) gen_server.erl:607: :gen_server.try_handle_call/4
                (stdlib) gen_server.erl:639: :gen_server.handle_msg/5
                (stdlib) proc_lib.erl:237: :proc_lib.init_p_do_apply/3
    (elixir) lib/gen_server.ex:356: GenServer.call/3
    lib/ecto/adapters/sql/worker.ex:22: Ecto.Adapters.SQL.Worker.query!/4
    lib/ecto/adapters/sql.ex:187: Ecto.Adapters.SQL.use_worker/3
    lib/ecto/adapters/postgres.ex:58: Ecto.Adapters.Postgres.ddl_exists?/3
    lib/ecto/migration/schema_migration.ex:19: Ecto.Migration.SchemaMigration.ensure_schema_migrations_table!/1
    lib/ecto/migrator.ex:36: Ecto.Migrator.migrated_versions/1
    lib/ecto/migrator.ex:134: Ecto.Migrator.run/4
    (mix) lib/mix/cli.ex:55: Mix.CLI.run_task/2
```