### PR TITLE
Added validate_subset to Ecto.changeset

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -729,6 +729,29 @@ defmodule Ecto.Changeset do
   end
 
   @doc """
+  Validates a change, of type enum, is a subset of the given enumerable. Like
+  validate_inclusion for lists.
+
+  ## Options
+
+    * `:message` - the message on failure, defaults to "\#{x} is invalid"
+
+  ## Examples
+
+      validate_subset(changeset, :pets, ["cat", "dog", "parrot"])
+      validate_subset(changeset, :lottery_numbers, 0..99)
+
+  """
+  @spec validate_subset(t, atom, Enum.t) :: t
+  def validate_subset(changeset, field, data, opts \\ []) do
+    validate_change changeset, field, {:subset, data}, fn _, values ->
+      Enum.flat_map values, fn(x) ->
+        if x in data, do: [], else: [{field, message(opts, "#{x} is invalid")}]
+      end
+    end
+  end
+
+  @doc """
   Validates a change is not included in given the enumerable.
 
   ## Options

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -730,7 +730,7 @@ defmodule Ecto.Changeset do
 
   @doc """
   Validates a change, of type enum, is a subset of the given enumerable. Like
-  validate_inclusion for lists.
+  validate_inclusion/4 for lists.
 
   ## Options
 
@@ -744,9 +744,10 @@ defmodule Ecto.Changeset do
   """
   @spec validate_subset(t, atom, Enum.t) :: t
   def validate_subset(changeset, field, data, opts \\ []) do
-    validate_change changeset, field, {:subset, data}, fn _, values ->
-      Enum.flat_map values, fn(x) ->
-        if x in data, do: [], else: [{field, message(opts, "#{x} is invalid")}]
+    validate_change changeset, field, {:subset, data}, fn _, value ->
+      case Enum.any?(value, fn(x) -> not x in data end) do
+        true -> [{field, message(opts, "has an invalid entry")}]
+        false -> []
       end
     end
   end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -553,7 +553,7 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"topics" => ["cat", "laptop"]})
       |> validate_subset(:topics, ~w(cat dog))
     refute changeset.valid?
-    assert changeset.errors == [topics: "laptop is invalid"]
+    assert changeset.errors == [topics: "has an invalid entry"]
     assert changeset.validations == [topics: {:subset, ~w(cat dog)}]
 
     changeset =

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -12,11 +12,12 @@ defmodule Ecto.ChangesetTest do
       field :body
       field :uuid, :binary_id
       field :upvotes, :integer, default: 0
+      field :topics, {:array, :string}
     end
   end
 
   defp changeset(params, model \\ %Post{}) do
-    cast(model, params, ~w(), ~w(title body upvotes))
+    cast(model, params, ~w(), ~w(title body upvotes topics))
   end
 
   ## cast/4
@@ -538,6 +539,27 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world), message: "yada")
     assert changeset.errors == [title: "yada"]
+  end
+
+  test "validate_subset/3" do
+    changeset =
+      changeset(%{"topics" => ["cat", "dog"]})
+      |> validate_subset(:topics, ~w(cat dog))
+    assert changeset.valid?
+    assert changeset.errors == []
+    assert changeset.validations == [topics: {:subset, ~w(cat dog)}]
+
+    changeset =
+      changeset(%{"topics" => ["cat", "laptop"]})
+      |> validate_subset(:topics, ~w(cat dog))
+    refute changeset.valid?
+    assert changeset.errors == [topics: "laptop is invalid"]
+    assert changeset.validations == [topics: {:subset, ~w(cat dog)}]
+
+    changeset =
+      changeset(%{"topics" => ["laptop"]})
+      |> validate_subset(:topics, ~w(cat dog), message: "yada")
+    assert changeset.errors == [topics: "yada"]
   end
 
   test "validate_exclusion/3" do


### PR DESCRIPTION
Creates a validator for lists to check if it is the subset of the given enumerable.

@josevalim The PR with the information discussed in #674 

It does create this warning in the tests that I'm unfamiliar with `[warning] :read_after_writes is deprecated. It was declared for field :x in model Ecto.SchemaTest.AutogenerateFail` after reading about RAW.

I also attempted to cover the following case before realizing that I'm not sure if you can even define an array of arrays in an `Ecto.Model`. This didn't work ` field :topics, {:array, {:array, :string }`, nor would I really expect it to. Thoughts?

```
@whitelist [["a", "b"], ["b", "c"]]
validate_inclusion(:list, [["a", "b"], ["b", "c"], ["a", "c"]], @whitelist)
```

As a follow up to this, is there any value in creating `validate_disjoint_set` (analagous to validate_exclusion) and a `validate_intersection` (at least one item)?