### PR TITLE
Tidy integration tests to support mongo adapter

### DIFF
--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -1,0 +1,333 @@
+defmodule Ecto.Integration.JoinsTest do
+  use Ecto.Integration.Case
+
+  require Ecto.Integration.TestRepo, as: TestRepo
+  import Ecto.Query
+
+  alias Ecto.Integration.Post
+  alias Ecto.Integration.PostUsecTimestamps
+  alias Ecto.Integration.Comment
+  alias Ecto.Integration.Permalink
+  alias Ecto.Integration.User
+  alias Ecto.Integration.Custom
+  alias Ecto.Integration.Barebone
+  alias Ecto.Schema.Metadata
+
+  @tag :update_with_join
+  test "update all with joins" do
+    user = TestRepo.insert(%User{name: "Tester"})
+    post = TestRepo.insert(%Post{title: "foo"})
+    comment = TestRepo.insert(%Comment{text: "hey", author_id: user.id, post_id: post.id})
+
+    query = from(c in Comment, join: u in User, on: u.id == c.author_id, where: c.post_id in ^[post.id])
+    assert 1 = TestRepo.update_all(query, text: "hoo")
+
+    assert %Comment{text: "hoo"} = TestRepo.get(Comment, comment.id)
+  end
+
+  @tag :delete_with_join
+  test "delete all with joins" do
+    user = TestRepo.insert(%User{name: "Tester"})
+    post = TestRepo.insert(%Post{title: "foo"})
+    TestRepo.insert(%Comment{text: "hey", author_id: user.id, post_id: post.id})
+    TestRepo.insert(%Comment{text: "foo", author_id: user.id, post_id: post.id})
+    TestRepo.insert(%Comment{text: "bar", author_id: user.id})
+
+    query = from(c in Comment, join: u in User, on: u.id == c.author_id, where: c.post_id in ^[post.id])
+    assert 2 = TestRepo.delete_all(query)
+
+    assert [%Comment{}] = TestRepo.all(Comment)
+  end
+
+  test "joins" do
+    p1 = TestRepo.insert(%Post{title: "1"})
+    p2 = TestRepo.insert(%Post{title: "2"})
+    c1 = TestRepo.insert(%Permalink{url: "1", post_id: p2.id})
+
+    query = from(p in Post, join: c in assoc(p, :permalink), order_by: p.id, select: {p, c})
+    assert [{^p2, ^c1}] = TestRepo.all(query)
+
+    query = from(p in Post, left_join: c in assoc(p, :permalink), order_by: p.id, select: {p, c})
+    assert [{^p1, nil}, {^p2, ^c1}] = TestRepo.all(query)
+  end
+
+  test "has_many association join" do
+    post = TestRepo.insert(%Post{title: "1", text: "hi"})
+    c1 = TestRepo.insert(%Comment{text: "hey", post_id: post.id})
+    c2 = TestRepo.insert(%Comment{text: "heya", post_id: post.id})
+
+    query = from(p in Post, join: c in assoc(p, :comments), select: {p, c}, order_by: p.id)
+    [{^post, ^c1}, {^post, ^c2}] = TestRepo.all(query)
+  end
+
+  test "has_one association join" do
+    post = TestRepo.insert(%Post{title: "1", text: "hi"})
+    p1 = TestRepo.insert(%Permalink{url: "hey", post_id: post.id})
+    p2 = TestRepo.insert(%Permalink{url: "heya", post_id: post.id})
+
+    query = from(p in Post, join: c in assoc(p, :permalink), select: {p, c}, order_by: c.id)
+    [{^post, ^p1}, {^post, ^p2}] = TestRepo.all(query)
+  end
+
+  test "belongs_to association join" do
+    post = TestRepo.insert(%Post{title: "1"})
+    p1 = TestRepo.insert(%Permalink{url: "hey", post_id: post.id})
+    p2 = TestRepo.insert(%Permalink{url: "heya", post_id: post.id})
+
+    query = from(p in Permalink, join: c in assoc(p, :post), select: {p, c}, order_by: p.id)
+    [{^p1, ^post}, {^p2, ^post}] = TestRepo.all(query)
+  end
+
+  test "has_many through assoc" do
+    %Post{id: pid1} = p1 = TestRepo.insert(%Post{})
+    %Post{id: pid2} = p2 = TestRepo.insert(%Post{})
+
+    %User{id: uid1} = TestRepo.insert(%User{name: "zzz"})
+    %User{id: uid2} = TestRepo.insert(%User{name: "aaa"})
+
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid2})
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid2, author_id: uid2})
+
+    [u2, u1] = TestRepo.all Ecto.Model.assoc([p1, p2], :comments_authors)
+                            |> order_by([a], a.name)
+    assert u1.id == uid1
+    assert u2.id == uid2
+  end
+
+  ## Preload
+
+  @tag :right_join
+  test "preload keyword query with missing entries" do
+    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
+    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
+
+    %Permalink{id: plid1} = TestRepo.insert(%Permalink{url: "1", post_id: pid2})
+
+    %Comment{id: _} = TestRepo.insert(%Comment{text: "1", post_id: pid1})
+    %Comment{id: _} = TestRepo.insert(%Comment{text: "2", post_id: pid2})
+    %Comment{id: _} = TestRepo.insert(%Comment{text: "3", post_id: nil})
+
+    query = from(p in Post, right_join: c in assoc(p, :comments),
+                 preload: :permalink, order_by: c.id)
+    assert [p1, p2, nil] = TestRepo.all(query)
+    assert p1.id == pid1
+    assert p2.id == pid2
+
+    assert p1.permalink == nil
+    assert p2.permalink.id == plid1
+  end
+
+  ## Preload assocs
+
+  test "has_many assoc selector" do
+    p1 = TestRepo.insert(%Post{title: "1"})
+    p2 = TestRepo.insert(%Post{title: "1"})
+
+    %Comment{id: cid1} = TestRepo.insert(%Comment{text: "1", post_id: p1.id})
+    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: p1.id})
+    %Comment{id: cid3} = TestRepo.insert(%Comment{text: "3", post_id: p2.id})
+
+    query = from(p in Post, join: c in assoc(p, :comments), preload: [comments: c])
+    assert [post1, post2] = TestRepo.all(query)
+    assert [%Comment{id: ^cid1}, %Comment{id: ^cid2}] = post1.comments
+    assert [%Comment{id: ^cid3}] = post2.comments
+  end
+
+  test "has_one assoc selector" do
+    p1 = TestRepo.insert(%Post{title: "1"})
+    p2 = TestRepo.insert(%Post{title: "2"})
+
+    %Permalink{id: pid1} = TestRepo.insert(%Permalink{url: "1", post_id: p1.id})
+    %Permalink{}         = TestRepo.insert(%Permalink{url: "2"})
+    %Permalink{id: pid3} = TestRepo.insert(%Permalink{url: "3", post_id: p2.id})
+
+    query = from(p in Post, join: pl in assoc(p, :permalink), preload: [permalink: pl])
+    assert [post1, post3] = TestRepo.all(query)
+
+    assert %Permalink{id: ^pid1} = post1.permalink
+    assert %Permalink{id: ^pid3} = post3.permalink
+  end
+
+  test "belongs_to assoc selector" do
+    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
+    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
+
+    TestRepo.insert(%Permalink{url: "1", post_id: pid1})
+    TestRepo.insert(%Permalink{url: "2"})
+    TestRepo.insert(%Permalink{url: "3", post_id: pid2})
+
+    query = from(pl in Permalink, left_join: p in assoc(pl, :post), preload: [post: p], order_by: pl.id)
+    assert [p1, p2, p3] = TestRepo.all(query)
+
+    assert %Post{id: ^pid1} = p1.post
+    assert nil = p2.post
+    assert %Post{id: ^pid2} = p3.post
+  end
+
+  test "has_many through assoc selector" do
+    %Post{id: pid1} = TestRepo.insert(%Post{})
+    %Post{id: pid2} = TestRepo.insert(%Post{})
+
+    %User{id: uid1} = TestRepo.insert(%User{})
+    %User{id: uid2} = TestRepo.insert(%User{})
+
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid2})
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid2, author_id: uid2})
+
+    query = from(p in Post, left_join: ca in assoc(p, :comments_authors),
+                            preload: [comments_authors: ca])
+    [p1, p2] = TestRepo.all(query)
+
+    [u1, u2] = p1.comments_authors
+    assert u1.id == uid1
+    assert u2.id == uid2
+
+    [u2] = p2.comments_authors
+    assert u2.id == uid2
+  end
+
+  test "has_many through-through assoc selector" do
+    %Post{id: pid1} = TestRepo.insert(%Post{})
+    %Post{id: pid2} = TestRepo.insert(%Post{})
+
+    %Permalink{} = TestRepo.insert(%Permalink{post_id: pid1})
+    %Permalink{} = TestRepo.insert(%Permalink{post_id: pid2})
+
+    %User{id: uid1} = TestRepo.insert(%User{})
+    %User{id: uid2} = TestRepo.insert(%User{})
+
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid2})
+    %Comment{} = TestRepo.insert(%Comment{post_id: pid2, author_id: uid2})
+
+    query = from(p in Permalink, left_join: ca in assoc(p, :post_comments_authors),
+                                 preload: [post_comments_authors: ca], order_by: ca.id)
+
+    [l1, l2] = TestRepo.all(query)
+    [u1, u2] = l1.post_comments_authors
+    assert u1.id == uid1
+    assert u2.id == uid2
+
+    [u2] = l2.post_comments_authors
+    assert u2.id == uid2
+
+    # Insert some intermediary joins to check indexes won't be shuffled
+    query = from(p in Permalink,
+                    left_join: assoc(p, :post),
+                    left_join: ca in assoc(p, :post_comments_authors),
+                    left_join: assoc(p, :post),
+                    left_join: assoc(p, :post),
+                    preload: [post_comments_authors: ca], order_by: ca.id)
+
+    [l1, l2] = TestRepo.all(query)
+    [u1, u2] = l1.post_comments_authors
+    assert u1.id == uid1
+    assert u2.id == uid2
+
+    [u2] = l2.post_comments_authors
+    assert u2.id == uid2
+  end
+
+  test "nested assoc" do
+    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
+    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
+
+    %User{id: uid1} = TestRepo.insert(%User{name: "1"})
+    %User{id: uid2} = TestRepo.insert(%User{name: "2"})
+
+    %Comment{id: cid1} = TestRepo.insert(%Comment{text: "1", post_id: pid1, author_id: uid1})
+    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: pid1, author_id: uid2})
+    %Comment{id: cid3} = TestRepo.insert(%Comment{text: "3", post_id: pid2, author_id: uid2})
+
+    query = from p in Post,
+      left_join: c in assoc(p, :comments),
+      left_join: u in assoc(c, :author),
+      order_by: [p.id, c.id, u.id],
+      preload: [comments: {c, author: u}],
+      select: {0, [p], 1, 2}
+
+    posts = TestRepo.all(query)
+    assert [p1, p2] = Enum.map(posts, fn {0, [p], 1, 2} -> p end)
+    assert p1.id == pid1
+    assert p2.id == pid2
+
+    assert [c1, c2] = p1.comments
+    assert [c3] = p2.comments
+    assert c1.id == cid1
+    assert c2.id == cid2
+    assert c3.id == cid3
+
+    assert c1.author.id == uid1
+    assert c2.author.id == uid2
+    assert c3.author.id == uid2
+  end
+
+  test "nested assoc with missing entries" do
+    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
+    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
+    %Post{id: pid3} = TestRepo.insert(%Post{title: "2"})
+
+    %User{id: uid1} = TestRepo.insert(%User{name: "1"})
+    %User{id: uid2} = TestRepo.insert(%User{name: "2"})
+
+    %Comment{id: cid1} = TestRepo.insert(%Comment{text: "1", post_id: pid1, author_id: uid1})
+    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: pid1, author_id: nil})
+    %Comment{id: cid3} = TestRepo.insert(%Comment{text: "3", post_id: pid3, author_id: uid2})
+
+    query = from p in Post,
+      left_join: c in assoc(p, :comments),
+      left_join: u in assoc(c, :author),
+      order_by: [p.id, c.id, u.id],
+      preload: [comments: {c, author: u}]
+
+    assert [p1, p2, p3] = TestRepo.all(query)
+    assert p1.id == pid1
+    assert p2.id == pid2
+    assert p3.id == pid3
+
+    assert [c1, c2] = p1.comments
+    assert [] = p2.comments
+    assert [c3] = p3.comments
+    assert c1.id == cid1
+    assert c2.id == cid2
+    assert c3.id == cid3
+
+    assert c1.author.id == uid1
+    assert c2.author == nil
+    assert c3.author.id == uid2
+  end
+
+  test "assoc with preload" do
+    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
+    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
+
+    %Permalink{id: plid1} = TestRepo.insert(%Permalink{url: "1", post_id: pid2})
+
+    %Comment{id: cid1} = TestRepo.insert(%Comment{text: "1", post_id: pid1})
+    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: pid2})
+    %Comment{id: _}    = TestRepo.insert(%Comment{text: "3", post_id: pid2})
+
+    query = from p in Post,
+      left_join: c in assoc(p, :comments),
+      where: c.text in ~w(1 2),
+      preload: [:permalink, comments: c],
+      select: {0, [p], 1, 2}
+
+    posts = TestRepo.all(query)
+    assert [p1, p2] = Enum.map(posts, fn {0, [p], 1, 2} -> p end)
+    assert p1.id == pid1
+    assert p2.id == pid2
+
+    assert p2.permalink.id == plid1
+
+    assert [c1] = p1.comments
+    assert [c2] = p2.comments
+    assert c1.id == cid1
+    assert c2.id == cid2
+  end
+end

