### PR TITLE
Introduce new update syntax

### DIFF
--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -11,13 +11,14 @@ defmodule Ecto.Integration.JoinsTest do
 
   @tag :update_with_join
   test "update all with joins" do
-    user = TestRepo.insert!(%User{name: "Tester"})
-    post = TestRepo.insert!(%Post{title: "foo"})
+    user    = TestRepo.insert!(%User{name: "Tester"})
+    post    = TestRepo.insert!(%Post{title: "foo"})
     comment = TestRepo.insert!(%Comment{text: "hey", author_id: user.id, post_id: post.id})
 
-    query = from(c in Comment, join: u in User, on: u.id == c.author_id, where: c.post_id in ^[post.id])
-    assert 1 = TestRepo.update_all(query, text: "hoo")
+    query = from(c in Comment, join: u in User, on: u.id == c.author_id,
+                               where: c.post_id in ^[post.id])
 
+    assert {1, nil} = TestRepo.update_all(query, set: [text: "hoo"])
     assert %Comment{text: "hoo"} = TestRepo.get(Comment, comment.id)
   end
 
@@ -29,9 +30,9 @@ defmodule Ecto.Integration.JoinsTest do
     TestRepo.insert!(%Comment{text: "foo", author_id: user.id, post_id: post.id})
     TestRepo.insert!(%Comment{text: "bar", author_id: user.id})
 
-    query = from(c in Comment, join: u in User, on: u.id == c.author_id, where: c.post_id in ^[post.id])
-    assert 2 = TestRepo.delete_all(query)
-
+    query = from(c in Comment, join: u in User, on: u.id == c.author_id,
+                               where: c.post_id in ^[post.id])
+    assert {2, nil} = TestRepo.delete_all(query)
     assert [%Comment{}] = TestRepo.all(Comment)
   end
 

--- a/integration_test/sql/escape.exs
+++ b/integration_test/sql/escape.exs
@@ -29,13 +29,15 @@ defmodule Ecto.Integration.EscapeTest do
 
   test "Repo.update_all escape" do
     TestRepo.insert!(%Post{title: "hello"})
-    TestRepo.update_all(Post, title: "'")
+    TestRepo.update_all(Post, set: [title: "'"])
 
-    query = from(p in Post, select: p.title)
-    assert ["'"] == TestRepo.all(query)
+    reader = from(p in Post, select: p.title)
+    assert ["'"] == TestRepo.all(reader)
 
-    TestRepo.update_all(from(Post, where: "'" != ""), title: "''")
-    assert ["''"] == TestRepo.all(query)
+    query = from(Post, where: "'" != "")
+    TestRepo.update_all(query, set: [title: "''"])
+
+    assert ["''"] == TestRepo.all(reader)
   end
 
   test "Repo.delete_all escape" do

--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -54,25 +54,28 @@ defmodule Ecto.Adapter do
   @doc """
   Fetches all results from the data store based on the given query.
   """
-  defcallback all(repo, query :: Ecto.Query.t, params :: list(), options) :: [[term]] | no_return
+  defcallback all(repo, query :: Ecto.Query.t,
+                  params :: list(), options) :: [[term]] | no_return
 
   @doc """
-  Updates all entities matching the given query with the values given. The
-  query shall only have `where` expressions and a single `from` expression. Returns
-  the number of affected entities.
+  Updates all entities matching the given query with the values given.
+
+  The query shall only have `where` and `join` expressions and a
+  single `from` expression. It returns a tuple containing the number
+  of entries and any returned result as second element
   """
   defcallback update_all(repo, query :: Ecto.Query.t,
-                         updates :: Keyword.t, params :: list(),
-                         options) :: integer | no_return
+                         params :: list(), options) :: {integer, nil} | no_return
 
   @doc """
   Deletes all entities matching the given query.
 
-  The query shall only have `where` expressions and a `from` expression.
-  Returns the number of affected entities.
+  The query shall only have `where` and `join` expressions and a
+  single `from` expression. It returns a tuple containing the number
+  of entries and any returned result as second element
   """
   defcallback delete_all(repo, query :: Ecto.Query.t,
-                         params :: list(), options :: Keyword.t) :: integer | no_return
+                         params :: list(), options :: Keyword.t) :: {integer, nil} | no_return
 
   @doc """
   Inserts a single new model in the data store.

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -56,8 +56,8 @@ defmodule Ecto.Adapters.SQL do
       end
 
       @doc false
-      def update_all(repo, query, values, params, opts) do
-        Ecto.Adapters.SQL.count_all(repo, @conn.update_all(query, values), params, opts)
+      def update_all(repo, query, params, opts) do
+        Ecto.Adapters.SQL.count_all(repo, @conn.update_all(query), params, opts)
       end
 
       @doc false
@@ -128,7 +128,7 @@ defmodule Ecto.Adapters.SQL do
         count > 0
       end
 
-      defoverridable [all: 4, update_all: 5, delete_all: 4,
+      defoverridable [all: 4, update_all: 4, delete_all: 4,
                       insert: 6, update: 7, delete: 5,
                       execute_ddl: 3, ddl_exists?: 3]
     end
@@ -444,7 +444,7 @@ defmodule Ecto.Adapters.SQL do
   @doc false
   def count_all(repo, sql, params, opts) do
     %{num_rows: num} = query(repo, sql, params, opts)
-    num
+    {num, nil}
   end
 
   @doc false

--- a/lib/ecto/adapters/sql/query.ex
+++ b/lib/ecto/adapters/sql/query.ex
@@ -32,7 +32,7 @@ defmodule Ecto.Adapters.SQL.Query do
   @doc """
   Receives a query and values to update and must return an UPDATE query.
   """
-  defcallback update_all(Ecto.Query.t, values :: Keyword.t) :: String.t
+  defcallback update_all(Ecto.Query.t) :: String.t
 
   @doc """
   Receives a query and must return a DELETE query.

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -142,7 +142,7 @@ defmodule Ecto.Query do
   """
 
   defstruct [sources: nil, from: nil, joins: [], wheres: [], select: nil,
-             order_bys: [], limit: nil, offset: nil, group_bys: [],
+             order_bys: [], limit: nil, offset: nil, group_bys: [], updates: [],
              havings: [], preloads: [], assocs: [], distinct: nil, lock: nil]
   @opaque t :: %__MODULE__{}
 
@@ -180,6 +180,7 @@ defmodule Ecto.Query do
   alias Ecto.Query.Builder.Preload
   alias Ecto.Query.Builder.Join
   alias Ecto.Query.Builder.Lock
+  alias Ecto.Query.Builder.Update
 
   @doc """
   Resets a previously set field on a query.
