### PR TITLE
added a commented description to the has_many/has_one :through example of Schema

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -478,6 +478,13 @@ defmodule Ecto.Schema do
           has_one :permalink, Permalink
           has_many :comments_authors, through: [:comments, :author]
 
+          # From the has_many :through example above, in the list
+          # `[:comments, :author]` the `:comments` refers to the
+          # `has_many :comments` in the Post model's own schema
+          # and the `:author` refers to the `belongs_to :author`
+          # of the Comment module's schema below.
+          # (see the description below for more details)
+
           # Specify the association with custom source
           has_many :tags, {"posts_tags", Tag}
         end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -476,14 +476,15 @@ defmodule Ecto.Schema do
         schema "posts" do
           has_many :comments, Comment
           has_one :permalink, Permalink
-          has_many :comments_authors, through: [:comments, :author]
 
-          # From the has_many :through example above, in the list
+          # In the has_many :through example below, in the list
           # `[:comments, :author]` the `:comments` refers to the
           # `has_many :comments` in the Post model's own schema
           # and the `:author` refers to the `belongs_to :author`
-          # of the Comment module's schema below.
+          # of the Comment module's schema (the module below).
           # (see the description below for more details)
+
+          has_many :comments_authors, through: [:comments, :author]
 
           # Specify the association with custom source
           has_many :tags, {"posts_tags", Tag}


### PR DESCRIPTION
After some confusion about has_many/has_one :through I was requested to improve the has_many/has_one :through documentation. Hopefully the comment will prevent other people from having the same issue.