### PR TITLE
Updated Ecto.changeset example to consistently use gender (instead of gender & sex)

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -717,7 +717,7 @@ defmodule Ecto.Changeset do
 
   ## Examples
 
-      validate_inclusion(changeset, :gender, ["male", "female", "who cares?"])
+      validate_inclusion(changeset, :gender, ["man", "woman", "other", "prefer not to say"])
       validate_inclusion(changeset, :age, 0..99)
 
   """
@@ -968,7 +968,7 @@ defmodule Ecto.Changeset do
       validate_confirmation(changeset, :password, message: "passwords do not match")
 
       cast(params, model, ~w(password), ~w())
-      |> validate_confirmation(:password, message: "passwords do not match")  
+      |> validate_confirmation(:password, message: "passwords do not match")
 
   """
   @spec validate_confirmation(t, atom, Enum.t) :: t


### PR DESCRIPTION
Because why not be more inclusive :)

More Comprehensive gender list. [source: Facebook via abcnews](http://abcnews.go.com/blogs/headlines/2014/02/heres-a-list-of-58-gender-options-for-facebook-users/)
```
Agender
Androgyne
Androgynous
Bigender
Cis
Cisgender
Cis Female
Cis Male
Cis Man
Cis Woman
Cisgender Female
Cisgender Male
Cisgender Man
Cisgender Woman
Female to Male
FTM
Gender Fluid
Gender Nonconforming
Gender Questioning
Gender Variant
Genderqueer
Intersex
Male to Female
MTF
Neither
Neutrois
Non-binary
Other
Pangender
Trans
Trans*
Trans Female
Trans* Female
Trans Male
Trans* Male
Trans Man
Trans* Man
Trans Person
Trans* Person
Trans Woman
Trans* Woman
Transfeminine
Transgender
Transgender Female
Transgender Male
Transgender Man
Transgender Person
Transgender Woman
Transmasculine
Transsexual
Transsexual Female
Transsexual Male
Transsexual Man
Transsexual Person
Transsexual Woman
Two-Spirit
```