@@ -262,7 +263,8 @@ defmodule Ecto.Query do
     from(kw, __CALLER__, count_bind, quoted, binds)
   end
 
-  @binds    [:where, :select, :distinct, :order_by, :group_by, :having, :limit, :offset, :preload]
+  @binds    [:where, :select, :distinct, :order_by, :group_by,
+             :having, :limit, :offset, :preload, :update]
   @no_binds [:lock]
   @joins    [:join, :inner_join, :left_join, :right_join, :full_join]
 
@@ -562,6 +564,35 @@ defmodule Ecto.Query do
   """
   defmacro lock(query, expr) do
     Lock.build(query, expr, __CALLER__)
+  end
+
+  @doc ~S"""
+  An update query expression.
+
+  Updates are used to update the filtered entries. In order for
+  updates to be applied, `Ecto.Repo.update_all/3` must be invoked.
+
+  ## Keywords examples
+
+      from(u in User, update: [set: [name: "new name"]]
+
+  ## Expressions examples
+
+      User |> update([u], set: [name: "new name"])
+
+  ## Operators
+
+  Different databases support different operators. In the example above,
+  we have uset `:set` which sets a new value in the selected models. Most
+  databases support `:inc` too, that increaments a given field by a given
+  value:
+
+      User |> update([u], inc: [accesses: 1])
+
+  Check your database and adapters to know more about supported operators.
+  """
+  defmacro update(query, binding, expr) do
+    Update.build(query, binding, expr, __CALLER__)
   end
 
   @doc """

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -61,6 +61,10 @@ defmodule Ecto.Query.Builder do
     {expr, params}
   end
 
+  def escape({:-, _, [number]}, _type, params, _vars, _env) when is_number(number) do
+    {-number, params}
+  end
+
   # fragments
   def escape({:fragment, meta, [query]}, _type, params, vars, env) when is_list(query) do
     {escaped, params} = Enum.map_reduce(query, params, &escape_fragment(&1, :any, &2, vars, env))
@@ -419,6 +423,10 @@ defmodule Ecto.Query.Builder do
       _      -> {:array, :any}
     end
   end
+
+  # Negative numbers
+  def quoted_type({:-, _, [number]}, _vars) when is_integer(number), do: :integer
+  def quoted_type({:-, _, [number]}, _vars) when is_float(number), do: :float
 
   # Literals
   def quoted_type(literal, _vars) when is_float(literal),   do: :float

--- a/lib/ecto/query/builder/update.ex
+++ b/lib/ecto/query/builder/update.ex
@@ -7,34 +7,55 @@ defmodule Ecto.Query.Builder.Update do
   Escapes a list of quoted expressions.
 
       iex> escape([], [], __ENV__)
-      {[], %{}}
+      {[], [], %{}}
 
       iex> escape([set: []], [], __ENV__)
-      {[set: []], %{}}
+      {[set: []], [], %{}}
 
       iex> escape([set: [foo: 1]], [], __ENV__)
-      {[set: [foo: 1]], %{}}
+      {[set: [foo: 1]], [], %{}}
+
+      iex> escape(quote(do: ^[set: []]), [], __ENV__)
+      {[], [set: []], %{}}
+
+      iex> escape(quote(do: [set: ^[foo: 1]]), [], __ENV__)
+      {[], [set: [foo: 1]], %{}}
 
       iex> escape(quote(do: [set: [foo: ^1]]), [], __ENV__)
-      {[set: [foo: {:{}, [], [:^, [], [0]]}]], %{0 => {1, {0, :foo}}}}
+      {[set: [foo: {:{}, [], [:^, [], [0]]}]], [], %{0 => {1, {0, :foo}}}}
 
   """
-  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, %{}}
+  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, Macro.t, %{}}
   def escape(expr, vars, env) when is_list(expr) do
-    Enum.map_reduce expr, %{}, fn
-      {k, v}, acc when is_atom(k) and is_list(v) ->
-        {v, params} = escape_each(k, v, acc, vars, env)
-        {{k, v}, params}
-      _, _acc ->
-        error! expr
-    end
+    escape_op(expr, [], [], %{}, vars, env)
+  end
+
+  def escape({:^, _, [v]}, _vars, _env) do
+    {[], v, %{}}
   end
 
   def escape(expr, _vars, _env) do
-    error! expr
+    compile_error!(expr)
   end
 
-  defp escape_each(key, kw, params, vars, env) do
+  defp escape_op([{k, v}|t], compile, runtime, params, vars, env) when is_atom(k) and is_list(v) do
+    {v, params} = escape_field(k, v, params, vars, env)
+    escape_op(t, [{k, v}|compile], runtime, params, vars, env)
+  end
+
+  defp escape_op([{k, {:^, _, [v]}}|t], compile, runtime, params, vars, env) when is_atom(k) do
+    escape_op(t, compile, [{k, v}|runtime], params, vars, env)
+  end
+
+  defp escape_op([], compile, runtime, params, _vars, _env) do
+    {Enum.reverse(compile), Enum.reverse(runtime), params}
+  end
+
+  defp escape_op(expr, _compile, _runtime, _params, _vars, _env) do
+    compile_error!(expr)
+  end
+
+  defp escape_field(key, kw, params, vars, env) do
     Enum.map_reduce kw, params, fn
       {k, v}, acc when is_atom(k) ->
         {v, params} = Builder.escape(v, {0, k}, acc, vars, env)
@@ -45,9 +66,9 @@ defmodule Ecto.Query.Builder.Update do
     end
   end
 
-  defp error!(expr) do
+  defp compile_error!(expr) do
     Builder.error! "malformed update `#{Macro.to_string(expr)}` in query expression, " <>
-                   "expected a keyword list with lists as values"
+                   "expected a keyword list with lists or interpolated expressions as values"
   end
 
   @doc """
@@ -59,16 +80,35 @@ defmodule Ecto.Query.Builder.Update do
   """
   @spec build(Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
   def build(query, binding, expr, env) do
-    binding        = Builder.escape_binding(binding)
-    {expr, params} = escape(expr, binding, env)
-    params         = Builder.escape_params(params)
+    binding = Builder.escape_binding(binding)
+    {compile, runtime, params} = escape(expr, binding, env)
 
-    distinct = quote do: %Ecto.Query.QueryExpr{
-                           expr: unquote(expr),
-                           params: unquote(params),
-                           file: unquote(env.file),
-                           line: unquote(env.line)}
-    Builder.apply_query(query, __MODULE__, [distinct], env)
+    query =
+      if compile == [] do
+        query
+      else
+        params = Builder.escape_params(params)
+
+        update = quote do
+          %Ecto.Query.QueryExpr{expr: unquote(compile), params: unquote(params),
+                                file: unquote(env.file), line: unquote(env.line)}
+        end
+
+        Builder.apply_query(query, __MODULE__, [update], env)
+      end
+
+    query =
+      if runtime == [] do
+        query
+      else
+        update = quote do
+          Ecto.Query.Builder.Update.runtime(unquote(runtime), unquote(env.line), unquote(env.file))
+        end
+
+        Builder.apply_query(query, __MODULE__, [update], env)
+      end
+
+    query
   end
 
   @doc """
@@ -78,5 +118,45 @@ defmodule Ecto.Query.Builder.Update do
   def apply(query, updates) do
     query = Ecto.Queryable.to_query(query)
     %{query | updates: [updates|query.updates]}
+  end
+
+  @doc """
+  If there are interpolated updates at compile time,
+  we need to handle them at runtime. We do such in
+  this callback.
+  """
+  @spec runtime(term, line :: integer, file :: binary) :: Ecto.Query.t
+  def runtime(runtime, line, file) when is_list(runtime) do
+    {runtime, {params, _count}} =
+      Enum.map_reduce runtime, {[], 0}, fn
+        {k, v}, acc when is_atom(k) and is_list(v) ->
+          {v, params} = runtime_field(k, v, acc)
+          {{k, v}, params}
+        _, _acc ->
+          runtime_error! runtime
+      end
+
+    %Ecto.Query.QueryExpr{expr: runtime, params: Enum.reverse(params),
+                          file: file, line: line}
+  end
+
+  def runtime(runtime, _line, _file) do
+    runtime_error!(runtime)
+  end
+
+  defp runtime_field(key, kw, acc) do
+    Enum.map_reduce kw, acc, fn
+      {k, v}, {params, count} when is_atom(k) ->
+        params = [{v, {0, k}}|params]
+        {{k, {:^, [], [count]}}, {params, count+1}}
+      _, _acc ->
+        Builder.error! "malformed #{inspect key} in update `#{inspect(kw)}`, " <>
+                       "expected a keyword list"
+    end
+  end
+
+  defp runtime_error!(value) do
+    Builder.error! "malformed update `#{inspect(value)}` in query expression, " <>
+                   "expected a keyword list with lists or interpolated expressions as values"
   end
 end

--- a/lib/ecto/query/builder/update.ex
+++ b/lib/ecto/query/builder/update.ex
@@ -1,0 +1,82 @@
+defmodule Ecto.Query.Builder.Update do
+  @moduledoc false
+
+  alias Ecto.Query.Builder
+
+  @doc """
+  Escapes a list of quoted expressions.
+
+      iex> escape([], [], __ENV__)
+      {[], %{}}
+
+      iex> escape([set: []], [], __ENV__)
+      {[set: []], %{}}
+
+      iex> escape([set: [foo: 1]], [], __ENV__)
+      {[set: [foo: 1]], %{}}
+
+      iex> escape(quote(do: [set: [foo: ^1]]), [], __ENV__)
+      {[set: [foo: {:{}, [], [:^, [], [0]]}]], %{0 => {1, {0, :foo}}}}
+
+  """
+  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, %{}}
+  def escape(expr, vars, env) when is_list(expr) do
+    Enum.map_reduce expr, %{}, fn
+      {k, v}, acc when is_atom(k) and is_list(v) ->
+        {v, params} = escape_each(k, v, acc, vars, env)
+        {{k, v}, params}
+      _, _acc ->
+        error! expr
+    end
+  end
+
+  def escape(expr, _vars, _env) do
+    error! expr
+  end
+
+  defp escape_each(key, kw, params, vars, env) do
+    Enum.map_reduce kw, params, fn
+      {k, v}, acc when is_atom(k) ->
+        {v, params} = Builder.escape(v, {0, k}, acc, vars, env)
+        {{k, v}, params}
+      _, _acc ->
+        Builder.error! "malformed #{inspect key} in update `#{Macro.to_string(kw)}`, " <>
+                       "expected a keyword list"
+    end
+  end
+
+  defp error!(expr) do
+    Builder.error! "malformed update `#{Macro.to_string(expr)}` in query expression, " <>
+                   "expected a keyword list with lists as values"
+  end
+
+  @doc """
+  Builds a quoted expression.
+
+  The quoted expression should evaluate to a query at runtime.
+  If possible, it does all calculations at compile time to avoid
+  runtime work.
+  """
+  @spec build(Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  def build(query, binding, expr, env) do
+    binding        = Builder.escape_binding(binding)
+    {expr, params} = escape(expr, binding, env)
+    params         = Builder.escape_params(params)
+
+    distinct = quote do: %Ecto.Query.QueryExpr{
+                           expr: unquote(expr),
+                           params: unquote(params),
+                           file: unquote(env.file),
+                           line: unquote(env.line)}
+    Builder.apply_query(query, __MODULE__, [distinct], env)
+  end
+
+  @doc """
+  The callback applied by `build/4` to build the query.
+  """
+  @spec apply(Ecto.Queryable.t, term) :: Ecto.Query.t
+  def apply(query, updates) do
+    query = Ecto.Queryable.to_query(query)
+    %{query | updates: [updates|query.updates]}
+  end
+end

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -41,6 +41,7 @@ defimpl Inspect, for: Ecto.Query do
     group_bys = kw_exprs(:group_by, query.group_bys, names)
     havings   = kw_exprs(:having, Enum.reverse(query.havings), names)
     order_bys = kw_exprs(:order_by, query.order_bys, names)
+    updates   = kw_exprs(:update, Enum.reverse(query.updates), names)
 
     lock      = kw_inspect(:lock, query.lock)
     limit     = kw_expr(:limit, query.limit, names)
@@ -49,7 +50,7 @@ defimpl Inspect, for: Ecto.Query do
     distinct  = kw_expr(:distinct, query.distinct, names)
 
     Enum.concat [from, joins, wheres, group_bys, havings, order_bys,
-                 limit, offset, lock, distinct, select, preloads, assocs]
+                 limit, offset, lock, distinct, updates, select, preloads, assocs]
   end
 
   defp bound_from(from, name), do: ["from #{name} in #{unbound_from from}"]

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -5,14 +5,14 @@ defmodule Ecto.Query.Planner do
   alias Ecto.Query.SelectExpr
   alias Ecto.Query.JoinExpr
 
