### PR TITLE
Also build using 1.0.4 and OTP 17.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ otp_release:
   - 17.0
   - 17.1
   - 17.4
+matrix:
+  include:
+    - elixir: 1.0.4
+      otp_release: 17.5
 services: mysql
 sudo: false # to use faster container based build environment
 env:


### PR DESCRIPTION
This requires Travis CI to release their new server image with support for Elixir 1.0.4 and OTP 17.5.

https://github.com/travis-ci/travis-build/pull/422#issuecomment-90949420