### PR TITLE
Added the inspect protocol to Ecto.DateTime, Ecto.Date, and Ecto.Time

### DIFF
--- a/lib/ecto/datetime.ex
+++ b/lib/ecto/datetime.ex
@@ -435,3 +435,10 @@ defimpl String.Chars, for: [Ecto.DateTime, Ecto.Date, Ecto.Time] do
     @for.to_string(dt)
   end
 end
+
+defimpl Inspect, for: [Ecto.DateTime, Ecto.Date, Ecto.Time] do
+  def inspect(dt, _opts) do
+    iso8601 = @for.to_iso8601(dt)
+    ~s(#{inspect(@for)}<#{iso8601}>)
+  end
+end

--- a/lib/ecto/datetime.ex
+++ b/lib/ecto/datetime.ex
@@ -439,6 +439,7 @@ end
 defimpl Inspect, for: [Ecto.DateTime, Ecto.Date, Ecto.Time] do
   def inspect(dt, _opts) do
     iso8601 = @for.to_iso8601(dt)
-    ~s(#{inspect(@for)}<#{iso8601}>)
+    module = inspect(@for)
+    ~s(#{module}<#{iso8601}>)
   end
 end

--- a/lib/ecto/datetime.ex
+++ b/lib/ecto/datetime.ex
@@ -440,6 +440,6 @@ defimpl Inspect, for: [Ecto.DateTime, Ecto.Date, Ecto.Time] do
   def inspect(dt, _opts) do
     iso8601 = @for.to_iso8601(dt)
     module = inspect(@for)
-    ~s(#{module}<#{iso8601}>)
+    ~s(##{module}<#{iso8601}>)
   end
 end

--- a/test/ecto/datetime_test.exs
+++ b/test/ecto/datetime_test.exs
@@ -40,6 +40,10 @@ defmodule Ecto.DateTest do
   test "to_erl and from_erl" do
     assert @date |> Ecto.Date.to_erl |> Ecto.Date.from_erl == @date
   end
+
+  test "inspect protocol" do
+    assert inspect(@date) == "Ecto.Date<2015-12-31>"
+  end
 end
 
 defmodule Ecto.TimeTest do
@@ -113,6 +117,11 @@ defmodule Ecto.TimeTest do
 
   test "to_erl and from_erl" do
     assert @time |> Ecto.Time.to_erl |> Ecto.Time.from_erl == @time
+  end
+
+  test "inspect protocol" do
+    assert inspect(@time) == "Ecto.Time<23:50:07>"
+    assert inspect(@time_usec) == "Ecto.Time<12:40:33.030000>"
   end
 end
 
@@ -191,5 +200,10 @@ defmodule Ecto.DateTimeTest do
 
   test "to_erl and from_erl" do
     assert @datetime |> Ecto.DateTime.to_erl |> Ecto.DateTime.from_erl == @datetime
+  end
+
+  test "inspect protocol" do
+    assert inspect(@datetime) == "Ecto.DateTime<2015-01-23T23:50:07Z>"
+    assert inspect(@datetime_usec) == "Ecto.DateTime<2015-01-23T23:50:07.008000Z>"
   end
 end

--- a/test/ecto/datetime_test.exs
+++ b/test/ecto/datetime_test.exs
@@ -42,7 +42,7 @@ defmodule Ecto.DateTest do
   end
 
   test "inspect protocol" do
-    assert inspect(@date) == "Ecto.Date<2015-12-31>"
+    assert inspect(@date) == "#Ecto.Date<2015-12-31>"
   end
 end
 
@@ -120,8 +120,8 @@ defmodule Ecto.TimeTest do
   end
 
   test "inspect protocol" do
-    assert inspect(@time) == "Ecto.Time<23:50:07>"
-    assert inspect(@time_usec) == "Ecto.Time<12:40:33.030000>"
+    assert inspect(@time) == "#Ecto.Time<23:50:07>"
+    assert inspect(@time_usec) == "#Ecto.Time<12:40:33.030000>"
   end
 end
 
@@ -203,7 +203,7 @@ defmodule Ecto.DateTimeTest do
   end
 
   test "inspect protocol" do
-    assert inspect(@datetime) == "Ecto.DateTime<2015-01-23T23:50:07Z>"
-    assert inspect(@datetime_usec) == "Ecto.DateTime<2015-01-23T23:50:07.008000Z>"
+    assert inspect(@datetime) == "#Ecto.DateTime<2015-01-23T23:50:07Z>"
+    assert inspect(@datetime_usec) == "#Ecto.DateTime<2015-01-23T23:50:07.008000Z>"
   end
 end


### PR DESCRIPTION
This addresses issue #641. The issue calls for implementing the inspect protocols on more than the DateTime modules. Initially I would just like to make sure I am on the right track.