-  if map_size(%Ecto.Query{}) != 15 do
+  if map_size(%Ecto.Query{}) != 16 do
     raise "Ecto.Query match out of date in builder"
   end
 
   @doc """
   Validates and cast the given fields belonging to the given model.
   """
-  def fields(kind, model, kw, id_types) do
+  def fields(model, kind, kw, id_types) do
     types = model.__changeset__
 
     for {field, value} <- kw do
@@ -61,9 +61,9 @@ defmodule Ecto.Query.Planner do
   The cache value is the compiled query by the adapter
   along-side the select expression.
   """
-  def query(query, base, id_types, opts \\ []) do
-    {query, params} = prepare(query, base, id_types)
-    {normalize(query, base, opts), params}
+  def query(query, operation, base, id_types) do
+    {query, params} = prepare(query, operation, base, id_types)
+    {normalize(query, operation, base), params}
   end
 
   @doc """
@@ -76,10 +76,10 @@ defmodule Ecto.Query.Planner do
   This function is called by the backend before invoking
   any cache mechanism.
   """
-  def prepare(query, params, id_types) do
+  def prepare(query, operation, params, id_types) do
     query
     |> prepare_sources
-    |> prepare_params(params, id_types)
+    |> prepare_params(operation, params, id_types)
   rescue
     e ->
       # Reraise errors so we ignore the planner inner stacktrace
@@ -89,12 +89,13 @@ defmodule Ecto.Query.Planner do
   @doc """
   Prepare the parameters by merging and casting them according to sources.
   """
-  def prepare_params(query, base, id_types) do
-    {query, params} = traverse_exprs(query, [], &{&3, merge_params(&1, &2, &3, &4, id_types)})
+  def prepare_params(query, operation, base, id_types) do
+    {query, params} = traverse_exprs(query, operation, [], &{&3, merge_params(&1, &2, &3, &4, id_types)})
     {query, base ++ Enum.reverse(params)}
   end
 
-  defp merge_params(kind, query, expr, params, id_types) when kind in ~w(select distinct limit offset)a do
+  defp merge_params(kind, query, expr, params, id_types)
+      when kind in ~w(select distinct limit offset)a do
     if expr do
       cast_and_merge_params(kind, query, expr, params, id_types)
     else
@@ -102,7 +103,8 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp merge_params(kind, query, exprs, acc, id_types) when kind in ~w(where group_by having order_by)a do
+  defp merge_params(kind, query, exprs, acc, id_types)
+      when kind in ~w(where update group_by having order_by)a do
     Enum.reduce exprs, acc, fn expr, params ->
       cast_and_merge_params(kind, query, expr, params, id_types)
     end
@@ -127,7 +129,7 @@ defmodule Ecto.Query.Planner do
     {model, field, type} = type_from_param!(kind, query, expr, type)
     type = Ecto.Type.normalize(type, id_types)
 
-    case cast_param(type, v) do
+    case cast_param(kind, type, v) do
       {:ok, v} ->
         Ecto.Type.dump!(type, v)
       {:match, type} ->
@@ -145,11 +147,11 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp cast_param(_type, nil) do
+  defp cast_param(kind, _type, nil) when kind != :update do
     :error
   end
 
-  defp cast_param(type, v) do
+  defp cast_param(_kind, type, v) do
     # If the type is a primitive type and we are giving it
     # a struct, we first check if the struct type and the
     # given type are match and, if so, use the struct type
@@ -298,17 +300,21 @@ defmodule Ecto.Query.Planner do
   entry, we need to update its interpolations and check
   its fields and associations exist and are valid.
   """
