### PR TITLE
Fixing reference in docs to Ecto.Associations

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -127,9 +127,9 @@ defmodule Ecto.Association do
   ## Examples
 
       post = Repo.get(Post, 1)
-      Ecto.Associations.loaded?(post.comments) # false
+      Ecto.Association.loaded?(post.comments) # false
       post = post |> Repo.preload(:comments)
-      Ecto.Associations.loaded?(post.comments) # true
+      Ecto.Association.loaded?(post.comments) # true
 
   """
   def loaded?(association) do


### PR DESCRIPTION
Hello.  I know this is a minor issue, but I tripped up on it just now.  This fixes one spot where the documenting comments refer to the old module name Ecto.Associations, instead of the new one Ecto.Association.