### PR TITLE
Prevent endless recursion in Ecto.Repo.Model

### DIFF
--- a/lib/ecto/repo/model.ex
+++ b/lib/ecto/repo/model.ex
@@ -56,7 +56,7 @@ defmodule Ecto.Repo.Model do
     end
   end
 
-  def insert!(repo, adapter, %{__struct__: _} = struct, opts) do
+  def insert!(repo, adapter, %{__struct__: _} = struct, opts) when is_list(opts) do
     insert!(repo, adapter, %Changeset{model: struct, valid?: true}, opts)
   end
 
@@ -102,7 +102,7 @@ defmodule Ecto.Repo.Model do
     end
   end
 
-  def update!(repo, adapter, %{__struct__: model} = struct, opts) do
+  def update!(repo, adapter, %{__struct__: model} = struct, opts) when is_list(opts) do
     changes = Map.take(struct, model.__schema__(:fields))
 
     # Remove all primary key fields from the list of changes.
@@ -143,7 +143,7 @@ defmodule Ecto.Repo.Model do
     end
   end
 
-  def delete!(repo, adapter, %{__struct__: _} = struct, opts) do
+  def delete!(repo, adapter, %{__struct__: _} = struct, opts) when is_list(opts) do
     delete!(repo, adapter, %Changeset{model: struct, valid?: true}, opts)
   end
 


### PR DESCRIPTION
Calling `Repo.insert!/2` with second argument not being a list would force an endless recursion eating all of memory wrapping changeset in a changest in a changeset.... Quite fun when encountered.