### PR TITLE
[WIP] Control transactions from client process

### DIFF
--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -1,6 +1,8 @@
 Logger.configure(level: :info)
 ExUnit.start exclude: [:array_type, :read_after_writes, :case_sensitive, :uses_usec]
 
+Code.require_file "../support/repo.exs", __DIR__
+
 # Basic test repo
 alias Ecto.Integration.TestRepo
 
@@ -11,7 +13,7 @@ Application.put_env(:ecto, TestRepo,
   max_overflow: 0)
 
 defmodule Ecto.Integration.TestRepo do
-  use Ecto.Repo, otp_app: :ecto
+  use Ecto.Integration.Repo, otp_app: :ecto
 end
 
 # Pool repo for transaction and lock tests
@@ -23,7 +25,7 @@ Application.put_env(:ecto, PoolRepo,
   size: 10)
 
 defmodule Ecto.Integration.PoolRepo do
-  use Ecto.Repo, otp_app: :ecto
+  use Ecto.Integration.Repo, otp_app: :ecto
 end
 
 defmodule Ecto.Integration.Case do

--- a/integration_test/pg/deadlock_test.exs
+++ b/integration_test/pg/deadlock_test.exs
@@ -92,8 +92,7 @@ defmodule Ecto.Integration.DeadlockTest do
 
         # At this time the transaction count is actually 0 not 1 because Postgres
         # has killed the tx but Ecto doesn't know/care.
-        {aborted_worker, _} = Process.get({:ecto_transaction_pid, elem(PoolRepo.__pool__, 0)})
-        %{transactions: 1}  = :sys.get_state(aborted_worker)
+        %{transactions: [:transaction], depth: 1} = Process.get({:ecto_transaction_info, elem(PoolRepo.__pool__, 0)})
 
         assert_tx_aborted
 

--- a/integration_test/pg/pg_transaction.ex
+++ b/integration_test/pg/pg_transaction.ex
@@ -1,0 +1,40 @@
+defmodule Ecto.Integration.PGTransactionTest do
+  use ExUnit.Case
+
+  import Ecto.Query
+  require Ecto.Integration.PoolRepo, as: PoolRepo
+
+  setup do
+    PoolRepo.delete_all "transactions"
+    :ok
+  end
+
+  defmodule PGTrans do
+    use Ecto.Model
+
+    schema "transactions" do
+      field :text, :string
+    end
+  end
+
+  test "nested transaction begin raises and does not rollback to savepoint with same name" do
+    PoolRepo.transaction(fn ->
+      PoolRepo.transaction(fn ->
+        PoolRepo.insert(%PGTrans{text: "pg_1"})
+      end)
+      try do
+        Ecto.Adapters.SQL.query(PoolRepo, "UPDATE transactions SET error = error + 1", [])
+      rescue
+        _ ->
+          :ok
+      end
+      try do
+        PoolRepo.transaction(fn -> flunk "begin did not raise" end)
+      rescue
+        _ ->
+          :ok
+      end
+    end)
+    assert [%PGTrans{text: "pg_1"}] = PoolRepo.all(PGTrans)
+  end
+end

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -1,6 +1,8 @@
 Logger.configure(level: :info)
 ExUnit.start
 
+Code.require_file "../support/repo.exs", __DIR__
+
 # Basic test repo
 alias Ecto.Integration.TestRepo
 
@@ -11,7 +13,7 @@ Application.put_env(:ecto, TestRepo,
   max_overflow: 0)
 
 defmodule Ecto.Integration.TestRepo do
-  use Ecto.Repo, otp_app: :ecto
+  use Ecto.Integration.Repo, otp_app: :ecto
 end
 
 # Pool repo for transaction and lock tests
@@ -23,7 +25,7 @@ Application.put_env(:ecto, PoolRepo,
   size: 10)
 
 defmodule Ecto.Integration.PoolRepo do
-  use Ecto.Repo, otp_app: :ecto
+  use Ecto.Integration.Repo, otp_app: :ecto
 
   def lock_for_update, do: "FOR UPDATE"
 end