-  def normalize(query, base, opts) do
-    only_filters = Keyword.get(opts, :only_filters)
-
-    if only_filters do
-      assert_filtered_expressions!(query, only_filters)
+  def normalize(query, operation, base) do
+    case operation do
+      :all ->
+        assert_no_update!(query, operation)
+      :update_all ->
+        assert_filter_expressions!(query, operation)
+      :delete_all ->
+        assert_no_update!(query, operation)
+        assert_filter_expressions!(query, operation)
     end
 
     query
-    |> traverse_exprs(length(base), &validate_and_increment/4)
+    |> traverse_exprs(operation, length(base), &validate_and_increment/4)
     |> elem(0)
-    |> normalize_select(only_filters)
+    |> normalize_select(operation)
     |> validate_assocs
   rescue
     e ->
@@ -316,27 +322,34 @@ defmodule Ecto.Query.Planner do
       raise e
   end
 
-  defp validate_and_increment(kind, query, expr, counter) when kind in ~w(select distinct limit offset)a do
+  defp validate_and_increment(kind, query, expr, counter)
+      when kind in ~w(select distinct limit offset)a do
     if expr do
-      do_validate_and_increment(kind, query, expr, counter)
+      validate_and_increment_each(kind, query, expr, counter)
     else
       {nil, counter}
     end
   end
 
-  defp validate_and_increment(kind, query, exprs, counter) when kind in ~w(where group_by having order_by)a do
-    Enum.map_reduce exprs, counter, &do_validate_and_increment(kind, query, &1, &2)
+  defp validate_and_increment(kind, query, exprs, counter)
+      when kind in ~w(where group_by having order_by update)a do
+    Enum.map_reduce exprs, counter, &validate_and_increment_each(kind, query, &1, &2)
   end
 
   defp validate_and_increment(:join, query, exprs, counter) do
     Enum.map_reduce exprs, counter, fn join, acc ->
-      {on, acc} = do_validate_and_increment(:join, query, join.on, acc)
+      {on, acc} = validate_and_increment_each(:join, query, join.on, acc)
       {%{join | on: on}, acc}
     end
   end
 
-  defp do_validate_and_increment(kind, query, expr, counter) do
-    {inner, acc} = Macro.prewalk expr.expr, counter, fn
+  defp validate_and_increment_each(kind, query, expr, counter) do
+    {inner, acc} = validate_and_increment_each(kind, query, expr, expr.expr, counter)
+    {%{expr | expr: inner, params: nil}, acc}
+  end
+
+  defp validate_and_increment_each(kind, query, expr, ast, counter) do
+    Macro.prewalk ast, counter, fn
       {:in, in_meta, [left, {:^, meta, [param]}]}, acc ->
         {right, acc} = validate_in(meta, expr, param, acc)
         {{:in, in_meta, [left, right]}, acc}
@@ -356,7 +369,6 @@ defmodule Ecto.Query.Planner do
       other, acc ->
         {other, acc}
     end
-    {%{expr | expr: inner, params: nil}, acc}
   end
 
   defp validate_in(meta, expr, param, acc) do