--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -5,13 +5,9 @@ defmodule Ecto.Integration.JoinsTest do
   import Ecto.Query
 
   alias Ecto.Integration.Post
-  alias Ecto.Integration.PostUsecTimestamps
   alias Ecto.Integration.Comment
   alias Ecto.Integration.Permalink
   alias Ecto.Integration.User
-  alias Ecto.Integration.Custom
-  alias Ecto.Integration.Barebone
-  alias Ecto.Schema.Metadata
 
   @tag :update_with_join
   test "update all with joins" do

--- a/integration_test/cases/preload.exs
+++ b/integration_test/cases/preload.exs
@@ -67,85 +67,6 @@ defmodule Ecto.Integration.PreloadTest do
     assert %Post{id: ^pid3} = pl3.post
   end
 
-  test "preload belongs_to with shared assocs" do
-    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
-    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
-
-    c1 = TestRepo.insert(%Comment{text: "1", post_id: pid1})
-    c2 = TestRepo.insert(%Comment{text: "2", post_id: pid1})
-    c3 = TestRepo.insert(%Comment{text: "3", post_id: pid2})
-
-    assert [c3, c1, c2] = TestRepo.preload([c3, c1, c2], :post)
-    assert %Post{id: ^pid1} = c1.post
-    assert %Post{id: ^pid1} = c2.post
-    assert %Post{id: ^pid2} = c3.post
-  end
-
-  test "preload nested" do
-    p1 = TestRepo.insert(%Post{title: "1"})
-    p2 = TestRepo.insert(%Post{title: "2"})
-
-    TestRepo.insert(%Comment{text: "1", post_id: p1.id})
-    TestRepo.insert(%Comment{text: "2", post_id: p1.id})
-    TestRepo.insert(%Comment{text: "3", post_id: p2.id})
-    TestRepo.insert(%Comment{text: "4", post_id: p2.id})
-
-    assert [p2, p1] = TestRepo.preload([p2, p1], [comments: :post])
-    assert [c1, c2] = p1.comments
-    assert [c3, c4] = p2.comments
-    assert p1.id == c1.post.id
-    assert p1.id == c2.post.id
-    assert p2.id == c3.post.id
-    assert p2.id == c4.post.id
-  end
-
-  test "preload has_many with no associated entries" do
-    p = TestRepo.insert(%Post{title: "1"})
-    p = TestRepo.preload(p, :comments)
-
-    assert p.title == "1"
-    assert p.comments == []
-  end
-
-  test "preload has_one with no associated entries" do
-    p = TestRepo.insert(%Post{title: "1"})
-    p = TestRepo.preload(p, :permalink)
-
-    assert p.title == "1"
-    assert p.permalink == nil
-  end
-
-  test "preload belongs_to with no associated entry" do
-    c = TestRepo.insert(%Comment{text: "1"})
-    c = TestRepo.preload(c, :post)
-
-    assert c.text == "1"
-    assert c.post == nil
-  end
-
-  test "preload with binary_id" do
-    c = TestRepo.insert(%Custom{bid: "00010203-0405-0607-0809-0a0b0c0d0e0f"})
-    u = TestRepo.insert(%User{custom_id: c.bid})
-
-    u = TestRepo.preload(u, :custom)
-    assert u.custom.bid == c.bid
-  end
-
-  test "preload skips already loaded" do
-    p1 = TestRepo.insert(%Post{title: "1"})
-    p2 = TestRepo.insert(%Post{title: "2"})
-
-    %Comment{id: _}    = TestRepo.insert(%Comment{text: "1", post_id: p1.id})
-    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: p2.id})
-
-    assert %Ecto.Association.NotLoaded{} = p1.comments
-    p1 = %{p1 | comments: []}
-
-    assert [p1, p2] = TestRepo.preload([p1, p2], :comments)
-    assert [] = p1.comments
-    assert [%Comment{id: ^cid2}] = p2.comments
-  end
-
   test "preload has_many through" do
     %Post{id: pid1} = p1 = TestRepo.insert(%Post{})
     %Post{id: pid2} = p2 = TestRepo.insert(%Post{})