--- a/integration_test/support/repo.exs
+++ b/integration_test/support/repo.exs
@@ -1,0 +1,15 @@
+defmodule Ecto.Integration.Repo do
+  defmacro __using__(opts) do
+    quote do
+      use Ecto.Repo, unquote(opts)
+        def log(cmd, fun) do
+        before_log = Process.delete(:before_log) || fn -> :ok end
+        before_log.()
+        res = super(cmd, fun)
+        after_log = Process.delete(:after_log) || fn -> :ok end
+        after_log.()
+        res
+      end
+    end
+  end
+end

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -204,8 +204,8 @@ defmodule Ecto.Adapters.SQL do
   end
 
   defp disconnect(key, info, timeout) do
-    info = %{info | conn: nil}
-    _ = Process.put(key, info)
+    new_info = %{info | conn: nil}
+    _ = Process.put(key, new_info)
     done_and_disconnect(info, timeout)
   end
 

--- a/lib/ecto/adapters/sql/worker.ex
+++ b/lib/ecto/adapters/sql/worker.ex
@@ -69,10 +69,7 @@ defmodule Ecto.Adapters.SQL.Worker do
     {:reply, :ok, s}
   end
 
-  def handle_call(:ask, from, %{client: nil, sandbox: false, transactions: []} = s) do
-    handle_ask(from, s)
-  end
-  def handle_call(:ask, from, %{client: nil, sandbox: true, transactions: [sandbox: _]} = s) do
+  def handle_call(:ask, from, %{client: nil} = s) do
     handle_ask(from, s)
   end
 

--- a/lib/ecto/adapters/sql/worker.ex
+++ b/lib/ecto/adapters/sql/worker.ex
@@ -10,55 +10,36 @@ defmodule Ecto.Adapters.SQL.Worker do
     GenServer.start(__MODULE__, {module, args})
   end
 
-  def link_me(worker, timeout) do
-    GenServer.call(worker, :link_me, timeout)
+  def ask(worker, timeout) do
+    GenServer.call(worker, :ask, timeout)
   end
 
-  def unlink_me(worker, timeout) do
-    GenServer.call(worker, :unlink_me, timeout)
+  def cancel(worker, timeout) do
+    GenServer.call(worker, :cancel, timeout)
   end
 
-  def query!(worker, sql, params, opts) do
-    case GenServer.call(worker, :query, opts[:timeout]) do
-      {:ok, {module, conn}} ->
-        case module.query(conn, sql, params, opts) do
-          {:ok, res} -> res
-          {:error, err} -> raise err
-        end
-      {:error, err} ->
-        raise err
-    end
+  def done(worker, monitor, trans) do
+    GenServer.cast(worker, {:done, monitor, trans})
   end
 
-  def begin!(worker, opts) do
-    call!(worker, {:begin, opts}, opts)
+  def stop(worker, monitor, timeout) do
+    GenServer.call(worker, {:stop, monitor}, timeout)
   end
 
-  def commit!(worker, opts) do
-    call!(worker, {:commit, opts}, opts)
+  def begin_test_transaction(worker, monitor, trans, opts) do
+    call(worker, {:begin_test_transaction, monitor, trans, opts}, opts)
   end
 
-  def rollback!(worker, opts) do
-    call!(worker, {:rollback, opts}, opts)
+  def restart_test_transaction(worker, monitor, trans, opts) do
+    call(worker, {:restart_test_transaction, monitor, trans, opts}, opts)
   end
 
-  def begin_test_transaction!(worker, opts) do
-    call!(worker, {:begin_test_transaction, opts}, opts)
+  def rollback_test_transaction(worker, monitor, trans, opts) do
+    call(worker, {:rollback_test_transaction, monitor, trans, opts}, opts)
   end
 
-  def restart_test_transaction!(worker, opts) do
-    call!(worker, {:restart_test_transaction, opts}, opts)
-  end
-
-  def rollback_test_transaction!(worker, opts) do
-    call!(worker, {:rollback_test_transaction, opts}, opts)
-  end
-
-  defp call!(worker, command, opts) do
-    case GenServer.call(worker, command, opts[:timeout]) do
-      :ok -> :ok
-      {:error, err} -> raise err
-    end
+  defp call(worker, command, opts) do
+    GenServer.call(worker, command, opts[:timeout])
   end
 
   ## Callbacks