@@ -385,9 +397,9 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp normalize_select(query, only_filters) do
+  defp normalize_select(query, operation) do
     cond do
-      only_filters ->
+      operation in [:update_all, :delete_all] ->
         query
       select = query.select ->
         %{query | select: normalize_fields(query, select)}
@@ -489,8 +501,13 @@ defmodule Ecto.Query.Planner do
 
   # Traverse all query components with expressions.
   # Therefore from, preload, assocs and lock are not traversed.
-  defp traverse_exprs(original, acc, fun) do
+  defp traverse_exprs(original, operation, acc, fun) do
     query = original
+
+    if operation == :update_all do
+      {updates, acc} = fun.(:update, original, original.updates, acc)
+      query = %{query | updates: updates}
+    end
 
     {select, acc} = fun.(:select, original, original.select, acc)
     query = %{query | select: select}
@@ -545,23 +562,22 @@ defmodule Ecto.Query.Planner do
     {nil, nil, type}
   end
 
-  def cast!(query, expr, message) do
-    message =
-      [message: message, query: query, file: expr.file, line: expr.line]
-      |> Ecto.QueryError.exception()
-      |> Exception.message
-
-    raise Ecto.CastError, message: message
+  defp assert_no_update!(query, operation) do
+    case query do
+      %Ecto.Query{updates: []} -> query
+      _ ->
+        error! query, "`#{operation}` does not allow `update` expressions"
+    end
   end
 
-  defp assert_filtered_expressions!(query, context) do
+  defp assert_filter_expressions!(query, operation) do
     case query do
       %Ecto.Query{select: nil, order_bys: [], limit: nil, offset: nil,
                   group_bys: [], havings: [], preloads: [], assocs: [],
                   distinct: nil, lock: nil} ->
         query
       _ ->
-        error! query, "`#{context}` allows only `where` and `join` expressions"
+        error! query, "`#{operation}` allows only `where` and `join` expressions"
     end
   end
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -118,9 +118,8 @@ defmodule Ecto.Repo do
         Ecto.Repo.Queryable.one!(__MODULE__, @adapter, queryable, opts)
       end
 
-      defmacro update_all(queryable, values, opts \\ []) do
-        Ecto.Repo.Queryable.update_all(__MODULE__, @adapter, queryable,
-                                       values, opts)
+      def update_all(queryable, updates, opts \\ []) do
+        Ecto.Repo.Queryable.update_all(__MODULE__, @adapter, queryable, updates, opts)
       end
 
       def delete_all(queryable, opts \\ []) do
@@ -330,6 +329,11 @@ defmodule Ecto.Repo do
   @doc """
   Updates all entries matching the given query with the given values.
 
+  It returns a tuple containing the number of entries
+  and any returned result as second element. If the database
+  does not support RETURNING in UPDATE statements or no
+  return result was selected, the second element will be nil.
+
   This operation does not run the model `before_update` and
   `after_update` callbacks.
 
@@ -341,17 +345,25 @@ defmodule Ecto.Repo do
 
   ## Examples
 
-      MyRepo.update_all(Post, title: "New title")
+      MyRepo.update_all(Post, set: [title: "New title"])
 
-      MyRepo.update_all(p in Post, visits: fragment("? + 1", p.visits))
+      MyRepo.update_all(Post, inc: [visits: 1])
 
       from(p in Post, where: p.id < 10)
-      |> MyRepo.update_all(title: "New title")
+      |> MyRepo.update_all(set: [title: "New title"])
+
+      from(p in Post, where: p.id < 10, update: [set: [title: "New title"]])
+      |> MyRepo.update_all([])
   """
-  defmacrocallback update_all(Macro.t, Keyword.t, Keyword.t) :: integer | no_return
+  defcallback update_all(Macro.t, Keyword.t, Keyword.t) :: {integer, nil} | no_return
 
   @doc """
   Deletes all entries matching the given query.
+
+  It returns a tuple containing the number of entries
+  and any returned result as second element. If the database
+  does not support RETURNING in DELETE statements or no
+  return result was selected, the second element will be nil.
 
   This operation does not run the model `before_delete` and
   `after_delete` callbacks.
@@ -368,7 +380,7 @@ defmodule Ecto.Repo do
 
       from(p in Post, where: p.id < 10) |> MyRepo.delete_all
   """
-  defcallback delete_all(Ecto.Queryable.t, Keyword.t) :: integer | no_return
+  defcallback delete_all(Ecto.Queryable.t, Keyword.t) :: {integer, nil} | no_return
 
   @doc """
   Inserts a model or a changeset.

--- a/lib/ecto/repo/model.ex
+++ b/lib/ecto/repo/model.ex
@@ -83,7 +83,7 @@ defmodule Ecto.Repo.Model do
       changes   = validate_changes(:update, changeset, model, fields, id_types)
 
       filters = add_pk_filter!(changeset.filters, struct)
-      filters = Planner.fields(:update, model, filters, id_types)
+      filters = Planner.fields(model, :update, filters, id_types)
 
       values =
         if changes != [] do
@@ -130,7 +130,7 @@ defmodule Ecto.Repo.Model do
       changeset = Callbacks.__apply__(model, :before_delete, changeset)
 
       filters = add_pk_filter!(changeset.filters, struct)
-      filters = Planner.fields(:delete, model, filters, adapter.id_types(repo))
+      filters = Planner.fields(model, :delete, filters, adapter.id_types(repo))
 
       case adapter.delete(repo, source, filters, autogen, opts) do
         {:ok, _} -> nil
@@ -215,7 +215,7 @@ defmodule Ecto.Repo.Model do
   end
 
   defp validate_changes(kind, changeset, model, fields, id_types) do
-    Planner.fields(kind, model, Map.take(changeset.changes, fields), id_types)
+    Planner.fields(model, kind, Map.take(changeset.changes, fields), id_types)
   end
 
   defp add_pk_filter!(filters, struct) do

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -80,11 +80,11 @@ defmodule Ecto.Repo.Queryable do
       update_all(repo, adapter, query, opts)
     else
       raise ArgumentError, """
-      You are using the old update syntax. Instead of:
+      You are using the deprecated update syntax. Instead of:
 
           Repo.update_all queryable, foo: "bar"
 
-      One shuold write:
+      One should write:
 
           Repo.update_all queryable,
             set: [foo: "bar"]

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -17,7 +17,7 @@ defmodule Ecto.Repo.Queryable do
 
     {query, params} =
       Queryable.to_query(queryable)
