### PR TITLE
[WIP] Add support for sbroker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ env:
   - ELIXIR_ERL_OPTIONS=""
   - ELIXIR_ERL_OPTIONS="+T 9"
 script:
-  - mix test.all
+  - ECTO_POOL=poolboy mix test.all
+  - ECTO_POOL=sojourn_broker mix test.all
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report

--- a/integration_test/cases/pool.exs
+++ b/integration_test/cases/pool.exs
@@ -16,9 +16,7 @@ defmodule Ecto.Integration.PoolTest do
 
   test "can start multiple repos" do
     # Can't start a second Repo with the default name
-    {_, pool_name, _} = PoolRepo.__pool__
-    pool_pid = Process.whereis(pool_name)
-    assert {:error, {:already_started, ^pool_pid}} = PoolRepo.start_link()
+    assert {:error, {:already_started, _}} = PoolRepo.start_link()
 
     # Can start a second repo with a different name
     assert {:ok, _second_pool} = PoolRepo.start_link(name: PoolRepo.Second)

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -10,6 +10,12 @@ Code.require_file "../support/repo.exs", __DIR__
 Code.require_file "../support/models.exs", __DIR__
 Code.require_file "../support/migration.exs", __DIR__
 
+pool =
+  case System.get_env("ECTO_POOL") || "poolboy" do
+    "poolboy"        -> Ecto.Adapters.Poolboy
+    "sojourn_broker" -> Ecto.Adapters.SojournBroker
+  end
+
 # Basic test repo
 alias Ecto.Integration.TestRepo
 
@@ -27,6 +33,7 @@ alias Ecto.Integration.PoolRepo
 
 Application.put_env(:ecto, PoolRepo,
   adapter: Ecto.Adapters.MySQL,
+  pool: pool,
   url: "ecto://root@localhost/ecto_test",
   size: 10)
 

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -10,6 +10,12 @@ Code.require_file "../support/repo.exs", __DIR__
 Code.require_file "../support/models.exs", __DIR__
 Code.require_file "../support/migration.exs", __DIR__
 
+pool =
+  case System.get_env("ECTO_POOL") || "poolboy" do
+    "poolboy"        -> Ecto.Adapters.Poolboy
+    "sojourn_broker" -> Ecto.Adapters.SojournBroker
+  end
+
 # Basic test repo
 alias Ecto.Integration.TestRepo
 
@@ -27,6 +33,7 @@ alias Ecto.Integration.PoolRepo
 
 Application.put_env(:ecto, PoolRepo,
   adapter: Ecto.Adapters.Postgres,
+  pool: pool,
   url: "ecto://postgres:postgres@localhost/ecto_test",
   size: 10)
 

--- a/integration_test/pool/pool_run.exs
+++ b/integration_test/pool/pool_run.exs
@@ -5,8 +5,15 @@ defmodule Ecto.Integration.PoolRunTest do
 
   @timeout :infinity
 
-  test "worker cleans up the connection when it crashes" do
-    {:ok, pool} = TestPool.start_link([lazy: false])
+  setup context do
+    case = context[:case]
+    test = context[:test]
+    {:ok, [pool: Module.concat(case, test)]}
+  end
+
+  test "worker cleans up the connection when it crashes", context do
+    pool = context[:pool]
+    {:ok, _} = TestPool.start_link([lazy: false, name: pool])
 
     assert {:ok, conn1} =
       TestPool.run(pool, @timeout, fn({_mod, conn1}, queue_time) ->
@@ -25,8 +32,9 @@ defmodule Ecto.Integration.PoolRunTest do
     end)
   end
 