@@ -275,6 +196,84 @@ defmodule Ecto.Integration.PreloadTest do
     assert u2.id == uid2
     assert u2.comments == [c3, c4]
   end
+  test "preload belongs_to with shared assocs" do
+    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
+    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
+
+    c1 = TestRepo.insert(%Comment{text: "1", post_id: pid1})
+    c2 = TestRepo.insert(%Comment{text: "2", post_id: pid1})
+    c3 = TestRepo.insert(%Comment{text: "3", post_id: pid2})
+
+    assert [c3, c1, c2] = TestRepo.preload([c3, c1, c2], :post)
+    assert %Post{id: ^pid1} = c1.post
+    assert %Post{id: ^pid1} = c2.post
+    assert %Post{id: ^pid2} = c3.post
+  end
+
+  test "preload nested" do
+    p1 = TestRepo.insert(%Post{title: "1"})
+    p2 = TestRepo.insert(%Post{title: "2"})
+
+    TestRepo.insert(%Comment{text: "1", post_id: p1.id})
+    TestRepo.insert(%Comment{text: "2", post_id: p1.id})
+    TestRepo.insert(%Comment{text: "3", post_id: p2.id})
+    TestRepo.insert(%Comment{text: "4", post_id: p2.id})
+
+    assert [p2, p1] = TestRepo.preload([p2, p1], [comments: :post])
+    assert [c1, c2] = p1.comments
+    assert [c3, c4] = p2.comments
+    assert p1.id == c1.post.id
+    assert p1.id == c2.post.id
+    assert p2.id == c3.post.id
+    assert p2.id == c4.post.id
+  end
+
+  test "preload has_many with no associated entries" do
+    p = TestRepo.insert(%Post{title: "1"})
+    p = TestRepo.preload(p, :comments)
+
+    assert p.title == "1"
+    assert p.comments == []
+  end
+
+  test "preload has_one with no associated entries" do
+    p = TestRepo.insert(%Post{title: "1"})
+    p = TestRepo.preload(p, :permalink)
+
+    assert p.title == "1"
+    assert p.permalink == nil
+  end
+
+  test "preload belongs_to with no associated entry" do
+    c = TestRepo.insert(%Comment{text: "1"})
+    c = TestRepo.preload(c, :post)
+
+    assert c.text == "1"
+    assert c.post == nil
+  end
+
+  test "preload with binary_id" do
+    c = TestRepo.insert(%Custom{bid: "00010203-0405-0607-0809-0a0b0c0d0e0f"})
+    u = TestRepo.insert(%User{custom_id: c.bid})
+
+    u = TestRepo.preload(u, :custom)
+    assert u.custom.bid == c.bid
+  end
+
+  test "preload skips already loaded" do
+    p1 = TestRepo.insert(%Post{title: "1"})
+    p2 = TestRepo.insert(%Post{title: "2"})
+
+    %Comment{id: _}    = TestRepo.insert(%Comment{text: "1", post_id: p1.id})
+    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: p2.id})
+
+    assert %Ecto.Association.NotLoaded{} = p1.comments
+    p1 = %{p1 | comments: []}
+
+    assert [p1, p2] = TestRepo.preload([p1, p2], :comments)
+    assert [] = p1.comments
+    assert [%Comment{id: ^cid2}] = p2.comments
+  end
 
   test "preload keyword query" do
     p1 = TestRepo.insert(%Post{title: "1"})
