### PR TITLE
Flatten transactions

### DIFF
--- a/integration_test/pool/pool_run.exs
+++ b/integration_test/pool/pool_run.exs
@@ -35,26 +35,7 @@ defmodule Ecto.Integration.PoolRunTest do
     end)
   end
 
-  test "disconnects if run raises" do
-    {:ok, pool} = TestPool.start_link([lazy: false])
-
-    assert {:ok, conn} =
-      TestPool.run(pool, @timeout, fn({_mod, conn}, _) ->
-        conn
-      end)
-
-    assert Process.alive?(conn)
-
-    try do
-      TestPool.run(pool, @timeout, fn(_, _) -> raise "oops" end)
-    rescue
-      RuntimeError -> :ok
-    end
-
-    refute Process.alive?(conn)
-  end
-
-  test "do not disconnect if caller dies during run" do
+  test "does not disconnect if caller dies during run" do
     {:ok, pool} = TestPool.start_link([lazy: false])
 
     _ = Process.flag(:trap_exit, true)

--- a/integration_test/poolboy/lazy_test.exs
+++ b/integration_test/poolboy/lazy_test.exs
@@ -13,7 +13,7 @@ defmodule Ecto.Integration.LazyTest do
     refute :sys.get_state(worker).conn
     :poolboy.checkin(pool, worker)
 
-    TestPool.transaction(pool, @timeout, fn(_, {Connection, conn}, _, _) ->
+    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {Connection, conn}, _) ->
       assert Process.alive?(conn)
     end)
   end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -470,7 +470,14 @@ defmodule Ecto.Repo do
   and return the value given to `rollback` as `{:error, value}`.
 
   A successful transaction returns the value returned by the function
-  wrapped in a tuple as `{:ok, value}`. Transactions can be nested.
+  wrapped in a tuple as `{:ok, value}`.
+
+  If `transaction/2` is called inside another transaction, the function
+  is simply executed, without wrapping the new transaction call in any
+  way. In fact, calling `rollback/1` inside the inner transaction will
+  propagate until the parent one. Finally, if there is an error in the
+  inner transaction and the error is rescued, the whole outer transaction
+  is marked as tainted, guaranteeing nothing will be comitted.
 
   ## Options
 


### PR DESCRIPTION
/cc @MSch @fishcakez 

This is almost ready, I need to refactor the code and clean some tests that rely on depth, but it is almost all there. Feedback is welcome.

The only thing up to discussion is this test:

https://github.com/elixir-lang/ecto/blob/master/integration_test/sql/transaction.exs#L71

Because the inner transaction fails and we rescue it, we need to make sure all operations inside the parent transaction still fails. Today we fail with `:noconnect` but that is a lie because the connection is there, we have just marked it as tainted. We could raise a specific error though. If so, which?

@fishcakez I would merge your PR before merging this so you don't have to rebase it one more time. Although I think little should be affected.