### PR TITLE
Support null: false columns with a default.

### DIFF
--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -4,7 +4,7 @@ defmodule Ecto.Integration.Migration do
   def change do
     create table(:posts) do
       add :title, :string, size: 100
-      add :counter, :integer, default: 10
+      add :counter, :integer, null: false, default: 10
       add :text, :binary
       add :uuid, :uuid
       add :public, :boolean

--- a/lib/ecto/repo/model.ex
+++ b/lib/ecto/repo/model.ex
@@ -153,14 +153,11 @@ defmodule Ecto.Repo.Model do
 
   defp merge_into_changeset(struct, fields, changeset) do
     # Get only the database fields from the struct
-    changes = Map.take(struct, fields)
-
-    # Remove nil primary key fields from changes
+    # and remove nil fields from changes.
     changes =
-      Enum.reduce Ecto.Model.primary_key(struct), changes, fn
-        {k, nil}, acc -> Map.delete(acc, k)
-        _, acc -> acc
-      end
+      Map.take(struct, fields)
+      |> Enum.reject(fn {_, v} -> v == nil end)
+      |> Enum.into(%{})
 
     update_in changeset.changes, &Map.merge(changes, &1)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Ecto.Mixfile do
     [{:poolboy, "~> 1.4"},
      {:decimal, "~> 1.0"},
      {:postgrex, "~> 0.8.0", optional: true},
-     {:mariaex, "~> 0.1.0", optional: true},
+     {:mariaex, "~> 0.1.4", optional: true},
      {:ex_doc, "~> 0.7", only: :docs},
      {:earmark, "~> 0.1", only: :docs},
      {:inch_ex, only: :docs}]

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "earmark": {:hex, :earmark, "0.1.13"},
   "ex_doc": {:hex, :ex_doc, "0.7.2"},
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
-  "mariaex": {:hex, :mariaex, "0.1.0"},
+  "mariaex": {:hex, :mariaex, "0.1.4"},
   "poison": {:hex, :poison, "1.3.1"},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.8.0"}}


### PR DESCRIPTION
I don't mean to be a pest, but #591 is still an issue in master for me. I'm opening a new PR with some failing tests this time, and hopefully a better error report.

Consider this model:
```elixir
create table(:clients, primary_key: false) do
  add :id, :uuid, primary_key: true, default: fragment("uuid_generate_v4()")
  add :name, :string, null: false
  add :url, :string, null: false
  add :secret, :uuid, null: false, default: fragment("uuid_generate_v4()")
  timestamps
end
```
```elixir
schema "clients"  do
  field :name, :string
  field :url, :string
  field :secret, Ecto.UUID, read_after_writes: true
  timestamps
end
```

When specifying both null: false and a default value, you are effectively prevented from using the database default at all:

```elixir
changeset = Client.changeset(%Client{}, %{name: "local", url: "http://localhost:4200"})
Repo.insert(changeset)
# => ** (Postgrex.Error) ERROR (not_null_violation): null value in column "secret" violates not-null constraint
```

I had the impression that #591 was about defaults, but my context was wrong. This appears to only be an issue when columns have both a default and a null: false.