@@ -304,238 +303,5 @@ defmodule Ecto.Integration.PreloadTest do
     assert [%Comment{id: ^cid1}, %Comment{id: ^cid2}] = p1.comments
     assert [%Comment{id: ^cid3}, %Comment{id: ^cid4}] = p2.comments
     assert [] = p3.comments
-  end
-
-  @tag :right_join
-  test "preload keyword query with missing entries" do
-    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
-    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
-
-    %Permalink{id: plid1} = TestRepo.insert(%Permalink{url: "1", post_id: pid2})
-
-    %Comment{id: _} = TestRepo.insert(%Comment{text: "1", post_id: pid1})
-    %Comment{id: _} = TestRepo.insert(%Comment{text: "2", post_id: pid2})
-    %Comment{id: _} = TestRepo.insert(%Comment{text: "3", post_id: nil})
-
-    query = from(p in Post, right_join: c in assoc(p, :comments),
-                 preload: :permalink, order_by: c.id)
-    assert [p1, p2, nil] = TestRepo.all(query)
-    assert p1.id == pid1
-    assert p2.id == pid2
-
-    assert p1.permalink == nil
-    assert p2.permalink.id == plid1
-  end
-
-  ## Preload assocs
-
-  test "has_many assoc selector" do
-    p1 = TestRepo.insert(%Post{title: "1"})
-    p2 = TestRepo.insert(%Post{title: "1"})
-
-    %Comment{id: cid1} = TestRepo.insert(%Comment{text: "1", post_id: p1.id})
-    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: p1.id})
-    %Comment{id: cid3} = TestRepo.insert(%Comment{text: "3", post_id: p2.id})
-
-    query = from(p in Post, join: c in assoc(p, :comments), preload: [comments: c])
-    assert [post1, post2] = TestRepo.all(query)
-    assert [%Comment{id: ^cid1}, %Comment{id: ^cid2}] = post1.comments
-    assert [%Comment{id: ^cid3}] = post2.comments
-  end
-
-  test "has_one assoc selector" do
-    p1 = TestRepo.insert(%Post{title: "1"})
-    p2 = TestRepo.insert(%Post{title: "2"})
-
-    %Permalink{id: pid1} = TestRepo.insert(%Permalink{url: "1", post_id: p1.id})
-    %Permalink{}         = TestRepo.insert(%Permalink{url: "2"})
-    %Permalink{id: pid3} = TestRepo.insert(%Permalink{url: "3", post_id: p2.id})
-
-    query = from(p in Post, join: pl in assoc(p, :permalink), preload: [permalink: pl])
-    assert [post1, post3] = TestRepo.all(query)
-
-    assert %Permalink{id: ^pid1} = post1.permalink
-    assert %Permalink{id: ^pid3} = post3.permalink
-  end
-
-  test "belongs_to assoc selector" do
-    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
-    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
-
-    TestRepo.insert(%Permalink{url: "1", post_id: pid1})
-    TestRepo.insert(%Permalink{url: "2"})
-    TestRepo.insert(%Permalink{url: "3", post_id: pid2})
-
-    query = from(pl in Permalink, left_join: p in assoc(pl, :post), preload: [post: p], order_by: pl.id)
-    assert [p1, p2, p3] = TestRepo.all(query)
-
-    assert %Post{id: ^pid1} = p1.post
-    assert nil = p2.post
-    assert %Post{id: ^pid2} = p3.post
-  end
-
-  test "has_many through assoc selector" do
-    %Post{id: pid1} = TestRepo.insert(%Post{})
-    %Post{id: pid2} = TestRepo.insert(%Post{})
-
-    %User{id: uid1} = TestRepo.insert(%User{})
-    %User{id: uid2} = TestRepo.insert(%User{})
-
-    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
-    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
-    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid2})
-    %Comment{} = TestRepo.insert(%Comment{post_id: pid2, author_id: uid2})
-
-    query = from(p in Post, left_join: ca in assoc(p, :comments_authors),
-                            preload: [comments_authors: ca])
-    [p1, p2] = TestRepo.all(query)
-
-    [u1, u2] = p1.comments_authors
-    assert u1.id == uid1
-    assert u2.id == uid2
-
-    [u2] = p2.comments_authors
-    assert u2.id == uid2
-  end
-
-  test "has_many through-through assoc selector" do
-    %Post{id: pid1} = TestRepo.insert(%Post{})
-    %Post{id: pid2} = TestRepo.insert(%Post{})
-
-    %Permalink{} = TestRepo.insert(%Permalink{post_id: pid1})
-    %Permalink{} = TestRepo.insert(%Permalink{post_id: pid2})
-
-    %User{id: uid1} = TestRepo.insert(%User{})
-    %User{id: uid2} = TestRepo.insert(%User{})
-
-    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
-    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid1})
-    %Comment{} = TestRepo.insert(%Comment{post_id: pid1, author_id: uid2})
-    %Comment{} = TestRepo.insert(%Comment{post_id: pid2, author_id: uid2})
-
-    query = from(p in Permalink, left_join: ca in assoc(p, :post_comments_authors),
-                                 preload: [post_comments_authors: ca], order_by: ca.id)
-
-    [l1, l2] = TestRepo.all(query)
-    [u1, u2] = l1.post_comments_authors
-    assert u1.id == uid1
-    assert u2.id == uid2
-
-    [u2] = l2.post_comments_authors
-    assert u2.id == uid2
-
-    # Insert some intermediary joins to check indexes won't be shuffled
-    query = from(p in Permalink,
-                    left_join: assoc(p, :post),
-                    left_join: ca in assoc(p, :post_comments_authors),
-                    left_join: assoc(p, :post),
-                    left_join: assoc(p, :post),
-                    preload: [post_comments_authors: ca], order_by: ca.id)
-
-    [l1, l2] = TestRepo.all(query)
-    [u1, u2] = l1.post_comments_authors
-    assert u1.id == uid1
-    assert u2.id == uid2
-
-    [u2] = l2.post_comments_authors
-    assert u2.id == uid2
-  end
-
-  test "nested assoc" do
-    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
-    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
-
-    %User{id: uid1} = TestRepo.insert(%User{name: "1"})
-    %User{id: uid2} = TestRepo.insert(%User{name: "2"})
-
-    %Comment{id: cid1} = TestRepo.insert(%Comment{text: "1", post_id: pid1, author_id: uid1})
-    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: pid1, author_id: uid2})
-    %Comment{id: cid3} = TestRepo.insert(%Comment{text: "3", post_id: pid2, author_id: uid2})
-
-    query = from p in Post,
-      left_join: c in assoc(p, :comments),
-      left_join: u in assoc(c, :author),
-      order_by: [p.id, c.id, u.id],
-      preload: [comments: {c, author: u}],
-      select: {0, [p], 1, 2}
-
-    posts = TestRepo.all(query)
-    assert [p1, p2] = Enum.map(posts, fn {0, [p], 1, 2} -> p end)
-    assert p1.id == pid1
-    assert p2.id == pid2
-
-    assert [c1, c2] = p1.comments
-    assert [c3] = p2.comments
-    assert c1.id == cid1
-    assert c2.id == cid2
-    assert c3.id == cid3
-
-    assert c1.author.id == uid1
-    assert c2.author.id == uid2
-    assert c3.author.id == uid2
-  end
-
-  test "nested assoc with missing entries" do
-    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
-    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
-    %Post{id: pid3} = TestRepo.insert(%Post{title: "2"})
-
-    %User{id: uid1} = TestRepo.insert(%User{name: "1"})
-    %User{id: uid2} = TestRepo.insert(%User{name: "2"})
-
-    %Comment{id: cid1} = TestRepo.insert(%Comment{text: "1", post_id: pid1, author_id: uid1})
-    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: pid1, author_id: nil})
-    %Comment{id: cid3} = TestRepo.insert(%Comment{text: "3", post_id: pid3, author_id: uid2})
-
-    query = from p in Post,
-      left_join: c in assoc(p, :comments),
-      left_join: u in assoc(c, :author),
-      order_by: [p.id, c.id, u.id],
-      preload: [comments: {c, author: u}]
-
-    assert [p1, p2, p3] = TestRepo.all(query)
-    assert p1.id == pid1
-    assert p2.id == pid2
-    assert p3.id == pid3
-
-    assert [c1, c2] = p1.comments
-    assert [] = p2.comments
-    assert [c3] = p3.comments
-    assert c1.id == cid1
-    assert c2.id == cid2
-    assert c3.id == cid3
-
-    assert c1.author.id == uid1
-    assert c2.author == nil
-    assert c3.author.id == uid2
-  end
-
-  test "assoc with preload" do
-    %Post{id: pid1} = TestRepo.insert(%Post{title: "1"})
-    %Post{id: pid2} = TestRepo.insert(%Post{title: "2"})
-
-    %Permalink{id: plid1} = TestRepo.insert(%Permalink{url: "1", post_id: pid2})
-
-    %Comment{id: cid1} = TestRepo.insert(%Comment{text: "1", post_id: pid1})
-    %Comment{id: cid2} = TestRepo.insert(%Comment{text: "2", post_id: pid2})
-    %Comment{id: _}    = TestRepo.insert(%Comment{text: "3", post_id: pid2})
-
-    query = from p in Post,
-      left_join: c in assoc(p, :comments),
-      where: c.text in ~w(1 2),
-      preload: [:permalink, comments: c],
-      select: {0, [p], 1, 2}
-
-    posts = TestRepo.all(query)
-    assert [p1, p2] = Enum.map(posts, fn {0, [p], 1, 2} -> p end)
-    assert p1.id == pid1
-    assert p2.id == pid2
-
-    assert p2.permalink.id == plid1
-
-    assert [c1] = p1.comments
-    assert [c2] = p2.comments
-    assert c1.id == cid1
-    assert c2.id == cid2
   end
 end

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -8,7 +8,6 @@ defmodule Ecto.Integration.RepoTest do
   alias Ecto.Integration.PostUsecTimestamps
   alias Ecto.Integration.Comment
   alias Ecto.Integration.Permalink
