### PR TITLE
Initial migration config

### DIFF
--- a/lib/ecto/migration/config.ex
+++ b/lib/ecto/migration/config.ex
@@ -1,0 +1,33 @@
+defmodule Ecto.Migration.Config do
+  @moduledoc false
+
+  @doc """
+  Retrieves the `:ecto_migration` configuration for `:primary_key`
+  """
+  def primary_key do
+    default = {:version, :integer, []}
+
+    app()
+    |> Application.get_env(:ecto_migration, primary_key: default)
+    |> Keyword.get(:primary_key)
+  end
+
+  @doc """
+  Retrieves the column name from primary_key/1
+  """
+  def primary_key_column(:name) do
+    elem(primary_key, 0)
+  end
+
+  @doc """
+  Retrieves the column type from primary_key/1
+  """
+  def primary_key_column(:type) do
+    type = elem(primary_key, 1)
+    if type == :integer do :bigint else type end
+  end
+
+  defp app do
+    Mix.Project.config |> Keyword.fetch!(:app)
+  end
+end

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -3,7 +3,9 @@ defmodule Ecto.Migration.SchemaMigration do
   @moduledoc false
   use Ecto.Model
 
-  @primary_key {:version, :integer, []}
+  alias Ecto.Migration.Config
+
+  @primary_key Config.primary_key()
   schema "schema_migrations" do
     timestamps updated_at: false
   end
@@ -17,9 +19,12 @@ defmodule Ecto.Migration.SchemaMigration do
     # DDL queries do not log, so we do not need
     # to pass log: false here.
     unless adapter.ddl_exists?(repo, @table, @opts) do
+      column_name = Config.primary_key_column(:name)
+      column_type = Config.primary_key_column(:type)
+
       adapter.execute_ddl(repo,
         {:create, @table, [
-          {:add, :version, :bigint, primary_key: true},
+          {:add, column_name, column_type, primary_key: true},
           {:add, :inserted_at, :datetime, []}]}, @opts)
     end
 

--- a/test/ecto/migration/config_test.exs
+++ b/test/ecto/migration/config_test.exs
@@ -1,0 +1,38 @@
+defmodule Ecto.Migration.ConfigTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Migration.Config
+
+  defp put_env(env) do
+    Application.put_env(:ecto, :ecto_migration, env)
+  end
+
+  test "primary key should have default" do
+    Application.delete_env(:ecto, :ecto_migration)
+    assert primary_key == {:version, :integer, []}
+    assert primary_key_column(:type) == :bigint
+  end
+
+  test "primary key should be sourced from config" do
+    custom_primary_key = {:version, :string, []}
+    put_env(primary_key: custom_primary_key)
+
+    assert primary_key == custom_primary_key
+  end
+
+  test "returns column name of primary key" do
+    put_env(primary_key: {:custom_primary_key, :string, []})
+
+    assert primary_key_column(:name) == :custom_primary_key
+  end
+
+  test "returns column type of primary key" do
+    put_env(primary_key: {:custom_primary_key, :string, []})
+
+    assert primary_key_column(:type) == :string
+
+    put_env(primary_key: {:custom_primary_key, :integer, []})
+
+    assert primary_key_column(:type) == :bigint
+  end
+end


### PR DESCRIPTION
refs: https://github.com/elixir-lang/ecto/issues/566

@josevalim will this work for customizing primary key in `Ecto.Migration.SchemaMigration`? I initially tried testing by checking if `SchemaMigration` has a primary key set but realized later on it gets compiled before I do `Application.put_env` in the tests. 

Should I write a test that checks `SchemaMigration` has the primary key set as expected? If so, how to provide the expected application env variables in compile-time in tests?