### PR TITLE
Fix put_change/3, put_new_change/3 and change/2 and add force_change/3

### DIFF
--- a/lib/ecto/model/optimistic_lock.ex
+++ b/lib/ecto/model/optimistic_lock.ex
@@ -117,6 +117,6 @@ defmodule Ecto.Model.OptimisticLock do
   def __lock__(%Ecto.Changeset{model: model} = changeset, field) do
     current = Map.fetch!(model, field)
     update_in(changeset.filters, &Map.put(&1, field, current))
-    |> put_change(field, current + 1)
+    |> force_change(field, current + 1)
   end
 end

--- a/lib/ecto/model/timestamps.ex
+++ b/lib/ecto/model/timestamps.ex
@@ -23,7 +23,7 @@ defmodule Ecto.Model.Timestamps do
     if get_change changeset, field do
       changeset
     else
-      put_change changeset, field, Ecto.Type.load!(type, timestamp_tuple(use_usec))
+      force_change changeset, field, Ecto.Type.load!(type, timestamp_tuple(use_usec))
     end
   end
 


### PR DESCRIPTION
The first three methods should not add a change to the list of changes if the changed value is the same as in the model. The latter add the change even if the model has the same value.

Closes #582 