### PR TITLE
Ecto.UUID.load should accept a valid uuid string.

### DIFF
--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -21,7 +21,7 @@ defmodule Ecto.UUID do
   def cast(_), do: :error
 
   @doc """
-  Converts an string representing a UUID into a binary.
+  Converts a string representing a UUID into a binary.
   """
   def dump(<< u0::64, ?-, u1::32, ?-, u2::32, ?-, u3::32, ?-, u4::96 >>) do
     case Base.decode16(<< u0::64, u1::32, u2::32, u3::32, u4::96 >>, case: :mixed) do
@@ -37,6 +37,7 @@ defmodule Ecto.UUID do
   def load(uuid = << _::128 >>) do
    {:ok, encode(uuid)}
   end
+  def load(<< _::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96 >> = u), do: {:ok, u}
   def load(_), do: :error
 
   @doc """

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -12,7 +12,8 @@ defmodule Ecto.UUIDTest do
 
   test "load" do
     assert Ecto.UUID.load(@test_uuid_binary) == {:ok, @test_uuid}
-    assert Ecto.UUID.load(@test_uuid) == :error
+    assert Ecto.UUID.load(@test_uuid) == {:ok, @test_uuid}
+    assert Ecto.UUID.load(nil) == :error
   end
 
   test "dump" do


### PR DESCRIPTION
Hi! I just found what I think is a bug.

migration:
```elixir
create table(:clients) do
  add :secret,  :string,  null: false, default: fragment("uuid_generate_v4()")
end
```
model:
```elixir
schema "clients" do
  field :secret,  Ecto.UUID, read_after_writes: true
end
before_insert :delete_change, [:secret]
```
Failing script:
```elixir
Repo.insert(%Client{})
# => ** (ArgumentError) cannot load `"5c43eb56-35d6-4eae-adb8-db289befdfe8"` as type Ecto.UUID  
```

So, the database is generating a valid UUID and returning it, but Ecto.UUID doesn't know how to load it.

This seemed like a simple enough thing to fix, so the PR is attached.

Additional backstory on this here: https://github.com/elixir-lang/ecto/pull/592#issuecomment-104573693
