### PR TITLE
Fix validate_unique

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -843,7 +843,7 @@ defmodule Ecto.Changeset do
     if Enum.any?(fields, &Map.has_key?(changes, &1)) &&
        Enum.all?(fields, &not Keyword.has_key?(errors, &1)) do
       struct = model.__struct__
-      value  = Map.get(changes, field)
+      value  = get_field(changeset, field)
       query  = from m in struct, select: field(m, ^field), limit: 1
 
       if scope do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -665,19 +665,29 @@ defmodule Ecto.ChangesetTest do
       def all(query) do
         assert query.wheres |> Enum.count == 2
         query_strings =  query.wheres |> Enum.map(&Macro.to_string(&1.expr))
-        assert ("&0.title() == ^0" in query_strings) or
-               ("is_nil(&0.title())" in query_strings)
+        case Process.get(:compare_type) do
+          :value -> assert ("&0.title() == ^0" in query_strings)
+          nil    -> assert ("is_nil(&0.title())" in query_strings)
+        end
         assert "&0.body() == ^0" in query_strings
         assert query.limit.expr == 1
         Process.get(:scope_query)
       end
     end
 
+
+    Process.put(:compare_type, :value)
     Process.put(:scope_query, [])
     changeset =
       changeset(%{"title" => "hello", "body" => "world"})
       |> validate_unique(:title, scope: [:body], on: ScopeRepo)
     assert changeset.valid?
+    assert changeset.errors == []
+    assert changeset.validations == [title: {:unique, [scope: [:body], on: ScopeRepo]}]
+
+    changeset =
+      changeset(%{"body" => "world"}, %Post{title: "hello"})
+      |> validate_unique(:title, scope: [:body], on: ScopeRepo)
     assert changeset.errors == []
     assert changeset.validations == [title: {:unique, [scope: [:body], on: ScopeRepo]}]
 
@@ -694,8 +704,15 @@ defmodule Ecto.ChangesetTest do
       |> validate_unique(:title, scope: [:body], on: ScopeRepo, message: "yada")
     assert changeset.errors == [title: "yada"]
 
+    Process.put(:compare_type, nil)
     changeset =
       changeset(%{"body" => "world"}) # Also validates when only scope changes
+      |> validate_unique(:title, scope: [:body], on: ScopeRepo)
+    assert changeset.errors == [title: "has already been taken"]
+    assert changeset.validations == [title: {:unique, [scope: [:body], on: ScopeRepo]}]
+
+    changeset =
+      changeset(%{"body" => "world"}, %Post{title: nil})
       |> validate_unique(:title, scope: [:body], on: ScopeRepo)
     assert changeset.errors == [title: "has already been taken"]
     assert changeset.validations == [title: {:unique, [scope: [:body], on: ScopeRepo]}]


### PR DESCRIPTION
I fixed an error in the `validate_unique` validation.
It wasn't checking the model's value. If there were no changes in the field and we had a record in the database with the value `null` for this field, it would result in a validation error, even though the model had the non unique value.

If there were no changes in the field, it would always validate like `is_nil(field(m, ^field))`