@@ -76,153 +57,98 @@ defmodule Ecto.Adapters.SQL.Worker do
       end
     end
 
-    {:ok, %{conn: conn, params: params, link: nil,
-            transactions: 0, module: module, sandbox: false}}
+    {:ok, %{conn: conn, params: params, client: nil, monitor: nil,
+            transactions: [], module: module, sandbox: false}}
   end
 
-  # Those functions do not need a connection
-  def handle_call(:link_me, {pid, _}, %{link: nil} = s) do
-    Process.link(pid)
-    {:reply, :ok, %{s | link: pid}}
+  def handle_call(:cancel, {client, _}, %{client: client} = s) do
+    {:reply, :ok, wipe_state(s)}
   end
 
-  def handle_call(:unlink_me, {pid, _}, %{link: pid} = s) do
-    Process.unlink(pid)
-    {:reply, :ok, %{s | link: nil}}
-  end
-
-  # Connection is disconnected, reconnect before continuing
-  def handle_call(request, from, %{conn: nil, params: params, module: module} = s) do
-    case module.connect(params) do
-      {:ok, conn} ->
-        case begin_sandbox(%{s | conn: conn}, params) do
-          {:ok, s}      -> handle_call(request, from, s)
-          {:error, err} -> {:reply, {:error, err}, s}
-        end
-      {:error, err} ->
-        {:reply, {:error, err}, s}
-    end
-  end
-
-  def handle_call(:query, _from, %{conn: conn, module: module} = s) do
-    {:reply, {:ok, {module, conn}}, s}
-  end
-
-  def handle_call({:begin, opts}, _from, s) do
-    %{conn: conn, transactions: trans, module: module} = s
-
-    sql =
-      if trans == 0 do
-        module.begin_transaction
-      else
-        module.savepoint "ecto_#{trans}"
-      end
-
-    # Increase the transaction counter as rollback should be triggered.
-    s = %{s | transactions: trans + 1}
-
-    case module.query(conn, sql, [], opts) do
-      {:ok, _} ->
-        {:reply, :ok, s}
-      {:error, _} = err ->
-        {:reply, err, s}
-    end
-  end
-
-  def handle_call({:commit, opts}, _from, %{transactions: trans} = s) when trans >= 1 do
-    %{conn: conn, module: module} = s
-
-    reply =
-      case trans do
-        1 -> module.query(conn, module.commit, [], opts)
-        _ -> {:ok, %{}}
-      end
-
-    case reply do
-      {:ok, _} ->
-        {:reply, :ok, %{s | transactions: trans - 1}}
-      {:error, _} = err ->
-        # Don't change the transaction counter as rollback should be triggered.
-        {:reply, err, s}
-    end
-  end
-
-  def handle_call({:rollback, opts}, _from, %{transactions: trans} = s) when trans >= 1 do
-    %{conn: conn, module: module} = s
-
-    sql =
-      case trans do
-        1 -> module.rollback
-        _ -> module.rollback_to_savepoint "ecto_#{trans-1}"
-      end
-
-    # Always reduce the transaction counter as the user
-    # will exit the transaction block anyway.
-    s = %{s | transactions: trans - 1}
-
-    case module.query(conn, sql, [], opts) do
-      {:ok, _} ->
-        {:reply, :ok, s}
-      {:error, _} = err when trans == 1 ->
-        # We don't know if we actually rolled back, so it is best
-        # to completely drop the connection.
-        #
-        # In any case, we don't need to worry about the client as
-        # it should not expect any state in the connection anyway.
-        module.disconnect(conn)
-        {:reply, err, %{s | conn: nil}}
-      {:error, _} = err ->
-        {:reply, err, s}
-    end
-  end
-
-  def handle_call({:begin_test_transaction, _opts}, _from, %{sandbox: true} = s) do
+  def handle_call(:cancel, _, s) do
     {:reply, :ok, s}
   end
 
