### PR TITLE
Add keyword fragments for queries

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -298,6 +298,10 @@ if Code.ensure_loaded?(Mariaex.Connection) do
       "NOT (" <> expr(expr, sources) <> ")"
     end
 
+    defp expr({:fragment, _, [kw]}, _sources) when is_list(kw) or tuple_size(kw) == 3 do
+      raise ArgumentError, "MySQL adapter does not support keyword or interpolated fragments"
+    end
+
     defp expr({:fragment, _, parts}, sources) do
       Enum.map_join(parts, "", fn
         {:raw, part}  -> part

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -339,6 +339,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       "NOT (" <> expr(expr, sources) <> ")"
     end
 
+    defp expr({:fragment, _, [kw]}, _sources) when is_list(kw) or tuple_size(kw) == 3 do
+      raise ArgumentError, "PostgreSQL adapter does not support keyword or interpolated fragments"
+    end
+
     defp expr({:fragment, _, parts}, sources) do
       Enum.map_join(parts, "", fn
         {:raw, part}  -> part

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -111,7 +111,8 @@ defimpl Inspect, for: Ecto.Query do
     Macro.to_string(expr, &expr_to_string(&1, &2, names, params))
   end
 
-  defp expr_to_string({:fragment, _, parts}, _, names, params) do
+  # For keyword and interpolated fragments use normal escaping
+  defp expr_to_string({:fragment, _, [{_, _}|_] = parts}, _, names, params) do
     "fragment(" <> unmerge_fragments(parts, "", [], names, params) <> ")"
   end
 

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -167,6 +167,11 @@ defmodule Ecto.Adapters.MySQLTest do
     value = 13
     query = Model |> select([r], fragment("lcase(?, ?)", r.x, ^value)) |> normalize
     assert SQL.all(query) == ~s{SELECT lcase(m0.`x`, ?) FROM `model` AS m0}
+
+    query = Model |> select([], fragment(title: 2)) |> normalize
+    assert_raise ArgumentError, fn ->
+      SQL.all(query)
+    end
   end
 
   test "literals" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -176,6 +176,11 @@ defmodule Ecto.Adapters.PostgresTest do
     value = 13
     query = Model |> select([r], fragment("downcase(?, ?)", r.x, ^value)) |> normalize
     assert SQL.all(query) == ~s{SELECT downcase(m0."x", $1) FROM "model" AS m0}
+
+    query = Model |> select([], fragment(title: 2)) |> normalize
+    assert_raise ArgumentError, fn ->
+      SQL.all(query)
+    end
   end
 
   test "literals" do

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -110,6 +110,12 @@ defmodule Ecto.Query.InspectTest do
     value = "foobar"
     assert i(from(x in Post, where: fragment("downcase(?) == ?", x.id, ^value))) ==
            ~s{from p in Inspect.Post, where: fragment("downcase(?) == ?", p.id, ^"foobar")}
+
+    assert i(from(x in Post, where: fragment(^[title: [foo: "foobar"]]))) ==
+           ~s{from p in Inspect.Post, where: fragment(^[title: [foo: "foobar"]])}
+
+    assert i(from(x in Post, where: fragment(title: [foo: ^value]))) ==
+      ~s{from p in Inspect.Post, where: fragment(title: [foo: ^"foobar"])}
   end
 
   test "inspect all" do


### PR DESCRIPTION
As we discussed earlier @josevalim, this allows two additional forms for fragments:
```elixir
fragment(title: [foo: ^0])
fragment(^[title: [foo: 0]])
```

Should we check in the second case that the interpolated value is a keyword?