### PR TITLE
Add join-based tags for some integration tests

### DIFF
--- a/integration_test/cases/preload.exs
+++ b/integration_test/cases/preload.exs
@@ -306,6 +306,7 @@ defmodule Ecto.Integration.PreloadTest do
     assert [] = p3.comments
   end
 
+  @tag :right_join
   test "preload keyword query with missing entries" do
     %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
     %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -326,6 +326,7 @@ defmodule Ecto.Integration.RepoTest do
     assert %Post{title: "y"} = TestRepo.get(Post, id3)
   end
 
+  @tag :update_with_join
   test "update all with joins" do
     user = TestRepo.insert(%User{name: "Tester"})
     post = TestRepo.insert(%Post{title: "foo"})
@@ -418,6 +419,7 @@ defmodule Ecto.Integration.RepoTest do
     assert [%Post{}] = TestRepo.all(Post)
   end
 
+  @tag :delete_with_join
   test "delete all with joins" do
     user = TestRepo.insert(%User{name: "Tester"})
     post = TestRepo.insert(%Post{title: "foo"})


### PR DESCRIPTION
SQLite does not support right outer joins or any joins in update and delete queries.