### PR TITLE
Add an `after_connect` callback in `Ecto.Repo`

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -408,6 +408,7 @@ defmodule Ecto.Adapters.SQL do
        worker_module: Worker] ++ pool_opts
 
     worker_opts = worker_opts
+      |> Keyword.put(:repo, repo)
       |> Keyword.put(:timeout, Keyword.get(worker_opts, :connect_timeout, 5000))
 
     {pool_opts, worker_opts}

--- a/lib/ecto/adapters/worker.ex
+++ b/lib/ecto/adapters/worker.ex
@@ -163,10 +163,12 @@ defmodule Ecto.Adapters.Worker do
   def init({module, params}) do
     Process.flag(:trap_exit, true)
     lazy? = Keyword.get(params, :lazy, true)
+    repo = params[:repo]
 
     unless lazy? do
       case module.connect(params) do
         {:ok, conn} ->
+          repo.after_connect(conn)
           conn = conn
         _ ->
           :ok
@@ -208,8 +210,12 @@ defmodule Ecto.Adapters.Worker do
   ## Lazy connection handling
 
   def handle_call(request, from, %{conn: nil, params: params, module: module} = s) do
+    repo = params[:repo]
+
     case module.connect(params) do
-      {:ok, conn}   -> handle_call(request, from, %{s | conn: conn})
+      {:ok, conn}   ->
+        repo.after_connect(conn)
+        handle_call(request, from, %{s | conn: conn})
       {:error, err} -> {:reply, {:error, err}, s}
     end
   end

--- a/lib/ecto/adapters/worker.ex
+++ b/lib/ecto/adapters/worker.ex
@@ -168,7 +168,9 @@ defmodule Ecto.Adapters.Worker do
     unless lazy? do
       case module.connect(params) do
         {:ok, conn} ->
-          repo.after_connect(conn)
+          if repo do
+            repo.after_connect(conn)
+          end
           conn = conn
         _ ->
           :ok
@@ -214,7 +216,9 @@ defmodule Ecto.Adapters.Worker do
 
     case module.connect(params) do
       {:ok, conn}   ->
-        repo.after_connect(conn)
+        if repo do
+          repo.after_connect(conn)
+        end
         handle_call(request, from, %{s | conn: conn})
       {:error, err} -> {:reply, {:error, err}, s}
     end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -159,6 +159,11 @@ defmodule Ecto.Repo do
       end
 
       defoverridable [log: 1]
+
+      def after_connect(_conn) do
+      end
+
+      defoverridable [after_connect: 1]
     end
   end
 
@@ -509,4 +514,24 @@ defmodule Ecto.Repo do
 
   """
   defcallback log(Ecto.LogEntry.t) :: any
+
+  @doc """
+  Called right after a new connection is opened.
+
+  By default does nothing.
+
+  ## Examples
+
+  It could be used to set the search_path in Postgres like this:
+
+      def after_connect(conn) do
+        Ecto.Adapters.Postgres.Connection.query(
+          conn,
+          "SET search_path TO my_search_path",
+          [],
+          []
+        )
+      end
+  """
+  defcallback after_connect(pid) :: any
 end


### PR DESCRIPTION
The callback is run right after a new connection has been opened passing
in the pid of the connection.