### PR TITLE
Fix typo in SQL adapter, check adapter.stop/1 works

### DIFF
--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -53,6 +53,8 @@ _   = Ecto.Storage.down(TestRepo)
 :ok = Ecto.Storage.up(TestRepo)
 
 {:ok, _pid} = TestRepo.start_link
+:ok = TestRepo.stop
+{:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -54,6 +54,8 @@ _   = Ecto.Storage.down(TestRepo)
 :ok = Ecto.Storage.up(TestRepo)
 
 {:ok, _pid} = TestRepo.start_link
+:ok = TestRepo.stop
+{:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -441,7 +441,7 @@ defmodule Ecto.Adapters.SQL do
 
   @doc false
   def stop(repo) do
-    {pool_mod, pool, _} = repo.__poo__
+    {pool_mod, pool, _} = repo.__pool__
     pool_mod.stop(pool)
   end
 


### PR DESCRIPTION
I don't like this way to test that `stop/1` works, but it can't be used in a test since test expect the repo to be started. 
Alternative is to add a regular test and add `TestRepo.start_link` to `setup_all` and `setup`.