-  alias Ecto.Integration.User
   alias Ecto.Integration.Custom
   alias Ecto.Integration.Barebone
   alias Ecto.Schema.Metadata
@@ -36,7 +35,7 @@ defmodule Ecto.Integration.RepoTest do
   end
 
   test "fetch without model" do
-    %Post{id: id} = TestRepo.insert(%Post{title: "title1"})
+    %Post{} = TestRepo.insert(%Post{title: "title1"})
     %Post{} = TestRepo.insert(%Post{title: "title2"})
 
     assert ["title1", "title2"] =

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -42,7 +42,7 @@ defmodule Ecto.Integration.RepoTest do
     assert ["title1", "title2"] =
       TestRepo.all(from(p in "posts", order_by: p.title, select: p.title))
 
-    assert [^id] =
+    assert [_] =
       TestRepo.all(from(p in "posts", where: p.title == "title1", select: p.id))
   end
 
@@ -214,7 +214,7 @@ defmodule Ecto.Integration.RepoTest do
     on_insert = cast(%Post{}, %{"title" => "hello"}, ~w(title), ~w())
     assert validate_unique(on_insert, :title, on: TestRepo).errors == []
 
-    on_update = cast(%{post | id: post.id + 1}, %{"title" => "hello"}, ~w(title), ~w())
+    on_update = cast(%{post | id: nil}, %{"title" => "hello"}, ~w(title), ~w())
     assert validate_unique(on_update, :title, on: TestRepo).errors == []
   end
 