-      |> Planner.query([], id_types)
+      |> Planner.query(:all, [], id_types)
 
     adapter.all(repo, query, params, opts)
     |> Ecto.Repo.Assoc.query(query)
@@ -105,7 +105,7 @@ defmodule Ecto.Repo.Queryable do
 
     {query, params} =
       Queryable.to_query(queryable)
-      |> Planner.query(params, id_types, only_filters: :update_all)
+      |> Planner.query(:update_all, params, id_types)
     adapter.update_all(repo, query, updates, params, opts)
   end
 
@@ -115,7 +115,7 @@ defmodule Ecto.Repo.Queryable do
   def delete_all(repo, adapter, queryable, opts) when is_list(opts) do
     {query, params} =
       Queryable.to_query(queryable)
-      |> Planner.query([], adapter.id_types(repo), only_filters: :delete_all)
+      |> Planner.query(:delete_all, [], adapter.id_types(repo))
     adapter.delete_all(repo, query, params, opts)
   end
 

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -42,9 +42,9 @@ defmodule Ecto.Adapters.MySQLTest do
     end
   end
 
-  defp normalize(query) do
-    {query, _params} = Ecto.Query.Planner.prepare(query, [], %{})
-    Ecto.Query.Planner.normalize(query, [], [])
+  defp normalize(query, operation \\ :all) do
+    {query, _params} = Ecto.Query.Planner.prepare(query, operation, [], %{})
+    Ecto.Query.Planner.normalize(query, operation, [])
   end
 
   test "from" do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -280,30 +280,36 @@ defmodule Ecto.Adapters.MySQLTest do
   ## *_all
 
   test "update all" do
-    query = Model |> Queryable.to_query |> normalize
-    assert SQL.update_all(query, [x: 0]) ==
-           ~s{UPDATE `model` AS m0 SET m0.`x` = 0}
+    query = from(m in Model, update: [set: [x: 0]]) |> normalize(:update_all)
+    assert SQL.update_all(query) ==
+           ~s{UPDATE `model` AS m0 SET `x` = 0}
 
-    query = from(e in Model, where: e.x == 123) |> normalize
-    assert SQL.update_all(query, [x: 0]) ==
-           ~s{UPDATE `model` AS m0 SET m0.`x` = 0 WHERE (m0.`x` = 123)}
+    query = from(m in Model, update: [set: [x: 0], inc: [y: 1, z: -3]]) |> normalize(:update_all)
+    assert SQL.update_all(query) ==
+           ~s{UPDATE `model` AS m0 SET `x` = 0, `y` = `y` + 1, `z` = `z` + -3}
 
-    query = Model |> Queryable.to_query |> normalize
-    assert SQL.update_all(query, [x: 0, y: "123"]) ==
-           ~s{UPDATE `model` AS m0 SET m0.`x` = 0, m0.`y` = '123'}
+    query = from(e in Model, where: e.x == 123, update: [set: [x: 0]]) |> normalize(:update_all)
+    assert SQL.update_all(query) ==
+           ~s{UPDATE `model` AS m0 SET `x` = 0 WHERE (m0.`x` = 123)}
 
-    query = Model |> Queryable.to_query |> normalize
-    assert SQL.update_all(query, [x: quote(do: ^0)]) ==
-           ~s{UPDATE `model` AS m0 SET m0.`x` = ?}
+    query = from(m in Model, update: [set: [x: 0, y: "123"]]) |> normalize(:update_all)
+    assert SQL.update_all(query) ==
+           ~s{UPDATE `model` AS m0 SET `x` = 0, `y` = '123'}
 
-    query = Model |> join(:inner, [p], q in Model2, p.x == q.z) |> normalize
-    assert SQL.update_all(query, [x: 0]) ==
-           ~s{UPDATE `model` AS m0 INNER JOIN `model2` AS m1 ON m0.`x` = m1.`z` SET m0.`x` = 0}
+    query = from(m in Model, update: [set: [x: ^0]]) |> normalize(:update_all)
+    assert SQL.update_all(query) ==
+           ~s{UPDATE `model` AS m0 SET `x` = ?}
 
-    query = from(e in Model, where: e.x == 123, join: q in Model2, on: e.x == q.z) |> normalize
-    assert SQL.update_all(query, [x: 0]) ==
-           ~s{UPDATE `model` AS m0 INNER JOIN `model2` AS m1 ON m0.`x` = m1.`z`} <>
-           ~s{ SET m0.`x` = 0 WHERE (m0.`x` = 123)}
+    query = Model |> join(:inner, [p], q in Model2, p.x == q.z)
+                  |> update([_], set: [x: 0]) |> normalize(:update_all)
+    assert SQL.update_all(query) ==
+           ~s{UPDATE `model` AS m0 INNER JOIN `model2` AS m1 ON m0.`x` = m1.`z` SET `x` = 0}
+
+    query = from(e in Model, where: e.x == 123, update: [set: [x: 0]],
+                             join: q in Model2, on: e.x == q.z) |> normalize(:update_all)
+    assert SQL.update_all(query) ==
+           ~s{UPDATE `model` AS m0 INNER JOIN `model2` AS m1 ON m0.`x` = m1.`z` } <>
+           ~s{SET `x` = 0 WHERE (m0.`x` = 123)}
   end
 
   test "delete all" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -45,9 +45,9 @@ defmodule Ecto.Adapters.PostgresTest do
     end
   end
 
-  defp normalize(query) do
-    {query, _params} = Ecto.Query.Planner.prepare(query, [], %{})
-    Ecto.Query.Planner.normalize(query, [], [])
+  defp normalize(query, operation \\ :all) do
+    {query, _params} = Ecto.Query.Planner.prepare(query, operation, [], %{})
+    Ecto.Query.Planner.normalize(query, operation, [])
   end
 
   test "from" do

--- a/test/ecto/query/builder/update_test.exs
+++ b/test/ecto/query/builder/update_test.exs
@@ -1,12 +1,51 @@
 defmodule Ecto.Query.Builder.UpdateTest do
   use ExUnit.Case, async: true
 
+  import Ecto.Query
   import Ecto.Query.Builder.Update
   doctest Ecto.Query.Builder.Update
 
   test "escape" do
-    assert {Macro.escape(quote do [set: [foo: &0.bar]] end), %{}} ==
+    assert {Macro.escape(quote do [set: [foo: &0.bar]] end), [], %{}} ==
            escape(quote do [set: [foo: x.bar]] end, [x: 0], __ENV__)