-  test "nested run has no queue time" do
-    {:ok, pool} = TestPool.start_link([lazy: false])
+  test "nested run has no queue time", context do
+    pool = context[:pool]
+    {:ok, _} = TestPool.start_link([lazy: false, name: pool])
 
     TestPool.transaction(pool, @timeout, fn(_, _, _, _) ->
       TestPool.run(pool, @timeout, fn({_mod, _conn}, queue_time) ->
@@ -35,14 +43,16 @@ defmodule Ecto.Integration.PoolRunTest do
     end)
   end
 
-  test "disconnects if run raises" do
-    {:ok, pool} = TestPool.start_link([lazy: false])
+  test "disconnects if run raises", context do
+    pool = context[:pool]
+    {:ok, _} = TestPool.start_link([lazy: false, name: pool])
 
     assert {:ok, conn} =
       TestPool.run(pool, @timeout, fn({_mod, conn}, _) ->
         conn
       end)
 
+    monitor = Process.monitor(conn)
     assert Process.alive?(conn)
 
     try do
@@ -51,11 +61,12 @@ defmodule Ecto.Integration.PoolRunTest do
       RuntimeError -> :ok
     end
 
-    refute Process.alive?(conn)
+    assert_receive {:DOWN, ^monitor, _, _, _}
   end
 
-  test "do not disconnect if caller dies during run" do
-    {:ok, pool} = TestPool.start_link([lazy: false])
+  test "do not disconnect if caller dies during run", context do
+    pool = context[:pool]
+    {:ok, _} = TestPool.start_link([lazy: false, name: pool])
 
     _ = Process.flag(:trap_exit, true)
     parent = self()

--- a/integration_test/sojourn_broker/all_test.exs
+++ b/integration_test/sojourn_broker/all_test.exs
@@ -1,0 +1,2 @@
+Code.require_file "../pool/pool_transaction.exs", __DIR__
+Code.require_file "../pool/pool_run.exs", __DIR__

--- a/integration_test/sojourn_broker/test_helper.exs
+++ b/integration_test/sojourn_broker/test_helper.exs
@@ -1,0 +1,9 @@
+Logger.configure(level: :info)
+ExUnit.start
+
+# Load support files
+Code.require_file "../pool/pool.exs", __DIR__
+
+defmodule Ecto.Integration.TestPool do
+  use Ecto.Integration.Pool, Ecto.Adapters.SojournBroker
+end

--- a/integration_test/sojourn_broker/worker_test.exs
+++ b/integration_test/sojourn_broker/worker_test.exs
@@ -1,0 +1,46 @@
+defmodule Ecto.Integration.WorkerTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Integration.TestPool
+  alias Ecto.Integration.Pool.Connection
+
+  @timeout :infinity
+
+  setup context do
+    case = context[:case]
+    test = context[:test]
+    {:ok, [pool: Module.concat(case, test)]}
+  end
+
+  test "worker restarts connection when waiting", context do
+    pool = context[:pool]
+    {:ok, _} = TestPool.start_link([name: pool])
+
+    {:ok, conn1} = TestPool.transaction(pool, @timeout,
+      fn(_, {Connection, conn}, _, _) ->
+        conn
+      end)
+
+    await_len_r(pool, 1)
+
+    ref = Process.monitor(conn1)
+    Process.exit(conn1, :kill)
+    receive do: ({:DOWN, ^ref, _, _, _} -> :ok)
+
+    await_len_r(pool, 0)
+
+    {:ok, conn2} = TestPool.transaction(pool, @timeout,
+      fn(_, {Connection, conn}, _, _) ->
+        conn
+      end)
+
+    assert conn1 != conn2
+  end
+
+  defp await_len_r(pool, len) do
+    case :sbroker.len_r(pool, @timeout) do
+      ^len -> :ok
+      _    -> await_len_r(pool, len)
+    end
+  end
+end

--- a/lib/ecto/adapters/sojourn_broker.ex
+++ b/lib/ecto/adapters/sojourn_broker.ex
@@ -1,0 +1,100 @@
+defmodule Ecto.Adapters.SojournBroker do
+  @moduledoc """
+  Start a pool of connections using `sbroker`.
+
+  ### Options
+
+    * `:size` - The number of connections to keep in the pool (default: 10)
+    * `:min_backoff` - The minimum backoff on failed connect in milliseconds (default: 50)
+    * `:max_backoff` - The maximum backoff on failed connect in milliseconds (default: 5000)
+    * `:broker` - The `sbroker` module to use (default: `Ecto.Adapters.SojournBroker.Broker`)
+
+  """
+
+  alias Ecto.Adapters.SojournBroker.Broker
+  alias Ecto.Adapters.SojournBroker.Worker
+  @behaviour Ecto.Adapters.Pool
+
+  @doc """
+  Starts a pool of connections for the given connection module and options.
+
+    * `conn_mod` - The connection module, see `Ecto.Adapters.Connection`
+    * `opts` - The options for the pool, the broker and the connections
+
+  """
+  def start_link(conn_mod, opts) do
+    {:ok, _} = Application.ensure_all_started(:sbroker)
+    {pool_opts, opts} = split_opts(opts)
+
+    import Supervisor.Spec
+    name = Keyword.fetch!(pool_opts, :name)
+    mod = Keyword.get(pool_opts, :broker, Broker)
+    args = [{:local, name}, mod, opts, [time_unit: :micro_seconds]]
+    broker = worker(:sbroker, args)
+
+    size = Keyword.fetch!(pool_opts, :size)
+    workers = for id <- 1..size do
+      worker(Worker, [conn_mod, opts], [id: id])
+    end
+    worker_sup_opts = [strategy: :one_for_one, max_restarts: size]
+    worker_sup = supervisor(Supervisor, [workers, worker_sup_opts])
+
+
+    children = [broker, worker_sup]
+    sup_opts = [strategy: :rest_for_one, name: Module.concat(name, Supervisor)]
+    Supervisor.start_link(children, sup_opts)
+  end
+ 
+  @doc false
+  def checkout(pool, _) do
+    ask(pool, :run)
+  end
+
+  @doc false
+  def checkin(_, {worker, ref}, _) do
+    Worker.done(worker, ref)
+  end
+
+  @doc false
+  def open_transaction(pool, _) do
+    ask(pool, :transaction)
+  end
+
+  @doc false
+  def close_transaction(_, {worker, ref}, _) do
+    Worker.done(worker, ref)
+  end
+
+  @doc false
+  def break(_, {worker, ref}, timeout) do
+    Worker.break(worker, ref, timeout)
+  end
+
+  ## Helpers
+
+  defp ask(pool, fun) do
+    case :sbroker.ask(pool, {fun, self()}) do
+      {:go, ref, {worker, mod_conn}, _, queue_time} ->
+          {:ok, {worker, ref}, mod_conn, queue_time}
+      {:drop, _} ->
+        {:error, :noconnect}
+    end
+  end
+
+  ## Helpers
+
+  defp split_opts(opts) do
+    {pool_opts, opts} = Keyword.split(opts, [:size, :broker])
+
+    opts = opts
+      |> Keyword.put_new(:queue_timeout, Keyword.get(opts, :timeout, 5_000))
+      |> Keyword.put(:timeout, Keyword.get(opts, :connect_timeout, 5_000))
+
+    pool_opts = pool_opts
+      |> Keyword.put_new(:size, 10)
+      |> Keyword.put_new(:broker, Broker)
+      |> Keyword.put(:name, Keyword.fetch!(opts, :name))
+
+    {pool_opts, opts}
+  end
+end

--- a/lib/ecto/adapters/sojourn_broker/broker.ex
+++ b/lib/ecto/adapters/sojourn_broker/broker.ex
@@ -1,0 +1,28 @@
+defmodule Ecto.Adapters.SojournBroker.Broker do
+  @moduledoc """
+  Default `:sbroker` callback module.
+
+  ### Options
+
+    * `:queue_timeout` - The amount of time in milliseconds to wait in queue (default: 5000)
+    * `:queue_out` - Either `:out` for a FIFO queue or `:out_r` for a LIFO queue (default: :out)
+    * `:queue_drop` - Either `:drop` for head drop on max size or `:drop_r` for tail drop (default: :drop)
+    * `:queue_size` - The maximum size of the queue (default: 64)
+
+  """
+
+  @behaviour :sbroker
+
+  @doc false
+  def init(opts) do
+    out      = Keyword.get(opts, :queue_out, :out)
+    timeout  = Keyword.get(opts, :queue_timeout, 5_000)
+    drop     = Keyword.get(opts, :queue_drop, :drop)
+    size     = Keyword.get(opts, :queue_size, 64)
+
+    client_queue = {:sbroker_timeout_queue, {out, timeout * 1_000, drop, size}}
+    worker_queue = {:sbroker_drop_queue, {:out_r, :drop, :infinity}}
+
+    {:ok, {client_queue, worker_queue, div(timeout, 2)}}
+  end
+end

--- a/lib/ecto/adapters/sojourn_broker/worker.ex
+++ b/lib/ecto/adapters/sojourn_broker/worker.ex
@@ -1,0 +1,222 @@
+defmodule Ecto.Adapters.SojournBroker.Worker do
+  @moduledoc false
+
+  use GenServer
+  require Logger
+  use Bitwise
+
+  @timeout 5_000
+
+  @spec start_link(module, Keyword.t) :: {:ok, pid}
+  def start_link(module, params) do
+    GenServer.start_link(__MODULE__, {module, params}, [])
+  end
+
+  @spec break(pid, reference, timeout) :: :ok
+  def break(worker, ref, _) do
+    GenServer.cast(worker, {:break, ref})
+  end
+
+  @spec done(pid, reference) :: :ok
+  def done(worker, ref) do
+    GenServer.cast(worker, {:done, ref})
+  end
+
+  ## Callbacks
+
+  def init({module, opts}) do
+    Process.flag(:trap_exit, true)
+    worker_keys = [:name, :min_backoff, :max_backoff]
+    {worker_opts, params} = Keyword.split(opts, worker_keys)
+    broker = Keyword.fetch!(worker_opts, :name)
+    tag = make_ref()
+    min_backoff = Keyword.get(worker_opts, :min_backoff, 500)
+    max_backoff = Keyword.get(worker_opts, :max_backoff, 5_000)
+    backoff_threshold = div(max_backoff, 3)
+
+    s = %{conn: nil, module: module, params: params, transaction: nil,
+          broker: Process.whereis(broker), tag: tag, ref: nil, fun: nil,
+          monitor: nil, backoff: min_backoff, min_backoff: min_backoff,
+          max_backoff: max_backoff, backoff_threshold: backoff_threshold}
+    send(self(), {tag, :connect})
+    {:ok, s}
+  end
+
+  ## Break
+
+  def handle_cast({:break, ref}, %{ref: ref, conn: nil} = s) do
+    s = s
+    |> demonitor()
+    |> connect()
+    {:noreply, s}
+  end
+  def handle_cast({:break, ref}, %{ref: ref} = s) do
+    s = s
+    |> demonitor()
+    |> disconnect()
+    |> connect()
+    {:noreply, s}
+  end
+
+  ## Done
+
+  def handle_cast({:done, ref}, %{ref: ref, conn: nil} = s) do
+    s = s
+      |> demonitor()
+      |> connect()
+    {:noreply, s}
+  end
+  def handle_cast({:done, ref}, %{ref: ref} = s) do
+    s = s
+      |> demonitor()
+      |> ask()
+    {:noreply, s}
+  end
+
+  ## connnect
+
+  def handle_info({tag, :connect}, %{tag: tag, ref: nil} = s) do
+    {:noreply, connect(s)}
+  end
+
+  ## EXIT
+
+  def handle_info({:EXIT, conn, _}, %{conn: conn} = s) when is_pid(conn) do
+    {:noreply, conn_exit(s)}
+  end
+
+  ## DOWN
+
+  def handle_info({:DOWN, mon, _, _, _}, %{monitor: mon, conn: nil} = s) do
+    {:noreply, connect(%{s | monitor: nil, fun: nil, ref: nil})}
+  end
+  def handle_info({:DOWN, mon, _, _, _}, %{monitor: mon, fun: :run} = s) do
+    {:noreply, ask(%{s | fun: nil, ref: nil, monitor: nil})}
+  end
+  def handle_info({:DOWN, mon, _, _, _}, %{monitor: mon} = s) do
+    s = %{s | monitor: nil, fun: nil, ref: nil}
+    |> disconnect()
+    |> connect()
+    {:noreply, s}
+  end
+
+  ## go
+
+  def handle_info({tag, {:go, ref, info, _, _}},%{tag: tag, ref: nil} = s) do
+    {fun, pid} = info
+    mon = Process.monitor(pid)
+    {:noreply, %{s | fun: fun, ref: ref, monitor: mon}}
+  end
+
+  ## drop
+
+  def handle_info({tag, {:drop, _}}, %{tag: tag, ref: nil} = s) do
+    s = s
+      |> disconnect()
+      |> connect()
+    {:noreply, s}
+  end
+
+  ## Info
+
+  def handle_info(_info, s) do
+    {:noreply, s}
+  end
+
+  def terminate(_reason, %{conn: conn, module: module}) do
+    conn && module.disconnect(conn)
+  end
+
+  ## Helpers
+
+  defp connect(%{conn: nil} = s) do
+    %{module: module, params: params, min_backoff: min_backoff} = s
+    case module.connect(params) do
+      {:ok, conn} ->
+        ask(%{s | conn: conn, backoff: min_backoff})
+      {:error, error} ->
+        log_connect_error(error, s)
+        backoff(s)
+    end
+  end
+
+  defp ask(%{ref: nil} = s) do
+    %{broker: broker, module: module, conn: conn, tag: tag} = s
+    _ = :sbroker.async_ask_r(broker, {self(), {module, conn}}, tag)
+    s
+  end
+
+  defp log_connect_error(error, %{module: module, params: params}) do
+    Logger.error(fn() ->
+      [inspect(module), " failed to connect with parameters ", inspect(params),
+       ?\n | inspect_error(error)]
+    end)
+  end
+
+  defp inspect_error({'EXIT', reason}) do
+    Exception.format_exit(reason)
+  end
+  defp inspect_error(reason) do
+    if Exception.exception?(reason) do
+      Exception.format_banner(:error, reason)
+    else
+      Exception.format_banner(:exit, reason)
+    end
+  end
+
+  defp backoff(%{tag: tag} = s) do
+    backoff = get_backoff(s)
+    :erlang.send_after(backoff, self(), {tag, :connect})
+    %{s | backoff: backoff}
+  end
+
+  ## random backoff where the next value is uniformal distributed with
+  ## [n, 3n], unless 3n > max and then [div(max, 3), max]
+  defp get_backoff(%{threshold: 0, max_backoff: max}) do
+    max
+  end
+  defp get_backoff(%{backoff: backoff, backoff_threshold: threshold})
+  when backoff > threshold do
+    next_backoff(threshold)
+  end
+  defp get_backoff(%{backoff: backoff}) do
+    next_backoff(backoff)
+  end
+
+  defp next_backoff(backoff) do
+    width = backoff >>> 1
+    backoff + :random.uniform(width + 1) - 1
+  end
+
+  defp conn_exit(%{ref: nil} = s) do
+    case cancel_or_await(s) do
+      :cancelled ->
+        connect(%{s | conn: nil})
+      {:go, ref, {fun, pid}, _, _} ->
+        mon = Process.monitor(pid)
+        %{s | mon: mon, ref: ref, fun: fun, conn: nil}
+      {:drop, _} ->
+        connect(%{s | conn: nil})
+    end
+  end
+  defp conn_exit(s) do
+    %{s | conn: nil}
+  end
+
+  defp cancel_or_await(%{tag: tag}) do
+    case :sbroker.cancel(tag, @timeout) do
+      false -> :cancelled
+      1     -> :sbroker.await(tag, 0)
+    end
+  end
+
+  defp demonitor(%{monitor: mon} = s) do
+    Process.demonitor(mon, [:flush])
+    %{s | monitor: nil, fun: nil, ref: nil}
+  end
+
+  defp disconnect(%{module: module, conn: conn} = s) do
+    module.disconnect(conn)
+    %{s | conn: nil}
+  end
+end

--- a/lib/ecto/adapters/sojourn_broker/worker.ex
+++ b/lib/ecto/adapters/sojourn_broker/worker.ex
@@ -203,10 +203,10 @@ defmodule Ecto.Adapters.SojournBroker.Worker do
     %{s | conn: nil}
   end
 
-  defp cancel_or_await(%{tag: tag}) do
-    case :sbroker.cancel(tag, @timeout) do
-      false -> :cancelled
-      1     -> :sbroker.await(tag, 0)
+  defp cancel_or_await(%{broker: broker, tag: tag}) do
+    case :sbroker.cancel(broker, tag, @timeout) do
+      false -> :sbroker.await(tag, 0)
+      1     -> :cancelled
     end
   end
 

--- a/lib/ecto/adapters/sojourn_broker/worker.ex
+++ b/lib/ecto/adapters/sojourn_broker/worker.ex
@@ -12,6 +12,12 @@ defmodule Ecto.Adapters.SojournBroker.Worker do
     GenServer.start_link(__MODULE__, {module, params}, [])
   end
 
+  @spec mod_conn(pid, reference, timeout) ::
+    {:ok, {module, pid}} | {:error, :noconnect}
+  def mod_conn(worker, ref, timeout) do
+    GenServer.call(worker, {:mod_conn, ref}, timeout)
+  end
+
   @spec break(pid, reference, timeout) :: :ok
   def break(worker, ref, _) do
     GenServer.cast(worker, {:break, ref})
@@ -26,20 +32,37 @@ defmodule Ecto.Adapters.SojournBroker.Worker do
 
   def init({module, opts}) do
     Process.flag(:trap_exit, true)
-    worker_keys = [:name, :min_backoff, :max_backoff]
+    worker_keys = [:name, :lazy, :min_backoff, :max_backoff]
     {worker_opts, params} = Keyword.split(opts, worker_keys)
     broker = Keyword.fetch!(worker_opts, :name)
     tag = make_ref()
     min_backoff = Keyword.get(worker_opts, :min_backoff, 500)
     max_backoff = Keyword.get(worker_opts, :max_backoff, 5_000)
     backoff_threshold = div(max_backoff, 3)
+    lazy = Keyword.get(worker_opts, :lazy, true)
 
     s = %{conn: nil, module: module, params: params, transaction: nil,
           broker: Process.whereis(broker), tag: tag, ref: nil, fun: nil,
           monitor: nil, backoff: min_backoff, min_backoff: min_backoff,
-          max_backoff: max_backoff, backoff_threshold: backoff_threshold}
-    send(self(), {tag, :connect})
-    {:ok, s}
+          max_backoff: max_backoff, backoff_threshold: backoff_threshold,
+          lazy: lazy}
+
+    if lazy do
+      {:ok, lazy_ask(s)}
+    else
+      send(self(), {tag, :connect})
+      {:ok, s}
+    end
+  end
+
+  ## Module/Connection
+
+  def handle_call({:mod_conn, ref}, _, %{ref: ref, conn: nil} = s) do
+    {:reply, {:error, :noconnect}, s}
+  end
+  def handle_call({:mod_conn, ref}, _, %{ref: ref} = s) do
+    %{module: module, conn: conn} = s
+    {:reply, {:ok, {module, conn}}, s}
   end
 
   ## Break