@@ -285,13 +285,13 @@ defmodule Ecto.Integration.RepoTest do
 
     assert post1 == TestRepo.one(from p in Post, where: p.id == ^post1.id)
     assert post2 == TestRepo.one(from p in Post, where: p.id == ^to_string post2.id) # With casting
-    assert nil   == TestRepo.one(from p in Post, where: p.id == ^-1)
+    assert nil   == TestRepo.one(from p in Post, where: is_nil(p.id))
 
     assert post1 == TestRepo.one!(from p in Post, where: p.id == ^post1.id)
     assert post2 == TestRepo.one!(from p in Post, where: p.id == ^to_string post2.id) # With casting
 
     assert_raise Ecto.NoResultsError, fn ->
-      TestRepo.one!(from p in Post, where: p.id == ^-1)
+      TestRepo.one!(from p in Post, where: is_nil(p.id))
     end
   end
 

--- a/integration_test/mysql/all_test.exs
+++ b/integration_test/mysql/all_test.exs
@@ -1,6 +1,7 @@
 Code.require_file "../sql/migration.exs", __DIR__
 Code.require_file "../sql/escape.exs", __DIR__
 Code.require_file "../sql/transaction.exs", __DIR__
+Code.require_file "../cases/joins.exs", __DIR__
 Code.require_file "../cases/repo.exs", __DIR__
 Code.require_file "../cases/type.exs", __DIR__
 Code.require_file "../cases/preload.exs", __DIR__

