### PR TITLE
Tag integration tests using fragments, id and decimal types

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -361,12 +361,13 @@ defmodule Ecto.Integration.RepoTest do
     assert %Post{title: "3"} = TestRepo.get(Post, id3)
   end
 
+  @tag :sql_fragments
   test "update all expression syntax" do
     assert %Post{id: id1} = TestRepo.insert(%Post{title: "1", visits: 0})
     assert %Post{id: id2} = TestRepo.insert(%Post{title: "2", visits: 1})
 
     # Expressions
-    query = from p in Post, where: p.id > 0
+    query = from p in Post, where: not is_nil(p.id)
     assert 2 = TestRepo.update_all(p in query, visits: fragment("? + 2", p.visits))
 
     assert %Post{visits: 2} = TestRepo.get(Post, id1)
@@ -379,13 +380,16 @@ defmodule Ecto.Integration.RepoTest do
     assert %Post{visits: nil} = TestRepo.get(Post, id2)
   end
 
-  test "update all with casting and dumping" do
+  @tag :id_type
+  test "update all with casting and dumping on id type field" do
     text = "hai"
     date = Ecto.DateTime.utc
     assert %Post{id: id1} = TestRepo.insert(%Post{})
     assert 1 = TestRepo.update_all(p in Post, text: ^text, counter: ^to_string(id1), inserted_at: ^date)
     assert %Post{text: "hai", counter: ^id1, inserted_at: ^date} = TestRepo.get(Post, id1)
+  end
 
+  test "update all with casting and dumping" do
     text = "hai"
     date = {{2010, 4, 17}, {14, 00, 00, 00}}
     assert %Comment{id: id2} = TestRepo.insert(%Comment{})

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -14,13 +14,12 @@ defmodule Ecto.Integration.TypeTest do
     integer  = 1
     float    = 0.1
     text     = <<0,1>>
-    decimal  = Decimal.new("1.0")
     uuid     = "00010203-0405-0607-0809-0a0b0c0d0e0f"
     datetime = %Ecto.DateTime{year: 2014, month: 1, day: 16,
                               hour: 20, min: 26, sec: 51, usec: 0}
 
     TestRepo.insert(%Post{text: text, public: true, visits: integer, uuid: uuid, counter: integer,
-                          inserted_at: datetime, cost: decimal, intensity: float})
+                          inserted_at: datetime, intensity: float})
 
     # nil
     assert [nil] = TestRepo.all(from Post, select: nil)
@@ -36,13 +35,6 @@ defmodule Ecto.Integration.TypeTest do
     assert [0.1] = TestRepo.all(from p in Post, where: p.intensity == ^float, select: p.intensity)
     assert [0.1] = TestRepo.all(from p in Post, where: p.intensity == 0.1, select: p.intensity)
 
-    # Decimal
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^decimal, select: p.cost)
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^1.0, select: p.cost)
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^1, select: p.cost)
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1.0, select: p.cost)
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1, select: p.cost)
-
     # Booleans
     assert [true] = TestRepo.all(from p in Post, where: p.public == ^true, select: p.public)
     assert [true] = TestRepo.all(from p in Post, where: p.public == true, select: p.public)
@@ -56,6 +48,19 @@ defmodule Ecto.Integration.TypeTest do
 
     # Datetime
     assert [^datetime] = TestRepo.all(from p in Post, where: p.inserted_at == ^datetime, select: p.inserted_at)
+  end
+
+  @tag :decimal_type
+  test "decimal type" do
+    decimal = Decimal.new("1.0")
+
+    TestRepo.insert(%Post{cost: decimal})
+
+    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^decimal, select: p.cost)
+    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^1.0, select: p.cost)
+    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^1, select: p.cost)
+    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1.0, select: p.cost)
+    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1, select: p.cost)
   end
 
   test "tagged types" do


### PR DESCRIPTION
I tried splitting the `update all expression syntax` test in two, but what left wasn't testing anything other than the other tests do.