-  def handle_call({:begin_test_transaction, opts}, _from, %{transactions: 0} = s) do
+  def handle_call(:ask, from, %{client: nil, sandbox: false, transactions: []} = s) do
+    handle_ask(from, s)
+  end
+  def handle_call(:ask, from, %{client: nil, sandbox: true, transactions: [sandbox: _]} = s) do
+    handle_ask(from, s)
+  end
+
+  def handle_call(:ask, from, %{client: client} = s) do
+    # Technically it is possible for poolboy to receive a :DOWN, assign a new
+    # client and that client to call ask without the worker being sent a :DOWN.
+    # If is_alive?/1 returns true then poolboy can not have been sent a :DOWN
+    # and there is a bug.
+    if Process.is_alive?(client) do
+      {:stop, :busy_ask, s}
+    else
+      handle_call(:ask, from, wipe_state(s))
+    end
+  end
+
+  def handle_call({:stop, monitor}, _, %{monitor: monitor} = s) do
+    {:reply, :ok, wipe_state(s)}
+  end
+
+  def handle_call({:begin_test_transaction, monitor, [sandbox: _] = trans, _}, _from,
+  %{monitor: monitor, transactions: trans, sandbox: true} = s) do
+    {:reply, {:ok, trans}, s}
+  end
+
+  def handle_call({:begin_test_transaction, monitor, [], opts}, _from,
+  %{monitor: monitor, transactions: []} = s) do
     case begin_sandbox(%{s | sandbox: true}, opts) do
-      {:ok, s}      -> {:reply, :ok, s}
-      {:error, err} -> {:reply, {:error, err}, s}
+      {:ok, %{transactions: trans} = s} -> {:reply, {:ok, trans}, s}
+      {:error, err}                     -> {:reply, {:error, err}, s}
     end
   end
 
-  def handle_call({:restart_test_transaction, _opts}, _from, %{sandbox: false} = s) do
-    {:reply, :ok, s}
+  def handle_call({:restart_test_transaction, monitor, [], _opts}, _from,
+  %{monitor: monitor, transactions: []} = s) do
+    {:reply, {:ok, []}, s}
   end
 
-  def handle_call({:restart_test_transaction, opts}, _from, %{transactions: 1} = s) do
+  def handle_call({:restart_test_transaction, monitor, [sandbox: savepoint] = trans, opts}, _from,
+  %{monitor: monitor, transactions: trans} = s) do
     %{conn: conn, module: module} = s
 
-    case module.query(conn, module.rollback_to_savepoint("ecto_sandbox"), [], opts) do
-      {:ok, _} -> {:reply, :ok, s}
+    case module.query(conn, module.rollback_to_savepoint(savepoint), [], opts) do
+      {:ok, _} -> {:reply, {:ok, trans}, s}
       {:error, _} = err -> {:reply, err, s}
     end
   end
 
-  def handle_call({:rollback_test_transaction, _opts}, _from, %{sandbox: false} = s) do
-    {:reply, :ok, s}
+  def handle_call({:rollback_test_transaction, monitor, [], _opts}, _from,
+  %{monitor: monitor, transactions: []} = s) do
+    {:reply, {:ok, []}, s}
   end
 
-  def handle_call({:rollback_test_transaction, opts}, _from, %{transactions: 1} = s) do
+  def handle_call({:rollback_test_transaction, monitor, [sandbox: _] = trans, opts}, _from,
+  %{monitor: monitor, transactions: trans} = s) do
     %{conn: conn, module: module} = s
 
     case module.query(conn, module.rollback, [], opts) do
       {:ok, _} ->
-        {:reply, :ok, %{s | transactions: 0, sandbox: false}}
+        {:reply, {:ok, []}, %{s | transactions: [], sandbox: false}}
       {:error, _} = err ->
         {:reply, err, s}
     end
   end
 
-  # The connection crashed, notify all linked process.
-  def handle_info({:EXIT, conn, _reason}, %{conn: conn} = s) do
-    wipe_state(%{s | conn: nil})
+  def handle_cast({:done, monitor, trans}, %{monitor: monitor, transactions: trans} = s) do
+    Process.demonitor(monitor, [:flush])
+    {:noreply, %{s | client: nil, monitor: nil}}
   end
 
