### PR TITLE
Add piped example of validate_confirmation

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -966,6 +966,9 @@ defmodule Ecto.Changeset do
       validate_confirmation(changeset, :email)
       validate_confirmation(changeset, :password, message: "passwords do not match")
 
+      cast(params, model, ~w(password), ~w())
+      |> validate_confirmation(:password, message: "passwords do not match")  
+
   """
   @spec validate_confirmation(t, atom, Enum.t) :: t
   def validate_confirmation(changeset, field, opts \\ []) do


### PR DESCRIPTION
I added an example of how validate_confirmation would look like being piped from cast. This may be pretty obvious that this is possible for more experience elixir developers, but it took me quite a while to figure out that could do it this way and use it in my changeset function.

