### PR TITLE
Log DB's connection ids

### DIFF
--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -1,4 +1,4 @@
-Logger.configure(level: :info)
+Logger.configure(level: :debug)
 ExUnit.start exclude: [:array_type, :read_after_writes, :case_sensitive,
                        :uses_usec, :strict_savepoint]
 

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -1,4 +1,4 @@
-Logger.configure(level: :info)
+Logger.configure(level: :debug)
 ExUnit.start
 
 # Configure Ecto for support and tests

--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -39,6 +39,8 @@ defmodule Ecto.Adapter do
   defcallback start_link(repo, options) ::
               {:ok, pid} | :ok | {:error, {:already_started, pid}} | {:error, term}
 
+  defcallback fetch_conn_id(pid) :: {:ok, term} | :ignore | {:error, term}
+
   @doc """
   Returns the binary id type for this adapter.
 

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -93,6 +93,13 @@ defmodule Ecto.Adapters.MySQL do
   # And provide a custom storage implementation
   @behaviour Ecto.Adapter.Storage
 
+  def fetch_conn_id(conn) do
+    case Mariaex.Connection.query(conn, "SELECT CONNECTION_ID();", []) do
+      {:ok, %{rows: [{conn_id}]}} -> {:ok, conn_id}
+      {:error, _} = error -> error
+    end
+  end
+
   ## Storage API
 
   @doc false

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -63,6 +63,13 @@ defmodule Ecto.Adapters.Postgres do
   # And provide a custom storage implementation
   @behaviour Ecto.Adapter.Storage
 
+  def fetch_conn_id(conn) do
+    case Postgrex.Connection.query(conn, "SELECT pg_backend_pid();", []) do
+      {:ok, %{rows: [{conn_id}]}} -> {:ok, conn_id}
+      {:error, _} = error -> error
+    end
+  end
+
   ## Storage API
 
   @doc false

--- a/lib/ecto/adapters/sql/db_conn_id_map.ex
+++ b/lib/ecto/adapters/sql/db_conn_id_map.ex
@@ -1,0 +1,57 @@
+defmodule Ecto.Adapters.SQL.DBConnIdMap do
+  @moduledoc ~S"""
+  Map between Ecto connection processes and DB backend connections. Allows to correlate
+  DB log entries (which show the backend connection id) with Elixir log entries (where we can
+  output the DB connection id and not the Ecto connection pid).
+  """
+
+  @name __MODULE__
+  @table :db_conn_id_map
+
+  use GenServer
+
+  def register(conn_pid, conn_id) do
+    :ok = GenServer.call(@name, {:register, conn_pid, conn_id})
+  end
+
+  def fetch(conn_pid) do
+    case :ets.lookup(@table, conn_pid) do
+      [{_, conn_id}] -> {:ok, conn_id}
+      [] -> :error
+    end
+  end
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: @name)
+  end
+
+  def init([]) do
+    :ets.new(@table, [:set, :named_table, :protected, read_concurrency: true])
+    {:ok, nil}
+  end
+
+  def handle_call({:register, conn_pid, conn_id}, _from, state) do
+    IO.puts "DBConnIdMap registered: conn_pid=#{inspect conn_pid} conn_id=#{inspect conn_id}"
+    :ets.insert(@table, {conn_pid, conn_id})
+    Process.monitor(conn_pid)
+    {:reply, :ok, state}
+  end
+
+  def handle_call(request, from, state) do
+    super(request, from, state)
+  end
+
+  def handle_cast(request, state) do
+    super(request, state)
+  end
+
+  def handle_info({:DOWN, _ref, :process, conn_pid, _reason}, state) do
+    IO.puts "DBConnIdMap conn died: conn_pid=#{inspect conn_pid}"
+    :ets.delete(@table, conn_pid)
+    {:noreply, state}
+  end
+
+  def handle_info(info, state) do
+    super(info, state)
+  end
+end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -76,6 +76,9 @@ defmodule Ecto.Repo do
       end
 
       def start_link(custom_config \\ []) do
+        # Hackety hack
+        Ecto.Adapters.SQL.DBConnIdMap.start_link()
+
         config = Keyword.merge(config(), custom_config)
         @adapter.start_link(__MODULE__, config)
       end

--- a/test/ecto/adapters/sql_test.exs
+++ b/test/ecto/adapters/sql_test.exs
@@ -4,6 +4,7 @@ defmodule Ecto.Adapters.SQLTest do
   defmodule Adapter do
     use Ecto.Adapters.SQL
     def supports_ddl_transaction?, do: false
+    def fetch_conn_id(conn_pid), do: {:ok, {:test, conn_pid}}
   end
 
   Application.put_env(:ecto, __MODULE__.Repo, adapter: Adapter)

--- a/test/pool/cases/transaction.exs
+++ b/test/pool/cases/transaction.exs
@@ -14,7 +14,7 @@ defmodule Ecto.Pool.TransactionTest do
 
   test "worker cleans up the connection when it crashes", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([lazy: false, name: pool])
+    {:ok, _} = TestPool.start_link([lazy: false, name: pool, timeout: @timeout, adapter: Ecto.TestAdapter])
 
     conn1 =
       TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, queue_time) ->
@@ -35,7 +35,7 @@ defmodule Ecto.Pool.TransactionTest do
 
   test "transaction can disconnect connection", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([lazy: false, name: pool])
+    {:ok, _} = TestPool.start_link([lazy: false, name: pool, timeout: @timeout, adapter: Ecto.TestAdapter])
 
     TestPool.transaction(pool, @timeout,
       fn(:opened, ref, {_mod, conn1}, queue_time) ->
@@ -49,7 +49,7 @@ defmodule Ecto.Pool.TransactionTest do
 
   test "disconnects if caller dies during transaction", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([lazy: false, name: pool])
+    {:ok, _} = TestPool.start_link([lazy: false, name: pool, timeout: @timeout, adapter: Ecto.TestAdapter])
 
     _ = Process.flag(:trap_exit, true)
     parent = self()
@@ -73,7 +73,7 @@ defmodule Ecto.Pool.TransactionTest do
 
   test "does not disconnect if caller dies after closing", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([lazy: false, name: pool])
+    {:ok, _} = TestPool.start_link([lazy: false, name: pool, timeout: @timeout, adapter: Ecto.TestAdapter])
 
     task = Task.async(fn ->
       TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, _) ->
@@ -91,7 +91,7 @@ defmodule Ecto.Pool.TransactionTest do
 
   test "transactions can be nested", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([lazy: false, name: pool])
+    {:ok, _} = TestPool.start_link([lazy: false, name: pool, timeout: @timeout, adapter: Ecto.TestAdapter])
 
     TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, queue_time) ->
       assert is_integer(queue_time)
@@ -103,7 +103,7 @@ defmodule Ecto.Pool.TransactionTest do
 
   test "shutdowns connection on break", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([name: pool])
+    {:ok, _} = TestPool.start_link([name: pool, timeout: @timeout, adapter: Ecto.TestAdapter])
 
     TestPool.transaction(pool, @timeout, fn(_, ref, {_mod, conn}, _) ->
       mon = Process.monitor(conn)
@@ -114,7 +114,7 @@ defmodule Ecto.Pool.TransactionTest do
 
   test "kill connection on break", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([name: pool, shutdown: :brutal_kill])
+    {:ok, _} = TestPool.start_link([name: pool, shutdown: :brutal_kill, timeout: @timeout, adapter: Ecto.TestAdapter])
 
     TestPool.transaction(pool, @timeout, fn(_, ref, {_mod, conn}, _) ->
       mon = Process.monitor(conn)
@@ -125,7 +125,7 @@ defmodule Ecto.Pool.TransactionTest do
 
   test "shutdown timeout and kill connection on break", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([name: pool, shutdown: 1, trap_exit: true])
+    {:ok, _} = TestPool.start_link([name: pool, shutdown: 1, trap_exit: true, timeout: @timeout, adapter: Ecto.TestAdapter])
 
     TestPool.transaction(pool, @timeout, fn(_, ref, {_mod, conn}, _) ->
       mon = Process.monitor(conn)

--- a/test/pool/poolboy/test_helper.exs
+++ b/test/pool/poolboy/test_helper.exs
@@ -3,4 +3,6 @@ ExUnit.start
 
 # Load support files
 Application.put_env(:ecto, :pool, Ecto.Pools.Poolboy)
+Ecto.Adapters.SQL.DBConnIdMap.start_link # Hackety Hack
 Code.require_file "../../support/test_pool.exs", __DIR__
+Code.require_file "../../support/test_repo.exs", __DIR__

--- a/test/pool/poolboy/worker_test.exs
+++ b/test/pool/poolboy/worker_test.exs
@@ -7,7 +7,7 @@ defmodule Ecto.Pools.Poolboy.WorkerTest do
   @timeout :infinity
 
   test "worker starts without an active connection but connects on transaction" do
-    {:ok, pool} = TestPool.start_link([])
+    {:ok, pool} = TestPool.start_link([timeout: @timeout, adapter: Ecto.TestAdapter])
     worker = :poolboy.checkout(pool, false)
     assert Process.alive?(worker)
     refute :sys.get_state(worker).conn
@@ -19,7 +19,7 @@ defmodule Ecto.Pools.Poolboy.WorkerTest do
   end
 
   test "worker starts with an active connection" do
-    {:ok, pool} = TestPool.start_link([lazy: false])
+    {:ok, pool} = TestPool.start_link([lazy: false, timeout: @timeout, adapter: Ecto.TestAdapter])
     worker = :poolboy.checkout(pool, false)
     assert Process.alive?(worker)
     assert :sys.get_state(worker).conn

--- a/test/pool/sojourn_broker/test_helper.exs
+++ b/test/pool/sojourn_broker/test_helper.exs
@@ -3,4 +3,6 @@ ExUnit.start
 
 # Load support files
 Application.put_env(:ecto, :pool, Ecto.Pools.SojournBroker)
+Ecto.Adapters.SQL.DBConnIdMap.start_link # Hackety Hack
 Code.require_file "../../support/test_pool.exs", __DIR__
+Code.require_file "../../support/test_repo.exs", __DIR__

--- a/test/pool/sojourn_broker/worker_test.exs
+++ b/test/pool/sojourn_broker/worker_test.exs
@@ -14,7 +14,7 @@ defmodule Ecto.Pools.SojournBroker.WorkerTest do
 
   test "worker starts without an active connection but connects on go", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([name: pool, lazy: true])
+    {:ok, _} = TestPool.start_link([name: pool, lazy: true, timeout: @timeout, adapter: Ecto.TestAdapter])
     assert {:go, _, {worker, :lazy}, _, _} = :sbroker.ask(pool, {:run, self()})
     assert Process.alive?(worker)
     conn = :sys.get_state(worker).conn
@@ -23,7 +23,7 @@ defmodule Ecto.Pools.SojournBroker.WorkerTest do
 
   test "worker starts with an active connection", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([name: pool, lazy: false])
+    {:ok, _} = TestPool.start_link([name: pool, lazy: false, timeout: @timeout, adapter: Ecto.TestAdapter])
     assert {:go, _, {worker, {Connection, conn}}, _, _} =
       :sbroker.ask(pool, {:run, self()})
     assert Process.alive?(worker)
@@ -33,7 +33,7 @@ defmodule Ecto.Pools.SojournBroker.WorkerTest do
 
   test "worker restarts connection when waiting", context do
     pool = context[:pool]
-    {:ok, _} = TestPool.start_link([name: pool])
+    {:ok, _} = TestPool.start_link([name: pool, timeout: @timeout, adapter: Ecto.TestAdapter])
 
     conn1 = TestPool.transaction(pool, @timeout,
       fn(:opened, _ref, {Connection, conn}, _) ->

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -6,6 +6,7 @@ defmodule Ecto.TestAdapter do
   defmacro __before_compile__(_opts), do: :ok
   def start_link(_repo, _opts), do: :ok
   def id_types(_repo), do: %{binary_id: Ecto.UUID}
+  def fetch_conn_id(conn_pid), do: {:ok, {:test, conn_pid}}
 
   ## Queryable
 


### PR DESCRIPTION
I've started working on https://github.com/elixir-lang/ecto/issues/667

Right now this is just a proof of concept. I've got some questions /cc @ericmj @fishcakez @josevalim

- The mapping between the DB `conn_id` and Ecto's `conn_pid` is kept in ETS, managed via a separate process.

  Advantages: a) No need to store this meta information in the Worker (where else could it be stored?) and somehow get it to `Ecto.Adapters.SQL.query` so it can go into the LogEntry. b) Also can be fetched from other parts (e.g. exometer) so it can query the DB for stats on what's happening.

  Disadvantages: Either Ecto becomes an application with it's own top supervisor where the global GenServer+ETS table live or every Repo becomes a supervisor that has a separate GenServer+ETS table for the mapping.

  Right now I think the recommended pattern (at least what `mix phoenix.new` creates) is to have `YourApp.Repo` as a worker in `YourApp`'s supervisor. But with sbroker the Repo is no longer a worker it should be a supervisor. So I think that is already something that needs to be thought about.

  Right now (because I noticed the problem with poolboy worker vs sbroker supervisor and because I need a place to put my GenServer) I'm thinking it would be nice to have all repo processes in Ecto's supervision tree, not in the supervision tree of my app. (That would also make the configuration simpler, no need for the `otp_app` key any more, config becomes just `config :ecto, YourApp.repo, ...`.)

- Storing the mapping in ETS and cleaning the table when the connection process dies means that the mapping is then no longer available for logging. I'm not sure if that can actually happen, or if in that case the whole query won't be logged anyhow, since it never reaches `Repo.log`?

- I've introduced the `Ecto.Adapter.fetch_conn_id(conn_pid)` callback, that returns either `{:ok, conn_id}` as an arbitrary db-specific term or `:ignore` if the connection doesn't support it. Is `Ecto.Adapter` that a good place to put the callback?

- Is the way I call `register_conn_id` in `Ecto.Adapters.Connection` ok?