-  # If a linked process crashed, assume stale connection and close it.
-  def handle_info({:EXIT, link, _reason}, %{link: link} = s) do
-    wipe_state(s)
+  def handle_info({:EXIT, conn, _reason}, %{conn: conn} = s) do
+    {:noreply, %{s | conn: nil}}
+  end
+
+  def handle_info({:DOWN, monitor, _, _, _}, %{monitor: monitor} = s)
+  when is_reference(monitor) do
+    {:noreply, wipe_state(s)}
   end
 
   def handle_info(_info, s) do
@@ -241,8 +167,10 @@ defmodule Ecto.Adapters.SQL.Worker do
 
     case module.query(conn, module.begin_transaction, [], opts) do
       {:ok, _} ->
-        case module.query(conn, module.savepoint("ecto_sandbox"), [], opts) do
-          {:ok, _}          -> {:ok, %{s | transactions: 1}}
+        savepoint = "ecto_sandbox"
+        case module.query(conn, module.savepoint(savepoint), [], opts) do
+          {:ok, _} ->
+            {:ok, %{s | transactions: [sandbox: savepoint]}}
           {:error, _} = err -> err
         end
       {:error, _} = err ->
@@ -250,43 +178,28 @@ defmodule Ecto.Adapters.SQL.Worker do
     end
   end
 
-  # Imagine the following scenario:
-  #
-  #   1. PID starts a transaction
-  #   2. PID sends a query
-  #   3. The connection crashes (and we receive an EXIT message)
-  #
-  # If 2 and 3 happen at the same, there is no guarantee which
-  # one will be handled first. That's why we can't simply kill
-  # the linked processes and start a new connection as we may
-  # have left-over messages in the inbox.
-  #
-  # So this is what we do:
-  #
-  #   1. We disconnect from the database
-  #   2. We kill the linked processes (transaction owner)
-  #   3. We remove all calls from that process
-  #
-  # Because this worker only accept calls and it is controlled by
-  # the pool, the expectation is that the number of messages to
-  # be removed will always be maximum 1.
-  defp wipe_state(%{conn: conn, module: module, link: link} = s) do
-    conn && module.disconnect(conn)
-
-    if link do
-      Process.unlink(link)
-      Process.exit(link, {:ecto, :no_connection})
-      clear_calls(link)
+  defp handle_ask(from, %{conn: nil, params: params, module: module} = s) do
+    case module.connect(params) do
+      {:ok, conn} ->
+        case begin_sandbox(%{s | conn: conn}, params) do
+          {:ok, s}      -> handle_ask(from, s)
+          {:error, err} -> {:reply, {:error, err}, s}
+        end
+      {:error, err} ->
+        {:reply, {:error, err}, s}
     end
-
-    {:noreply, %{s | conn: nil, link: nil, transactions: 0}}
+  end
+  defp handle_ask({pid, _}, %{module: module, conn: conn, transactions: trans} =s) do
+    monitor = Process.monitor(pid)
+    reply = {:ok, {module, conn, monitor, trans}}
+    {:reply, reply, %{s | client: pid, monitor: monitor}}
   end
 
-  defp clear_calls(link) do
-    receive do
-      {:"$gen_call", {^link, _}, _} -> clear_calls(link)
-    after
-      0 -> :ok
-    end
+  defp wipe_state(%{conn: conn, module: module, monitor: monitor} = s) do
+    conn && module.disconnect(conn)
+
+    if monitor, do: Process.demonitor(monitor, [:flush])
+
+    %{s | conn: nil, client: nil, monitor: nil, transactions: []}
   end
 end


### PR DESCRIPTION
Resolves #585, #611.

This branch takes a different approach to I suggested in #585 and keeps the transaction state in the client, instead of in the connection processes - on master the state is kept in the worker. Keeping the state in the connection process created significant complexity for the different drivers (postgrex, mariaex etc) and was starting to result in too many lines of code.

This implementation requires heavy use of the process dictionary, which makes logic hard to follow. I will need to add quite a few transaction tests and I would like to check the approach is ok before continuing.