+  end
+
+  test "escape with compile time interpolation" do
+    query = "foo" |> update([_], set: [foo: ^"foo"])
+    [compile] = query.updates
+    assert compile.expr == [set: [foo: {:^, [], [0]}]]
+    assert compile.params == [{"foo", {0, :foo}}]
+
+    query = "foo" |> update([_], set: [foo: ^"foo", bar: ^"bar"])
+    [compile] = query.updates
+    assert compile.expr == [set: [foo: {:^, [], [0]}, bar: {:^, [], [1]}]]
+    assert compile.params == [{"foo", {0, :foo}}, {"bar", {0, :bar}}]
+  end
+
+  test "escape with runtime time interpolation" do
+    query = "foo" |> update([_], ^[set: [foo: "foo", bar: "bar"]])
+    [runtime] = query.updates
+    assert runtime.expr == [set: [foo: {:^, [], [0]}, bar: {:^, [], [1]}]]
+    assert runtime.params == [{"foo", {0, :foo}}, {"bar", {0, :bar}}]
+
+    query = "foo" |> update([_], set: ^[foo: "foo"])
+    [runtime] = query.updates
+    assert runtime.expr == [set: [foo: {:^, [], [0]}]]
+    assert runtime.params == [{"foo", {0, :foo}}]
+
+    query = "foo" |> update([_], set: ^[foo: "foo"], inc: ^[bar: "bar"])
+    [runtime] = query.updates
+    assert runtime.expr == [set: [foo: {:^, [], [0]}], inc: [bar: {:^, [], [1]}]]
+    assert runtime.params == [{"foo", {0, :foo}}, {"bar", {0, :bar}}]
+  end
+
+  test "escape with both compile and runtime time interpolation" do
+    query = "foo" |> update([_], set: ^[foo: "foo"], inc: [bar: ^"bar"])
+    [runtime, compile] = query.updates
+    assert runtime.expr == [set: [foo: {:^, [], [0]}]]
+    assert runtime.params == [{"foo", {0, :foo}}]
+    assert compile.expr == [inc: [bar: {:^, [], [0]}]]
+    assert compile.params == [{"bar", {0, :bar}}]
   end
 
   test "keyword lists are expected" do

--- a/test/ecto/query/builder/update_test.exs
+++ b/test/ecto/query/builder/update_test.exs
@@ -1,0 +1,23 @@
+defmodule Ecto.Query.Builder.UpdateTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Query.Builder.Update
+  doctest Ecto.Query.Builder.Update
+
+  test "escape" do
+    assert {Macro.escape(quote do [set: [foo: &0.bar]] end), %{}} ==
+           escape(quote do [set: [foo: x.bar]] end, [x: 0], __ENV__)
+  end
+
+  test "keyword lists are expected" do
+    assert_raise Ecto.Query.CompileError,
+                 ~r"malformed update `\[1\]` in query expression", fn ->
+      escape(quote do [1] end, [], __ENV__)
+    end
+
+    assert_raise Ecto.Query.CompileError,
+                 ~r"malformed :set in update `\[1\]`, expected a keyword list", fn ->
+      escape(quote do [set: [1]] end, [], __ENV__)
+    end
+  end
+end

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -194,9 +194,9 @@ defmodule Ecto.Query.InspectTest do
 
   def normalize(query) do
     query
-    |> Ecto.Query.Planner.prepare([], %{})
+    |> Ecto.Query.Planner.prepare(:all, [], %{})
     |> elem(0)
-    |> Ecto.Query.Planner.normalize([], [])
+    |> Ecto.Query.Planner.normalize(:all, [])
   end
 
   def i(query) do

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -123,14 +123,16 @@ defmodule Ecto.Query.InspectTest do
     string = """
     from p in Inspect.Post, join: c in assoc(p, :comments), where: true,
     group_by: [p.id], having: true, order_by: [asc: p.id], limit: 1,
-    offset: 1, lock: "FOO", distinct: [1], select: 1, preload: [:likes], preload: [comments: c]
+    offset: 1, lock: "FOO", distinct: [1], update: [set: [id: ^3]], select: 1,
+    preload: [:likes], preload: [comments: c]
     """
     |> String.rstrip
     |> String.replace("\n", " ")
 
     assert i(from(x in Post, join: y in assoc(x, :comments), where: true, group_by: x.id,
                              having: true, order_by: x.id, limit: 1, offset: 1,
-                             lock: "FOO", select: 1, distinct: 1, preload: [:likes, comments: y])) == string
+                             lock: "FOO", select: 1, distinct: 1,
+                             update: [set: [id: ^3]], preload: [:likes, comments: y])) == string
   end
 
   test "to_string all" do
@@ -145,6 +147,7 @@ defmodule Ecto.Query.InspectTest do
       offset: 1,
       lock: "FOO",
       distinct: [1],
+      update: [set: [id: 3]],
       select: 1,
       preload: [:likes],
       preload: [comments: c]
@@ -153,7 +156,7 @@ defmodule Ecto.Query.InspectTest do
 
     assert Inspect.Ecto.Query.to_string(
       from(x in Post, join: y in assoc(x, :comments), where: true, group_by: x.id,
-                      having: true, order_by: x.id, limit: 1, offset: 1,
+                      having: true, order_by: x.id, limit: 1, offset: 1, update: [set: [id: 3]],
                       lock: "FOO", distinct: 1, select: 1, preload: [:likes, comments: y])
     ) == string
   end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -348,10 +348,21 @@ defmodule Ecto.Query.PlannerTest do
     end
   end
 
-  test "normalize: update all only allow filters" do
+  test "normalize: update all only allow filters and checks updates" do
+    message = ~r"`update_all` requires at least one field to be updated"
+    assert_raise Ecto.QueryError, message, fn ->
+      from(p in Post, select: p, update: []) |> normalize(:update_all, [])
+    end
+
+    message = ~r"duplicate field `title` for `update_all`"
+    assert_raise Ecto.QueryError, message, fn ->
+      from(p in Post, select: p, update: [set: [title: "foo", title: "bar"]])
+      |> normalize(:update_all, [])
+    end
+
     message = ~r"`update_all` allows only `where` and `join` expressions in query"
     assert_raise Ecto.QueryError, message, fn ->
-      from(p in Post, select: p) |> normalize(:update_all, [])
+      from(p in Post, select: p, update: [set: [title: "foo"]]) |> normalize(:update_all, [])
     end
   end
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -35,18 +35,18 @@ defmodule Ecto.Query.PlannerTest do
     end
   end
 
-  defp prepare(query, params \\ []) do
-    Planner.prepare(query, params, %{binary_id: Ecto.UUID})
+  defp prepare(query, operation \\ :all, params \\ []) do
+    Planner.prepare(query, operation, params, %{binary_id: Ecto.UUID})
   end
 
