### PR TITLE
[WIP] Use sbroker instead of poolboy

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -12,6 +12,10 @@ defmodule Ecto.Adapters.SQL do
   to SQL. See `Ecto.Adapters.SQL.Connection` for more info.
   """
 
+  @queue_spec {:squeue_timeout, :sbroker_time.milli_seconds_to_native(5000),
+      :out, :infinity, :drop}
+  @queue_interval 200
+
   @doc false
   defmacro __using__(adapter) do
     quote do
@@ -112,6 +116,7 @@ defmodule Ecto.Adapters.SQL do
   end
 
   alias Ecto.Adapters.SQL.Worker
+  alias Ecto.Adapters.SQL.Broker
 
   @doc """
   Runs custom SQL query on given repo.
@@ -145,7 +150,7 @@ defmodule Ecto.Adapters.SQL do
     opts = Keyword.put_new(opts, :timeout, elem(repo.__pool__, 1))
 
     log(repo, {:query, sql, params}, opts, fn ->
-      use_worker(repo, opts[:timeout], fn worker ->
+      use_worker(repo, fn worker ->
         Worker.query!(worker, sql, params, opts)
       end)
     end)
@@ -171,7 +176,7 @@ defmodule Ecto.Adapters.SQL do
     {pid, timeout}
   end
 
-  defp use_worker(repo, timeout, fun) do
+  defp use_worker(repo, fun) do
     {pool, _} = pool!(repo)
     key  = {:ecto_transaction_pid, pool}
 
@@ -180,16 +185,24 @@ defmodule Ecto.Adapters.SQL do
         {worker, _} ->
           {true, worker}
         nil ->
-          {false, :poolboy.checkout(pool, true, timeout)}
+          {false, checkout(pool)}
       end
 
     try do
       fun.(worker)
     after
       if not in_transaction do
-        :poolboy.checkin(pool, worker)
+        checkin(worker)
       end
     end
+  end
+
+  defp checkout(pool) do
+    Broker.checkout(pool)
+  end
+
+  defp checkin(worker) do
+    Worker.done(worker)
   end
 
   @doc ~S"""
@@ -276,9 +289,9 @@ defmodule Ecto.Adapters.SQL do
     {pool, timeout} = pool!(repo)
     opts = Keyword.put_new(opts, :timeout, timeout)
 
-    :poolboy.transaction(pool, fn worker ->
+    raw_transaction(pool, fn worker ->
       Worker.begin_test_transaction!(worker, opts)
-    end, opts[:timeout])
+    end)
 
     :ok
   end
@@ -291,9 +304,9 @@ defmodule Ecto.Adapters.SQL do
     {pool, timeout} = pool!(repo)
     opts = Keyword.put_new(opts, :timeout, timeout)
 
-    :poolboy.transaction(pool, fn worker ->
+    raw_transaction(pool, fn worker ->
       Worker.restart_test_transaction!(worker, opts)
-    end, opts[:timeout])
+    end)
 
     :ok
   end
@@ -306,11 +319,20 @@ defmodule Ecto.Adapters.SQL do
     {pool, timeout} = pool!(repo)
     opts = Keyword.put_new(opts, :timeout, timeout)
 
-    :poolboy.transaction(pool, fn worker ->
+    raw_transaction(pool, fn worker ->
       Worker.rollback_test_transaction!(worker, opts)
-    end, opts[:timeout])
+    end)
 
     :ok
+  end
+
+  defp raw_transaction(pool, fun) do
+    worker = checkout(pool)
+    try do
+      fun.(worker)
+    after
+      checkin(worker)
+    end
   end
 
   ## Worker
@@ -348,25 +370,55 @@ defmodule Ecto.Adapters.SQL do
       """
     end
 
-    :poolboy.start_link(pool_opts, {connection, worker_opts})
+    sup_name = pool_opts
+      |> Keyword.fetch!(:name)
+      |> Atom.to_string()
+      |> Kernel.<>(".Supervisor")
+      |> String.to_atom()
+
+    Supervisor.start_link(__MODULE__, {pool_opts, connection, worker_opts},
+      [name: sup_name])
+  end
+
+  @doc false
+  def init({pool_opts, connection, worker_opts}) do
+    import Supervisor.Spec
+
+
+    broker = worker(Broker, [pool_opts])
+
+    size = Keyword.fetch!(pool_opts, :size)
+    pool_name = Keyword.fetch!(pool_opts, :name)
+    workers = for id <- 1..size do
+        worker(Worker, [{pool_name, connection, worker_opts}], [id: id])
+      end
+    worker_sup = supervisor(Supervisor, [workers, [strategy: :one_for_one]])
+
+    supervise([broker, worker_sup], [strategy: :rest_for_one, max_restarts: 0])
   end
 
   @doc false
   def stop(repo) do
-    :poolboy.stop elem(pool!(repo), 0)
+    {pool, _} = pool!(repo)
+    monitor = Process.monitor(pool)
+    Process.exit(pool, :shutdown)
+    receive do
+      {:DOWN, ^monitor, _, _, _} ->
+        :ok
+    end
   end
 
   defp split_opts(repo, opts) do
     pool_name = elem(repo.__pool__, 0)
-    {pool_opts, worker_opts} = Keyword.split(opts, [:size, :max_overflow])
+    pool_keys = [:size, :client_queue, :worker_queue, :queue_interval]
+    {pool_opts, worker_opts} = Keyword.split(opts, pool_keys)
 
     pool_opts = pool_opts
       |> Keyword.put_new(:size, 10)
-      |> Keyword.put_new(:max_overflow, 0)
-
-    pool_opts =
-      [name: {:local, pool_name},
-       worker_module: Worker] ++ pool_opts
+      |> Keyword.put_new(:client_queue, @queue_spec)
+      |> Keyword.put_new(:worker_queue, @queue_spec)
+      |> Keyword.put_new(:queue_interval, @queue_interval)
+      |> Keyword.put(:name, pool_name)
 
     worker_opts = worker_opts
       |> Keyword.put(:timeout, Keyword.get(worker_opts, :connect_timeout, 5000))
@@ -435,8 +487,7 @@ defmodule Ecto.Adapters.SQL do
     {pool, timeout} = pool!(repo)
 
     opts    = Keyword.put_new(opts, :timeout, timeout)
-    timeout = Keyword.get(opts, :timeout)
-    worker  = checkout_worker(pool, timeout)
+    worker  = transaction_checkout(pool)
 
     try do
       do_begin(repo, worker, opts)
@@ -452,11 +503,11 @@ defmodule Ecto.Adapters.SQL do
         do_rollback(repo, worker, opts)
         :erlang.raise(type, term, stacktrace)
     after
-      checkin_worker(pool, timeout)
+      transaction_checkin(pool)
     end
   end
 
-  defp checkout_worker(pool, timeout) do
+  defp transaction_checkout(pool) do
     key = {:ecto_transaction_pid, pool}
 
     case Process.get(key) do
@@ -464,20 +515,18 @@ defmodule Ecto.Adapters.SQL do
         Process.put(key, {worker, counter + 1})
         worker
       nil ->
-        worker = :poolboy.checkout(pool, true, timeout)
-        Worker.link_me(worker, timeout)
+        worker = checkout(pool)
         Process.put(key, {worker, 1})
         worker
     end
   end
 
-  defp checkin_worker(pool, timeout) do
+  defp transaction_checkin(pool) do
     key = {:ecto_transaction_pid, pool}
 
     case Process.get(key) do
       {worker, 1} ->
-        Worker.unlink_me(worker, timeout)
-        :poolboy.checkin(pool, worker)
+        checkin(worker)
         Process.delete(key)
       {worker, counter} ->
         Process.put(key, {worker, counter - 1})

--- a/lib/ecto/adapters/sql/broker.ex
+++ b/lib/ecto/adapters/sql/broker.ex
@@ -1,0 +1,33 @@
+defmodule Ecto.Adapters.SQL.Broker do
+
+  @behaviour :sbroker
+
+  def checkout(broker) do
+    case :sbroker.ask(broker) do
+      {:go, _, worker, _, _} -> worker
+      {:drop, _} = drop      -> exit({drop, {__MODULE__, :checkout, [broker]}})
+    end
+  end
+
+  def checkin(broker, tag) do
+    _ = :sbroker.async_ask_r(broker, tag)
+    :ok
+  end
+
+  def cancel(broker, ref) do
+    :sbroker.cancel(broker, ref)
+  end
+
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    :sbroker.start_link({:local, name}, __MODULE__, opts)
+  end
+
+  def init(opts) do
+    client_queue = Keyword.fetch!(opts, :client_queue)
+    worker_queue = Keyword.fetch!(opts, :worker_queue)
+    queue_interval = Keyword.fetch!(opts, :queue_interval)
+
+    {:ok, {client_queue, worker_queue, queue_interval}}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -27,11 +27,11 @@ defmodule Ecto.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :decimal, :poolboy]]
+    [applications: [:logger, :decimal, :sbroker]]
   end
 
   defp deps do
