### PR TITLE
Don't attempt to log on `mix ecto.migrate --no-start`

### DIFF
--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
       opts = Keyword.put(opts, :all, true)
     end
 
-    if opts[:quiet] do
+    if opts[:quiet] || opts[:no_start] do
       opts = Keyword.put(opts, :log, false)
     end
 

--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -33,6 +33,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
     * `--step` / `-n` - run n number of pending migrations
     * `--to` / `-v` - run all migrations up to and including version
     * `--no-start` - do not start applications
+    * `--quiet` - do no log output
   """
 
   @doc false

--- a/test/mix/tasks/ecto.migrate_test.exs
+++ b/test/mix/tasks/ecto.migrate_test.exs
@@ -19,8 +19,9 @@ defmodule Mix.Tasks.Ecto.MigrateTest do
   end
 
   test "runs the migrator with the repo started" do
-    run ["-r", to_string(Repo), "--no-start"], fn _, _, _, _ ->
+    run ["-r", to_string(Repo), "--no-start"], fn _, _, _, opts ->
       Process.put(:migrated, true)
+      assert opts[:log] == false
     end
     assert Process.get(:migrated)
     assert Process.get(:started)


### PR DESCRIPTION
Referecing issue #574 

Treats the "--no-start" flag the same as the "--quiet" flag. Also, updates the documentation to indicate that there *is* a --quiet flag.