### PR TITLE
Update mariaex to 0.2.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Ecto.Mixfile do
     [{:poolboy, "~> 1.4"},
      {:decimal, "~> 1.0"},
      {:postgrex, "~> 0.8.0", optional: true},
-     {:mariaex, "~> 0.1.0", optional: true},
+     {:mariaex, "~> 0.2.1", optional: true},
      {:ex_doc, "~> 0.7", only: :docs},
      {:earmark, "~> 0.1", only: :docs},
      {:inch_ex, only: :docs}]

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.7.3"},
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
-  "mariaex": {:hex, :mariaex, "0.1.6"},
+  "mariaex": {:hex, :mariaex, "0.2.1"},
   "poison": {:hex, :poison, "1.3.1"},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.8.0"}}


### PR DESCRIPTION
mariaex has backwards incompatible changes, no more sanitising of inputs, and performance improvements.