### PR TITLE
Implementes table renaming

### DIFF
--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -106,6 +106,26 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  defmodule RenameMigration do
+    use Ecto.Migration
+
+    @table_current table(:posts_migration)
+    @table_new table(:new_posts_migration)
+
+    def up do
+      assert false == exists? @table_current
+      create @table_current
+      rename @table_current, @table_new
+      assert true == exists? @table_new
+      assert false == exists? @table_current
+    end
+
+    def down do
+      drop @table_new
+      assert false == exists? @table_new
+    end
+  end
+
   defmodule NoSQLMigration do
     use Ecto.Migration
 
@@ -183,5 +203,12 @@ defmodule Ecto.Integration.MigrationTest do
     assert catch_error(TestRepo.one from p in "drop_col_migration", select: p.to_be_removed)
   after
     :ok = down(TestRepo, 20090906120000, DropColumnMigration, log: false)
+  end
+
+  @tag :rename
+  test "rename table" do
+    assert :ok == up(TestRepo, 20150712120000, RenameMigration, log: false)
+  after
+    assert :ok == down(TestRepo, 20150712120000, RenameMigration, log: false)
   end
 end

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -463,6 +463,10 @@ if Code.ensure_loaded?(Mariaex.Connection) do
                 if_do(index.concurrently, "LOCK=NONE")])
     end
 
+    def execute_ddl({:rename, %Table{}=current_table, %Table{}=new_table}) do
+      "RENAME TABLE #{quote_table(current_table.name)} TO #{quote_table(new_table.name)}"
+    end
+
     def execute_ddl(string) when is_binary(string), do: string
 
     def execute_ddl(keyword) when is_list(keyword),

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -503,6 +503,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
                 quote_name(index.name)])
     end
 
+    def execute_ddl({:rename, %Table{}=current_table, %Table{}=new_table}) do
+      "ALTER TABLE #{quote_table(current_table.name)} RENAME TO #{quote_table(new_table.name)}"
+    end
+
     def execute_ddl(string) when is_binary(string), do: string
 
     def execute_ddl(keyword) when is_list(keyword),

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -413,6 +413,17 @@ defmodule Ecto.Migration do
   end
 
   @doc """
+  Renames a table.
+
+  ## Examples
+
+      rename table(:posts), table(:new_posts)
+  """
+  def rename(%Table{} = table_current, %Table{} = table_new) do
+    Runner.execute {:rename, table_current, table_new}
+  end
+
+  @doc """
   Generates a fragment to be used as default value.
 
   ## Examples

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -145,6 +145,7 @@ defmodule Ecto.Migration.Runner do
       {:alter, table, reversed}
     end
   end
+  defp reverse({:rename, %Table{}=table_current, %Table{}=table_new}), do: {:rename, table_new, table_current}
   defp reverse(_command), do: false
 
   defp table_reverse([]),   do: []
@@ -187,4 +188,6 @@ defmodule Ecto.Migration.Runner do
     do: "create index #{index.name}"
   defp command({:drop, %Index{} = index}),
     do: "drop index #{index.name}"
+  defp command({:rename, %Table{} = current_table, %Table{} = new_table}),
+    do: "rename table #{current_table.name} to #{new_table.name}"
 end

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -561,6 +561,11 @@ defmodule Ecto.Adapters.MySQLTest do
     assert SQL.execute_ddl(drop) == ~s|DROP INDEX `posts$main` ON `posts` LOCK=NONE|
   end
 
+  test "rename table" do
+    rename = {:rename, table(:posts), table(:new_posts)}
+    assert SQL.execute_ddl(rename) == ~s|RENAME TABLE `posts` TO `new_posts`|
+  end
+
   # Unsupported types and clauses
 
   test "arrays" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -580,4 +580,9 @@ defmodule Ecto.Adapters.PostgresTest do
     drop = {:drop, index(:posts, [:id], name: "posts$main", concurrently: true)}
     assert SQL.execute_ddl(drop) == ~s|DROP INDEX CONCURRENTLY "posts$main"|
   end
+
+  test "rename table" do
+    rename = {:rename, table(:posts), table(:new_posts)}
+    assert SQL.execute_ddl(rename) == ~s|ALTER TABLE "posts" RENAME TO "new_posts"|
+  end
 end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -149,6 +149,11 @@ defmodule Ecto.MigrationTest do
     assert {:drop, %Index{}} = last_command()
   end
 
+  test "forward: renames a table" do
+    rename table(:posts), table(:new_posts)
+    assert {:rename, %Table{name: :posts}, %Table{name: :new_posts}} = last_command()
+  end
+
   ## Reverse
   @moduletag direction: :backward
 
@@ -220,6 +225,11 @@ defmodule Ecto.MigrationTest do
   test "backward: drops an index" do
     drop index(:posts, [:title])
     assert {:create, %Index{}} = last_command()
+  end
+
+  test "backward: renames a table" do
+    rename table(:posts), table(:new_posts)
+    assert {:rename, %Table{name: :new_posts}, %Table{name: :posts}} = last_command()
   end
 
   defp last_exists(), do: Process.get(:last_exists)


### PR DESCRIPTION
Usage:

```elixir
def change
  rename table(:foo), table(:bar)
end
```

This will rename the table "foo" to "bar".

Works with backward migrations