@@ -105,11 +128,19 @@ defmodule Ecto.Adapters.SojournBroker.Worker do
   def handle_info({tag, {:go, ref, info, _, _}},%{tag: tag, ref: nil} = s) do
     {fun, pid} = info
     mon = Process.monitor(pid)
-    {:noreply, %{s | fun: fun, ref: ref, monitor: mon}}
+    s = %{s | fun: fun, ref: ref, monitor: mon}
+    if s.lazy do
+      {:noreply, lazy_connect(s)}
+    else
+      {:noreply, s}
+    end
   end
 
   ## drop
 
+  def handle_info({tag, {:drop, _}}, %{tag: tag, lazy: true} = s) do
+    {:noreply, connect(%{s | lazy: false})}
+  end
   def handle_info({tag, {:drop, _}}, %{tag: tag, ref: nil} = s) do
     s = s
       |> disconnect()
@@ -129,6 +160,17 @@ defmodule Ecto.Adapters.SojournBroker.Worker do
 
   ## Helpers
 
+  defp lazy_connect(%{lazy: true, conn: nil} = s) do
+    %{module: module, params: params} = s
+    case module.connect(params) do
+      {:ok, conn} ->
+        %{s | lazy: false, conn: conn}
+      {:error, error} ->
+        log_connect_error(error, s)
+        %{s | lazy: false}
+    end
+  end
+
   defp connect(%{conn: nil} = s) do
     %{module: module, params: params, min_backoff: min_backoff} = s
     case module.connect(params) do
