### PR TITLE
Decode result sets outside of pool

### DIFF
--- a/integration_test/pg/deadlock_test.exs
+++ b/integration_test/pg/deadlock_test.exs
@@ -75,7 +75,7 @@ defmodule Ecto.Integration.DeadlockTest do
   end
 
   defp pg_advisory_xact_lock(key) do
-    %{rows: [{:void}]} =
+    %{rows: [[:void]]} =
       Ecto.Adapters.SQL.query(PoolRepo, "SELECT pg_advisory_xact_lock($1);", [key])
   end
 end

--- a/integration_test/sql/transaction.exs
+++ b/integration_test/sql/transaction.exs
@@ -229,15 +229,6 @@ defmodule Ecto.Integration.TransactionTest do
   test "transaction exit includes :timeout on query timeout" do
     assert match?({:timeout, _},
       catch_exit(PoolRepo.transaction(fn ->
-        PoolRepo.insert!(%Trans{text: "12"}, [timeout: 0])
-      end)))
-
-    assert [] = PoolRepo.all(Trans)
-  end
-
-  test "transaction exit includes :timeout on nested query timeout" do
-    assert match?({:timeout, _},
-      catch_exit(PoolRepo.transaction(fn ->
         PoolRepo.transaction(fn ->
           PoolRepo.insert!(%Trans{text: "13"}, [timeout: 0])
         end)

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -22,16 +22,15 @@ if Code.ensure_loaded?(Mariaex.Connection) do
         value -> value
       end
 
-      case Mariaex.Connection.query(conn, sql, params, opts) do
-        {:ok, %Mariaex.Result{} = result} -> {:ok, Map.from_struct(result)}
-        {:error, %Mariaex.Error{}} =  err -> err
-      end
+      Mariaex.Connection.query(conn, sql, params, [decode: :manual] ++ opts)
     end
 
-    def decode({:ok, %{rows: rows} = res}, mapper) when is_list(rows) do
-      {:ok, %{res | rows: Enum.map(rows, mapper)}}
+    def decode({:ok, res}, mapper) do
+      {:ok, Mariaex.Connection.decode(res, mapper) |> Map.from_struct}
     end
-    def decode(other, _mapper), do: other
+    def decode({:error, _} = err, _mapper) do
+      err
+    end
 
     defp normalize_port(port) when is_binary(port), do: String.to_integer(port)
     defp normalize_port(port) when is_integer(port), do: port

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -28,6 +28,11 @@ if Code.ensure_loaded?(Mariaex.Connection) do
       end
     end
 
+    def decode({:ok, %{rows: rows} = res}, mapper) when is_list(rows) do
+      {:ok, %{res | rows: Enum.map(rows, mapper)}}
+    end
+    def decode(other, _mapper), do: other
+
     defp normalize_port(port) when is_binary(port), do: String.to_integer(port)
     defp normalize_port(port) when is_integer(port), do: port
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -28,10 +28,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
         value -> value
       end
 
-      case Postgrex.Connection.query(conn, sql, params, [decode: :manual] ++ opts) do
-        {:ok, %Postgrex.Result{} = result} -> {:ok, result}
-        {:error, %Postgrex.Error{}} = err  -> err
-      end
+      Postgrex.Connection.query(conn, sql, params, [decode: :manual] ++ opts)
     end
 
     def decode({:ok, res}, mapper) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -28,10 +28,17 @@ if Code.ensure_loaded?(Postgrex.Connection) do
         value -> value
       end
 
-      case Postgrex.Connection.query(conn, sql, params, opts) do
-        {:ok, %Postgrex.Result{} = result} -> {:ok, Map.from_struct(result)}
+      case Postgrex.Connection.query(conn, sql, params, [decode: :manual] ++ opts) do
+        {:ok, %Postgrex.Result{} = result} -> {:ok, result}
         {:error, %Postgrex.Error{}} = err  -> err
       end
+    end
+
+    def decode({:ok, res}, mapper) do
+      {:ok, Postgrex.Connection.decode(res, mapper) |> Map.from_struct}
+    end
+    def decode({:error, _} = err, _mapper) do
+      err
     end
 
     defp normalize_port(port) when is_binary(port), do: String.to_integer(port)

--- a/lib/ecto/adapters/sql/query.ex
+++ b/lib/ecto/adapters/sql/query.ex
@@ -6,6 +6,9 @@ defmodule Ecto.Adapters.SQL.Query do
 
   use Behaviour
 
+  @type result :: {:ok, %{rows: nil | [tuple], num_rows: non_neg_integer}} |
+                  {:error, Exception.t}
+
   @doc """
   Executes the given query with params in connection.
 
@@ -19,8 +22,12 @@ defmodule Ecto.Adapters.SQL.Query do
       as result (but still yields the number of affected rows,
       like a `delete` command without returning would)
   """
-  defcallback query(pid, query :: binary, params :: list(), opts :: Keyword.t) ::
-              {:ok, %{rows: nil | [tuple], num_rows: non_neg_integer}} | {:error, Exception.t}
+  defcallback query(pid, query :: binary, params :: list(), opts :: Keyword.t) :: result
+
+  @doc """
+  Decodes the given result set given the mapper function.
+  """
+  defcallback decode(result, mapper :: (term -> term)) :: result
 
   ## Queries
 

--- a/lib/ecto/schema/serializer.ex
+++ b/lib/ecto/schema/serializer.ex
@@ -27,11 +27,11 @@ defmodule Ecto.Schema.Serializer do
     end)
   end
 
-  defp do_load(struct, fields, {idx, values}, id_types) when is_integer(idx) and is_tuple(values) do
-    Enum.reduce(fields, {struct, idx}, fn
-      {field, type}, {acc, idx} ->
-        value = Ecto.Type.load!(type, elem(values, idx), id_types)
-        {Map.put(acc, field, value), idx + 1}
+  defp do_load(struct, fields, list, id_types) when is_list(list) do
+    Enum.reduce(fields, {struct, list}, fn
+      {field, type}, {acc, [h|t]} ->
+        value = Ecto.Type.load!(type, h, id_types)
+        {Map.put(acc, field, value), t}
     end) |> elem(0)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Ecto.Mixfile do
     [{:poolboy, "~> 1.4"},
      {:sbroker, "~> 0.7", optional: true},
      {:decimal, "~> 1.0"},
-     {:postgrex, "~> 0.8.3", optional: true, github: "ericmj/postgrex"},
+     {:postgrex, "~> 0.9.0", optional: true},
      {:mariaex, "~> 0.4.1", optional: true},
      {:poison, "~> 1.0", optional: true},
      {:ex_doc, "~> 0.7", only: :docs},

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Ecto.Mixfile do
      {:sbroker, "~> 0.7", optional: true},
      {:decimal, "~> 1.0"},
      {:postgrex, "~> 0.8.3", optional: true, github: "ericmj/postgrex"},
-     {:mariaex, "~> 0.4.0", optional: true},
+     {:mariaex, "~> 0.4.1", optional: true},
      {:poison, "~> 1.0", optional: true},
      {:ex_doc, "~> 0.7", only: :docs},
      {:earmark, "~> 0.1", only: :docs},

--- a/mix.exs
+++ b/mix.exs
@@ -35,12 +35,11 @@ defmodule Ecto.Mixfile do
   end
 
   defp deps do
-    ## TODO: make poolboy optional
     [{:poolboy, "~> 1.4"},
      {:sbroker, "~> 0.7", optional: true},
      {:decimal, "~> 1.0"},
-     {:postgrex, "~> 0.8.3", optional: true},
-     {:mariaex, "~> 0.3.0", optional: true},
+     {:postgrex, "~> 0.8.3", optional: true, github: "ericmj/postgrex"},
+     {:mariaex, "~> 0.4.0", optional: true},
      {:poison, "~> 1.0", optional: true},
      {:ex_doc, "~> 0.7", only: :docs},
      {:earmark, "~> 0.1", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.7.3"},
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
-  "mariaex": {:hex, :mariaex, "0.4.0"},
+  "mariaex": {:hex, :mariaex, "0.4.1"},
   "poison": {:hex, :poison, "1.3.1"},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:git, "https://github.com/ericmj/postgrex.git", "9a1d11258f56ac852c7aff6b0883dd863f8c16b7", []},

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,5 @@
   "mariaex": {:hex, :mariaex, "0.4.1"},
   "poison": {:hex, :poison, "1.3.1"},
   "poolboy": {:hex, :poolboy, "1.4.2"},
-  "postgrex": {:git, "https://github.com/ericmj/postgrex.git", "9a1d11258f56ac852c7aff6b0883dd863f8c16b7", []},
+  "postgrex": {:hex, :postgrex, "0.9.0"},
   "sbroker": {:hex, :sbroker, "0.7.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -2,8 +2,8 @@
   "earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.7.3"},
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
-  "mariaex": {:hex, :mariaex, "0.3.0"},
+  "mariaex": {:hex, :mariaex, "0.4.0"},
   "poison": {:hex, :poison, "1.3.1"},
   "poolboy": {:hex, :poolboy, "1.4.2"},
-  "postgrex": {:hex, :postgrex, "0.8.3"},
+  "postgrex": {:git, "https://github.com/ericmj/postgrex.git", "9a1d11258f56ac852c7aff6b0883dd863f8c16b7", []},
   "sbroker": {:hex, :sbroker, "0.7.0"}}

--- a/test/ecto/model/callbacks_test.exs
+++ b/test/ecto/model/callbacks_test.exs
@@ -178,7 +178,7 @@ defmodule Ecto.Model.CallbacksTest do
   end
 
   test "after_load with model" do
-    model = Ecto.Schema.Serializer.load!(AllCallback, "hello", {2, {nil, nil, 1, "x", "y", "z"}}, %{})
+    model = Ecto.Schema.Serializer.load!(AllCallback, "hello", [1, "x", "y", "z"], %{})
     assert model.id == 1
     assert model.xyz == "xyz"
     assert model.__meta__ == %Ecto.Schema.Metadata{source: "hello", state: :loaded}


### PR DESCRIPTION
Hello @elixir-lang/ecto-adapters and @liveforeverx.

* [x] Postgres
* [x] MySQL
* [ ] MSSQL
* [ ] SQLite3
* [ ] MongoDB

This pull request introduces two big changes to adapters in Ecto:

1. Now we expect result sets to return a list of lists instead of lists of tuples

2. We now support decoding queries outside of the connection and outside of the pool, this means we will hold the connection for shorter period of times

Changing 1 is straight-forward but cumbersome. Changing 2 is a bit more complex so let's talk about it more.

You will notice that we now require a new function to be implemented by SQL adapters called `decode/2`, this function will receive the result set returned by `query/4` and a mapper function invoked when traversing the result. The idea is that adapters should be able to return a result set without being decoded so we can do it later on **once**, after putting the connection back in the pool.

Here is how the changes for the Postgres adapter look like: https://github.com/elixir-lang/ecto/commit/54429aa4397d41a11e5d00faa677fa2c164dacbf#diff-ee25bf8df5589fbf812f652738bfbdae

In order to support this feature, we did two changes to the Postgres driver:

1. First we moved the response decoding from server to client: https://github.com/ericmj/postgrex/commit/c99653c2e07bcc4030661f9d824836d076fc10d0

2. Then we allow the decoding to be controlled with an option: https://github.com/ericmj/postgrex/commit/2ea75b9e8f51ed79f02597fedda50e532d70a234

If for some reason you can't do client side decoding, you can emulate it (but we don't recommend it), which is what the MySQL adapter does today (we will change it soon™):

https://github.com/elixir-lang/ecto/commit/54429aa4397d41a11e5d00faa677fa2c164dacbf#diff-975ad8a7b1f8e27ac59595bcdbdd0a07R31

If you have any questions, please let me know!