### PR TITLE
Set UUIDs to lower case

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -100,7 +100,7 @@ defmodule Ecto.Integration.TypeTest do
     assert [[1, 2, 3]] = TestRepo.all(from p in Tag, where: p.ints == [1, 2, 3], select: p.ints)
 
     assert [] = TestRepo.all(from p in Tag, where: p.uuids == ^[], select: p.uuids)
-    assert [["51FCFBDD-AD60-4CCB-8BF9-47AABD66D075"]] =
+    assert [["51fcfbdd-ad60-4ccb-8bf9-47aabd66d075"]] =
            TestRepo.all(from p in Tag, where: p.uuids == ^["51FCFBDD-AD60-4CCB-8BF9-47AABD66D075"],
                                        select: p.uuids)
   end

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -48,8 +48,12 @@ defmodule Ecto.UUID do
   end
 
   defp encode(<<u0::32, u1::16, u2::16, u3::16, u4::48>>) do
-    hex_pad(u0, 8) <> "-" <> hex_pad(u1, 4) <> "-" <> hex_pad(u2, 4) <>
-                      "-" <> hex_pad(u3, 4) <> "-" <> hex_pad(u4, 12)
+    hex_pad(u0, 8) <> "-" <>
+    hex_pad(u1, 4) <> "-" <>
+    hex_pad(u2, 4) <> "-" <>
+    hex_pad(u3, 4) <> "-" <>
+    hex_pad(u4, 12)
+    |> String.downcase
   end
 
   defp hex_pad(hex, count) do

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -1,9 +1,9 @@
 defmodule Ecto.UUIDTest do
   use ExUnit.Case, async: true
 
-  @test_uuid "601D74E4-A8D3-4B6E-8365-EDDB4C893327"
+  @test_uuid "601d74e4-a8d3-4b6e-8365-eddb4c893327"
   @test_uuid_binary << 0x60, 0x1D, 0x74, 0xE4, 0xA8, 0xD3, 0x4B, 0x6E, 0x83, 0x65, 0xED, 0xDB, 0x4C, 0x89, 0x33, 0x27 >>
-  
+
   test "cast" do
     assert Ecto.UUID.cast(@test_uuid) == {:ok, @test_uuid}
     assert Ecto.UUID.cast(@test_uuid_binary) == {:ok, @test_uuid}


### PR DESCRIPTION
[RFC 4122][1] specifies that hex characters should be lower cased for output.

[1]: http://tools.ietf.org/html/rfc4122#section-3