### PR TITLE
After connect hook and search_path (on PostgreSQL)

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -11,7 +11,13 @@ if Code.ensure_loaded?(Mariaex.Connection) do
 
     def connect(opts) do
       opts = Keyword.update(opts, :port, @default_port, &normalize_port/1)
-      Mariaex.Connection.start_link(opts)
+      {:ok, conn} = Mariaex.Connection.start_link(opts)
+      :ok = after_connect(conn, opts)
+      {:ok, conn}
+    end
+
+    def after_connect(_conn, _opts) do
+      :ok
     end
 
     def disconnect(conn) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -21,7 +21,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       {:ok, conn}
     end
 
-    def after_connect(_conn, _opts) do
+    def after_connect(conn, opts) do
+      if search_path = opts[:search_path] do
+        {:ok, _} = query(conn, "SET search_path TO #{search_path}", [], opts)
+      end
       :ok
     end
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -16,7 +16,13 @@ if Code.ensure_loaded?(Postgrex.Connection) do
         |> Keyword.update(:extensions, extensions, &(&1 ++ extensions))
         |> Keyword.update(:port, @default_port, &normalize_port/1)
 
-      Postgrex.Connection.start_link(opts)
+      {:ok, conn} = Postgrex.Connection.start_link(opts)
+      :ok = after_connect(conn, opts)
+      {:ok, conn}
+    end
+
+    def after_connect(_conn, _opts) do
+      :ok
     end
 
     def disconnect(conn) do

--- a/lib/ecto/adapters/worker.ex
+++ b/lib/ecto/adapters/worker.ex
@@ -50,6 +50,12 @@ defmodule Ecto.Adapters.Worker do
   defcallback connect(Keyword.t) :: {:ok, pid} | {:error, term}
 
   @doc """
+  Called right after a connection has been opened with the pid of the connection
+  and the connect options.
+  """
+  defcallback after_connect(pid, Keywork.t) :: :ok
+
+  @doc """
   Disconnects the given `pid`.
 
   If the given `pid` no longer exists, it should not raise.


### PR DESCRIPTION
After the discussion in https://github.com/ericmj/postgrex/pull/78, I've tried to implement the setting of `search_path` in Ecto.

I'm not sure if this is the way you would do it, so I'm open to your remark here.

I've splitted it in two commits, the first one adding an `after_connect` callback to the `Ecto.Adapters.Worker` which is called after a connection has been opened. 

Then in a second commit I've used this callback in `Ecto.Adapters.Postgres.Connection` to set the `search_path` (if given) when a new connection is opened. 