-    [{:poolboy, "~> 1.4"},
+    [{:sbroker, "~> 0.6.2"},
      {:decimal, "~> 1.0"},
      {:postgrex, "~> 0.8.0", optional: true},
      {:mariaex, "~> 0.1.0", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -4,5 +4,5 @@
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
   "mariaex": {:hex, :mariaex, "0.1.0"},
   "poison": {:hex, :poison, "1.3.1"},
-  "poolboy": {:hex, :poolboy, "1.4.2"},
-  "postgrex": {:hex, :postgrex, "0.8.0"}}
+  "postgrex": {:hex, :postgrex, "0.8.0"},
+  "sbroker": {:hex, :sbroker, "0.6.2"}}


### PR DESCRIPTION
I started a port from `poolboy` to `sbroker` using a version of `sbroker` targeted at OTP 18.0-rc1. This means that performance will likely be night and day between  OTP 17.* and 18.* (unless using an embedded release with smp disabled).

`poolboy` is really, really good at what it is designed for: it's easy to use, simple and fast. However simplicity and ease of use has a price.

Firstly `poolboy` does not require any worker code and so a worker can not provide back pressure to `poolboy`. Therefore `poolboy` assumes that a worker is always ready to handle a request when it doesn't have a client. For example if a database is down the worker might block trying to connect and a client will have to wait patiently for it to try (and fail). Its even possible that a worker is handling a previous request because the previous client exited or timed out before getting its result. This means a client waited for a worker, only to have to wait for the worker to be ready.

Secondly `poolboy` has an unbounded queue which requires a client initiated cancel after a timeout or no queueing. In the former case the queue can grow (if there are more client requests than workers can handle) such that all requests have to wait approximately the timeout before either timing out or getting a worker. In the later case it can be hard to get good utilisation of the pool because a worker may not be ready immediately.

`sbroker` is designed for smart and tunable queuing. It has significantly more lines of code but nearly all of them are for queues. `sbroker` only does dispatch, it does not do pooling/client tracking. This means a worker has to be started separately, a worker has to monitor a client and a worker has to notify the `sbroker` when it is ready for a request. These are easy problems in OTP but `sbroker` solves the harder problems that `poolboy` doesn't.

Firstly `sbroker` requires a worker to say when its ready, which means that once a client gets a worker it should never be queued at the worker.

Secondly `sbroker` handles time outs and other methods of dropping of client requests with a selection of algorithms (that can be combined together). In particular it has a CoDel (http://en.wikipedia.org/wiki/CoDel) implementation, which drops a client request with decreasing intervals when the queue is slow. The alogirthm allows bursts and tries to only drop requests it needs to. It also has support for bounded queues and timeout (like `poolboy`) based dropping.

An example benchmark showing blox (https://github.com/drewolson/blox/tree/perf_testing) at a slight overload is here: https://gist.github.com/fishcakez/f9b37dcb06859c38ab5b. `ecto-0.10.2` is with poolboy, `ecto-0.10.2-patch1` is with `sbroker` using the same queuing strategy as `poolboy`. `ecto-0.10.2-patch2` is with `sbroker` using CoDel with its default parameters.

The improvement in `patch1` is due to removing two synchronous calls a client makes to a worker per request. This is possible because of how a worker interacts with `sbroker`. It might be possible to improve the current situation slightly.

The improvement in `patch2` is due to CoDel dropping a small number of requests (~0.3%), which ends up improving the latency greatly. With CoDel requests are only dropped after having waited at least a certain amount of time and the queue having been slow for a minimum amount of time. It is possible to tune `sbroker` to improve latencies (especially the higher percentiles) at the price of dropping more requests.