### PR TITLE
handle on_delete: :nothing, :delete_all, :nillify all on create table in postgres and mysql

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -501,9 +501,10 @@ if Code.ensure_loaded?(Mariaex.Connection) do
 
     defp index_expr(literal), do: quote_name(literal)
 
-    defp reference_expr(%Reference{} = ref, foreign_key_name) do
-      ", FOREIGN KEY (#{quote_name(foreign_key_name)}) REFERENCES #{quote_table(ref.table)} (#{quote_name(ref.column)})"
-    end
+    defp reference_expr(%Reference{} = ref, foreign_key_name),
+      do: ", FOREIGN KEY (#{quote_name(foreign_key_name)}) REFERENCES " <>
+          "#{quote_table(ref.table)} (#{quote_name(ref.column)})" <>
+          reference_on_delete(ref.on_delete)
 
     defp engine_expr(nil),
       do: " ENGINE = INNODB"
@@ -531,6 +532,10 @@ if Code.ensure_loaded?(Mariaex.Connection) do
 
     defp reference_column_type(:serial, _opts), do: "BIGINT UNSIGNED"
     defp reference_column_type(type, opts), do: column_type(type, opts)
+
+    defp reference_on_delete(:nillify_all), do: " ON DELETE SET NULL"
+    defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
+    defp reference_on_delete(_), do: ""
 
     ## Helpers
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -548,7 +548,9 @@ if Code.ensure_loaded?(Postgrex.Connection) do
 
     defp column_type(%Reference{} = ref, opts),
       do: "#{reference_column_type(ref.type, opts)} REFERENCES " <>
-          "#{quote_name(ref.table)}(#{quote_name(ref.column)})"
+          "#{quote_name(ref.table)}(#{quote_name(ref.column)})" <>
+          reference_on_delete(ref.on_delete)
+
     defp column_type({:array, type}, opts),
       do: column_type(type, opts) <> "[]"
     defp column_type(type, opts) do
@@ -568,6 +570,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     # A reference pointing to a serial column becomes integer in postgres
     defp reference_column_type(:serial, _opts), do: "integer"
     defp reference_column_type(type, opts), do: column_type(type, opts)
+
+    defp reference_on_delete(:nillify_all), do: " ON DELETE SET NULL"
+    defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
+    defp reference_on_delete(_), do: ""
 
     ## Helpers
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -124,8 +124,17 @@ defmodule Ecto.Migration do
     @moduledoc """
     Defines a reference struct used in migrations.
     """
-    defstruct table: nil, column: :id, type: :serial
-    @type t :: %__MODULE__{table: atom, column: atom, type: atom}
+    defstruct table: nil,
+              column: :id,
+              type: :serial,
+              on_delete: :nothing
+
+    @type t :: %__MODULE__{
+      table: atom,
+      column: atom,
+      type: atom,
+      on_delete: atom
+    }
   end
 
   alias Ecto.Migration.Runner

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -400,7 +400,7 @@ defmodule Ecto.Adapters.MySQLTest do
 
   # DDL
 
-  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1]
+  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1, references: 2]
 
   test "executing a string during migration" do
     assert SQL.execute_ddl("example") == "example"
@@ -430,6 +430,30 @@ defmodule Ecto.Adapters.MySQLTest do
                 {:add, :category_id, references(:categories), []} ]}
     assert SQL.execute_ddl(create) ==
            ~s|CREATE TABLE `posts` (`id` serial , PRIMARY KEY(`id`), `category_id` BIGINT UNSIGNED , FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`)) ENGINE = INNODB|
+  end
+
+  test "create table with reference and on_delete: :nothing clause" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories, on_delete: :nothing), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE `posts` (`id` serial , PRIMARY KEY(`id`), `category_id` BIGINT UNSIGNED , FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`)) ENGINE = INNODB|
+  end
+
+  test "create table with reference and on_delete: :nillify_all clause" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories, on_delete: :nillify_all), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE `posts` (`id` serial , PRIMARY KEY(`id`), `category_id` BIGINT UNSIGNED , FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`) ON DELETE SET NULL) ENGINE = INNODB|
+  end
+
+  test "create table with reference and on_delete: :delete_all clause" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories, on_delete: :delete_all), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE `posts` (`id` serial , PRIMARY KEY(`id`), `category_id` BIGINT UNSIGNED , FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`) ON DELETE CASCADE) ENGINE = INNODB|
   end
 
   test "create table with column options" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -441,7 +441,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
   # DDL
 
-  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1]
+  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1, references: 2]
 
   test "executing a string during migration" do
     assert SQL.execute_ddl("example") == "example"
@@ -462,6 +462,30 @@ defmodule Ecto.Adapters.PostgresTest do
                 {:add, :category_id, references(:categories), []} ]}
     assert SQL.execute_ddl(create) ==
            ~s|CREATE TABLE "posts" ("id" serial PRIMARY KEY, "category_id" integer REFERENCES "categories"("id"))|
+  end
+
+  test "create table with reference and on_delete: :nothing clause" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories, on_delete: :nothing), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE "posts" ("id" serial PRIMARY KEY, "category_id" integer REFERENCES "categories"("id"))|
+  end
+
+  test "create table with reference and on_delete: :nillify_all clause" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories, on_delete: :nillify_all), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE "posts" ("id" serial PRIMARY KEY, "category_id" integer REFERENCES "categories"("id") ON DELETE SET NULL)|
+  end
+
+  test "create table with reference and on_delete: :delete_all clause" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories, on_delete: :delete_all), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE "posts" ("id" serial PRIMARY KEY, "category_id" integer REFERENCES "categories"("id") ON DELETE CASCADE)|
   end
 
   test "create table with column options" do


### PR DESCRIPTION
This is implementation of feature requested https://github.com/elixir-lang/ecto/issues/703 (add ON DELETE CASCADE/SET NULL implementation)

I would appreciate review, and a suggestion if I should get rid of some code duplication between MySQL and PostgreSQL (the private functions adding clauses) or should it stay like that for readability/clarity.