### PR TITLE
Unused variable in Planner.cast_param/2

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -169,8 +169,8 @@ defmodule Ecto.Query.Planner do
     # when dumping.
     if Ecto.Type.primitive?(type) &&
        (struct = param_struct(v)) &&
-       Ecto.Type.match?(v.__struct__.type, type) do
-      {:match, v.__struct__}
+       Ecto.Type.match?(struct.type, type) do
+      {:match, struct}
     else
       Ecto.Type.cast(type, v)
     end


### PR DESCRIPTION
There was a warning about the `struct` variable before. We can use it later to access the type's module instead of extracting it again and get rid of the warning.