@@ -138,6 +180,11 @@ defmodule Ecto.Adapters.SojournBroker.Worker do
         log_connect_error(error, s)
         backoff(s)
     end
+  end
+
+  defp lazy_ask(%{lazy: true, conn: nil, broker: broker, tag: tag} = s) do
+    _ = :sbroker.async_ask_r(broker, {self(), :lazy}, tag)
+    s
   end
 
   defp ask(%{ref: nil} = s) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Ecto.Mixfile do
 
   @version "0.14.0-dev"
   @adapters [:pg, :mysql]
-  @pools [:poolboy]
+  @pools [:poolboy, :sojourn_broker]
 
   def project do
     [app: :ecto,
@@ -34,6 +34,7 @@ defmodule Ecto.Mixfile do
 
   defp deps do
     [{:poolboy, "~> 1.4"},
+     {:sbroker, "~> 0.7"},
      {:decimal, "~> 1.0"},
      {:postgrex, "~> 0.8.3", optional: true},
      {:mariaex, "~> 0.3.0", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -33,8 +33,9 @@ defmodule Ecto.Mixfile do
   end
 
   defp deps do
+    ## TODO: make poolboy optional
     [{:poolboy, "~> 1.4"},
-     {:sbroker, "~> 0.7"},
+     {:sbroker, "~> 0.7", optional: true},
      {:decimal, "~> 1.0"},
      {:postgrex, "~> 0.8.3", optional: true},
      {:mariaex, "~> 0.3.0", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -5,4 +5,5 @@
   "mariaex": {:hex, :mariaex, "0.3.0"},
   "poison": {:hex, :poison, "1.3.1"},
   "poolboy": {:hex, :poolboy, "1.4.2"},
-  "postgrex": {:hex, :postgrex, "0.8.3"}}
+  "postgrex": {:hex, :postgrex, "0.8.3"},
+  "sbroker": {:hex, :sbroker, "0.7.0"}}


### PR DESCRIPTION
Work in progress :).

Can we drop `stop/1`? It is awkward because it does not work in a supervision tree and as #706 shows we didn't test (or use?) it. I have removed it in a separate commit for now.

Todo:

- [x] Replace use of `Connection` with `GenServer` so not to add an extra dep, was useful to get started though.
- [x] Publish the version of `:sbroker` used and update dep/mix.lock