### PR TITLE
Use poolboy's name instead of pid in transaction key

### DIFF
--- a/integration_test/pg/deadlock_test.exs
+++ b/integration_test/pg/deadlock_test.exs
@@ -92,7 +92,7 @@ defmodule Ecto.Integration.DeadlockTest do
 
         # At this time the transaction count is actually 0 not 1 because Postgres
         # has killed the tx but Ecto doesn't know/care.
-        {aborted_worker, _} = Process.get({:ecto_transaction_pid, Process.whereis(elem(PoolRepo.__pool__, 0))})
+        {aborted_worker, _} = Process.get({:ecto_transaction_pid, elem(PoolRepo.__pool__, 0)})
         %{transactions: 1}  = :sys.get_state(aborted_worker)
 
         assert_tx_aborted


### PR DESCRIPTION
It is possible for poolboy's pid to change if it crashes or is restarted. Previously this could lead to the following race condition:

* client traps exits
* client looks up pid, checks out a worker and starts a transaction
* poolboy is restarted
* client does not handle exit signal as mid transaction
* client looks up new pid, key has changed and so checks out new worker

Doing `Process.whereis/1`, `Process.is_alive?/1` and then `GenServer.call/2,3` is an anti-pattern. The process could be alive at the check but dead at the call. It is also very defensive programming. It should be more natural to use `try do` when failure is an exceptional circumstance.

This patch is also more efficient as it does not lookup and check the poolboy process is alive everytime the worker is used. I am not sure how cheap or expensive `Process.is_alive?/1` is however avoiding the call is better either way.