### PR TITLE
Add ability to rename columns

### DIFF
--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -68,6 +68,7 @@ defmodule Ecto.Integration.Migration do
 
     create table(:users) do
       add :name, :string
+      add :details, :string
       add :to_be_removed, :string
     end
 
@@ -75,6 +76,7 @@ defmodule Ecto.Integration.Migration do
 
     alter table(:users) do
       modify :name, :text
+      rename :details, :description
       add :custom_id, :uuid
       remove :to_be_removed
       timestamps

--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -76,10 +76,13 @@ defmodule Ecto.Integration.Migration do
 
     alter table(:users) do
       modify :name, :text
-      rename :details, :description
       add :custom_id, :uuid
       remove :to_be_removed
       timestamps
+    end
+
+    alter table(:users) do
+      rename :details, :description, :string
     end
 
     index = index(:users, [:custom_id], unique: true)

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -22,6 +22,7 @@ defmodule Ecto.Adapter.Migration  do
   @type table_subcommand ::
     {:add, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t} |
     {:modify, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t} |
+    {:rename, field :: atom, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t} |
     {:remove, field :: atom}
 
   @typedoc """

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -454,6 +454,10 @@ if Code.ensure_loaded?(Mariaex.Connection) do
       assemble(["MODIFY", quote_name(name), column_type(type, opts)])
     end
 
+    defp column_change({:rename, old_name, new_name, type, opts}) do
+      assemble(["CHANGE", quote_name(old_name), quote_name(new_name), column_type(type, opts)])
+    end
+
     defp column_change({:remove, name}), do: "DROP #{quote_name(name)}"
 
     defp column_options(name, opts) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -493,6 +493,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       assemble(["ALTER COLUMN", quote_name(name), "TYPE", column_type(type, opts)])
     end
 
+    defp column_change({:rename, old_name, new_name, _type, _opts}) do
+      assemble(["RENAME COLUMN", quote_name(old_name), "TO", quote_name(new_name)])
+    end
+
     defp column_change({:remove, name}), do: "DROP COLUMN #{quote_name(name)}"
 
     defp column_options(opts) do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -185,6 +185,7 @@ defmodule Ecto.Migration do
       alter table(:posts) do
         add :summary, :text
         modify :title, :text
+        rename :details, :description, :text
         remove :views
       end
 
@@ -430,6 +431,27 @@ defmodule Ecto.Migration do
   """
   def modify(column, type, opts \\ []) when is_atom(column) do
     Runner.subcommand {:modify, column, type, opts}
+  end
+
+  @doc """
+  Rename the column when altering a table.
+
+  See `add/3` for more information on supported types.
+
+  ## Examples
+
+      alter table(:posts) do
+        rename :details, :description, :text
+      end
+
+  ## Options
+
+    * `:size` - the size of the type (for example the numbers of characters). Default is no size.
+    * `:precision` - the precision for a numberic type. Default is no precision.
+    * `:scale` - the scale of a numberic type. Default is 0 scale.
+  """
+  def rename(column, new_name, type \\ :string, opts \\ []) when is_atom(column) do
+    Runner.subcommand {:rename, column, new_name, type, opts}
   end
 
   @doc """

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -450,12 +450,14 @@ defmodule Ecto.Adapters.MySQLTest do
     alter = {:alter, table(:posts),
                [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},
                 {:modify, :price, :numeric, [precision: 8, scale: 2]},
+                {:rename, :details, :description, :string, [size: 1000]},
                 {:remove, :summary}]}
 
     assert SQL.execute_ddl(alter) == """
     ALTER TABLE `posts`
     ADD `title` varchar(100) DEFAULT 'Untitled' NOT NULL,
     MODIFY `price` numeric(8,2),
+    CHANGE `details` `description` varchar(1000),
     DROP `summary`
     """ |> String.strip |> String.replace("\n", " ")
   end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -469,12 +469,14 @@ defmodule Ecto.Adapters.PostgresTest do
     alter = {:alter, table(:posts),
                [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},
                 {:modify, :price, :numeric, [precision: 8, scale: 2]},
+                {:rename, :details, :description, :string, [size: 1000]},
                 {:remove, :summary}]}
 
     assert SQL.execute_ddl(alter) == """
     ALTER TABLE "posts"
     ADD COLUMN "title" varchar(100) DEFAULT 'Untitled' NOT NULL,
     ALTER COLUMN "price" TYPE numeric(8,2),
+    RENAME COLUMN "details" TO "description",
     DROP COLUMN "summary"
     """ |> String.strip |> String.replace("\n", " ")
   end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -112,6 +112,7 @@ defmodule Ecto.MigrationTest do
     alter table(:posts) do
       add :summary, :text
       modify :title, :text
+      rename :details, :description
       remove :views
     end
 
@@ -119,6 +120,7 @@ defmodule Ecto.MigrationTest do
            {:alter, %Table{name: :posts},
               [{:add, :summary, :text, []},
                {:modify, :title, :text, []},
+               {:rename, :details, :description, :string, []},
                {:remove, :views}]}
   end
 


### PR DESCRIPTION
I am looking to add support for renaming columns in ecto migrations.

Here is the documentation I referred to regarding the Postgres and MySQL syntax.

http://www.postgresql.org/docs/9.4/static/sql-altertable.html

https://dev.mysql.com/doc/refman/5.1/en/alter-table.html