### PR TITLE
Do not execute update callbacks for empty changesets by default.

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -425,6 +425,10 @@ defmodule Ecto.Repo do
 
   ## Options
 
+    * `:force` - By default, if there are no changes in the changeset,
+      `update!` is a no-op. By setting this option to true, update
+      callbacks will always be executed, even if there are no changes
+      (including timestamps).
     * `:timeout` - The time in milliseconds to wait for the call to finish,
       `:infinity` will wait indefinitely (default: 5000);
     * `:log` - When false, does not log the query

--- a/test/ecto/model/callbacks_test.exs
+++ b/test/ecto/model/callbacks_test.exs
@@ -143,6 +143,24 @@ defmodule Ecto.Model.CallbacksTest do
     assert model.z == ""
   end
 
+  test "before_update and after_update with empty changeset" do
+    changeset = Ecto.Changeset.change(%AllCallback{id: 1, x: "x", y: "z"}, %{})
+    model = MockRepo.update! changeset
+    assert model.before == nil
+    assert model.after == nil
+    assert model.x == "x"
+    assert model.y == "z"
+    assert model.z == ""
+
+    changeset = Ecto.Changeset.change(%AllCallback{id: 1, x: "x", y: "z"}, %{})
+    model = MockRepo.update! changeset, force: true
+    assert model.before == %{}
+    assert model.after == %{}
+    assert model.x == "x"
+    assert model.y == "z"
+    assert model.z == ""
+  end
+
   test "before_insert and after_insert with id in changeset" do
     changeset = Ecto.Changeset.cast(%AllCallback{},
                                     %{"id" => 1}, ~w(id), ~w())


### PR DESCRIPTION
As per the discussion on #733, here is another attempt at #731.