### PR TITLE
Allow Date/DateTime to cast 1digit month/day strings

### DIFF
--- a/lib/ecto/datetime.ex
+++ b/lib/ecto/datetime.ex
@@ -84,6 +84,12 @@ defmodule Ecto.Date do
   """
   def cast(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes>>),
     do: from_parts(to_i(year), to_i(month), to_i(day))
+  def cast(<<year::4-bytes, ?-, month::2-bytes, ?-, day::1-bytes>>),
+    do: from_parts(to_i(year), to_i(month), to_i(day))
+  def cast(<<year::4-bytes, ?-, month::1-bytes, ?-, day::2-bytes>>),
+    do: from_parts(to_i(year), to_i(month), to_i(day))
+  def cast(<<year::4-bytes, ?-, month::1-bytes, ?-, day::1-bytes>>),
+    do: from_parts(to_i(year), to_i(month), to_i(day))
   def cast(%Ecto.Date{} = d),
     do: {:ok, d}
   def cast(%{"year" => year, "month" => month, "day" => day}),

--- a/test/ecto/datetime_test.exs
+++ b/test/ecto/datetime_test.exs
@@ -8,6 +8,9 @@ defmodule Ecto.DateTest do
   end
 
   test "cast strings" do
+    assert Ecto.Date.cast("2015-8-31") == {:ok, %Ecto.Date{year: 2015, month: 8,  day: 31}}
+    assert Ecto.Date.cast("2015-12-5") == {:ok, %Ecto.Date{year: 2015, month: 12, day: 5}}
+    assert Ecto.Date.cast("2015-3-8")  == {:ok, %Ecto.Date{year: 2015, month: 3,  day: 8}}
     assert Ecto.Date.cast("2015-12-31") == {:ok, @date}
     assert Ecto.Date.cast("2015-00-23") == :error
     assert Ecto.Date.cast("2015-13-23") == :error


### PR DESCRIPTION
Minor improvement on `cast` to handle 1 digit month/day strings.
Since is pretty common to have strings like `"2015-8-5"`