--- a/integration_test/pg/all_test.exs
+++ b/integration_test/pg/all_test.exs
@@ -2,6 +2,7 @@ Code.require_file "../sql/lock.exs", __DIR__
 Code.require_file "../sql/migration.exs", __DIR__
 Code.require_file "../sql/escape.exs", __DIR__
 Code.require_file "../sql/transaction.exs", __DIR__
+Code.require_file "../cases/joins.exs", __DIR__
 Code.require_file "../cases/repo.exs", __DIR__
 Code.require_file "../cases/type.exs", __DIR__
 Code.require_file "../cases/preload.exs", __DIR__


### PR DESCRIPTION
The first commit splits all the integration tests that use joins (that are strictly a SQL feature) to a separate file.

The second one tries to amend some tests that relied on the assumption that primary key is always integer, as it's no longer true. There are some tests that are broken for Mongo that I don't know how to fix. These are:
* [preload with binary_id](https://github.com/elixir-lang/ecto/blob/c209efe05f2e07327435e06f661d32a9780b41a8/integration_test/cases/preload.exs#L255-261) - assumes that binary_id is uuid, that is not true for mongo.
* [insert with user-assigned primary key](https://github.com/elixir-lang/ecto/blob/c209efe05f2e07327435e06f661d32a9780b41a8/integration_test/cases/repo.exs#L102-104) - assumes primary key is integer
* [insert and update with user-assigned primary key in changeset](https://github.com/elixir-lang/ecto/blob/c209efe05f2e07327435e06f661d32a9780b41a8/integration_test/cases/repo.exs#L107-113) - assumes primary key is integer
* [validate_unique/3](https://github.com/elixir-lang/ecto/blob/c209efe05f2e07327435e06f661d32a9780b41a8/integration_test/cases/repo.exs#L188-206) - `validate_unique/3` with `downcase: true` uses SQL fragments `lower(?)` that I'm unable to support.
* [get(!)](https://github.com/elixir-lang/ecto/blob/c209efe05f2e07327435e06f661d32a9780b41a8/integration_test/cases/repo.exs#L236-250) - at line 242 there's a `-1` I'm not sure what to do about.

I haven't considered all the tests that are related to updates or deletes as I haven't implemented them yet, so it's hard to tell what wont work.