-  defp normalize(query, params \\ [], opts \\ []) do
-    {query, params} = prepare(query, params)
-    Planner.normalize(query, params, opts)
+  defp normalize(query, operation \\ :all, params \\ []) do
+    {query, params} = prepare(query, operation, params)
+    Planner.normalize(query, operation, params)
   end
 
   defp normalize_with_params(query) do
-    {query, params} = prepare(query, [])
-    {Planner.normalize(query, [], []), params}
+    {query, params} = prepare(query, :all, [])
+    {Planner.normalize(query, :all, []), params}
   end
 
   test "prepare: merges all parameters" do
@@ -140,6 +140,17 @@ defmodule Ecto.Query.PlannerTest do
 
     {_query, params} = prepare(Post |> where([p], p.code in ^["abcd"]))
     assert params == [%Ecto.Query.Tagged{tag: nil, type: :binary, value: "abcd"}]
+  end
+
+  test "prepare: casts values on update_all" do
+    {_query, params} = prepare(Post |> update([p], set: [id: ^"1"]), :update_all)
+    assert params == [1]
+
+    {_query, params} = prepare(Post |> update([p], set: [title: ^nil]), :update_all)
+    assert params == [%Ecto.Query.Tagged{type: :string, value: nil}]
+
+    {_query, params} = prepare(Post |> update([p], set: [title: nil]), :update_all)
+    assert params == []
   end
 
   test "prepare: joins" do
@@ -306,17 +317,6 @@ defmodule Ecto.Query.PlannerTest do
             {{:., [], [{:&, [], [0]}, :title]}, [ecto_type: :string], []}]
   end
 
-  test "normalize: only filters" do
-    query = from(Post, []) |> normalize([], only_filters: :sample)
-    assert is_nil query.select
-
-    message = ~r"`sample` allows only `where` and `join` expressions in query"
-    assert_raise Ecto.QueryError, message, fn ->
-      query = from(p in Post, select: p)
-      normalize(query, [], only_filters: :sample)
-    end
-  end
-
   test "normalize: preload" do
     message = ~r"the binding used in `from` must be selected in `select` when using `preload`"
     assert_raise Ecto.QueryError, message, fn ->
@@ -338,6 +338,32 @@ defmodule Ecto.Query.PlannerTest do
     assert_raise Ecto.QueryError, message, fn ->
       query = from(p in Post, right_join: c in assoc(p, :comments), preload: [comments: c])
       normalize(query)
+    end
+  end
+
+  test "normalize: all does not allow updates" do
+    message = ~r"`all` does not allow `update` expressions"
+    assert_raise Ecto.QueryError, message, fn ->
+      from(p in Post, update: [set: [name: "foo"]]) |> normalize(:all, [])
+    end
+  end
+
+  test "normalize: update all only allow filters" do
+    message = ~r"`update_all` allows only `where` and `join` expressions in query"
+    assert_raise Ecto.QueryError, message, fn ->
+      from(p in Post, select: p) |> normalize(:update_all, [])
+    end
+  end
+
+  test "normalize: delete all only allow filters and forbids updates" do
+    message = ~r"`delete_all` does not allow `update` expressions"
+    assert_raise Ecto.QueryError, message, fn ->
+      from(p in Post, update: [set: [name: "foo"]]) |> normalize(:delete_all, [])
+    end
+
+    message = ~r"`delete_all` allows only `where` and `join` expressions in query"
+    assert_raise Ecto.QueryError, message, fn ->
+      from(p in Post, select: p) |> normalize(:delete_all, [])
     end
   end
 end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -110,39 +110,18 @@ defmodule Ecto.RepoTest do
 
   test "repo validates update_all" do
     # Success
-    MockRepo.update_all(e in MyModel, x: nil)
-    MockRepo.update_all(e in MyModel, x: e.x)
-    MockRepo.update_all(e in MyModel, x: "123")
-    MockRepo.update_all(MyModel, x: "123")
-    MockRepo.update_all("my_model", x: "123")
+    MockRepo.update_all(MyModel, set: [x: "321"])
 
-    query = from(e in MyModel, where: e.x == "123")
-    MockRepo.update_all(query, x: "")
+    query = from(e in MyModel, where: e.x == "123", update: [set: [x: "321"]])
+    MockRepo.update_all(query, [])
 
     # Failures
-    message = "no fields given to `update_all`"
-    assert_raise ArgumentError, message, fn ->
-      MockRepo.update_all(from(e in MyModel, select: e), [])
+    assert_raise Ecto.QueryError, fn ->
+      MockRepo.update_all from(e in MyModel, select: e), set: [x: "321"]
     end
 
-    assert_raise ArgumentError, "value `123` in `update_all` cannot be cast to type :string", fn ->
-      MockRepo.update_all(p in MyModel, x: ^123)
-    end
-
-    message = ~r"`update_all` allows only `where` and `join` expressions in query"
-    assert_raise Ecto.QueryError, message, fn ->
-      MockRepo.update_all(from(e in MyModel, order_by: e.x), x: "123")
-    end
-
-    message = "field `Ecto.RepoTest.MyModel.w` in `update_all` does not exist in the model source"
-    assert_raise Ecto.ChangeError, message, fn ->
-      MockRepo.update_all(MyModel, w: "123")
-    end
-
-    message = "field `Ecto.RepoTest.MyModel.y` in `update_all` does not type check. " <>
-              "It has type :binary but a type :string was given"
-    assert_raise Ecto.ChangeError, message, fn ->
-      MockRepo.update_all(MyModel, y: "123")
+    assert_raise Ecto.QueryError, fn ->
+      MockRepo.update_all from(e in MyModel, order_by: e.x), set: [x: "321"]
     end
   end
 

--- a/test/support/mock_repo.exs
+++ b/test/support/mock_repo.exs
@@ -13,8 +13,8 @@ defmodule Ecto.MockAdapter do
   def all(_repo, _query, _params, _opts),
     do: [[1]]
 
-  def update_all(_repo, _query, _values, _params, _opts), do: 1
-  def delete_all(_repo, _query, _params, _opts), do: 1
+  def update_all(_repo, _query, _params, _opts), do: {1, nil}
+  def delete_all(_repo, _query, _params, _opts), do: {1, nil}
 
   ## Model
 


### PR DESCRIPTION
Closes #704.

It also changes the return type from for both `update_all` and `delete_all` to a tuple.

This pull request is almost ready, we just need to:

* [x] Print updates in inspect
* [x] Update the query planner to raise on empty updates and on duplicated columns