### PR TITLE
Clarify syntax for the array type

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -129,6 +129,8 @@ defmodule Ecto.Schema do
   `:date`                 | `{year, month, day}`
   `:time`                 | `{hour, min, sec}`
 
+  **Note:** For the `:array` type, replace `inner_type` with one of the valid types, such as `:string`.
+
   **Note:** Although Ecto provides `:date`, `:time` and `:datetime`, you
   likely want to use `Ecto.Date`, `Ecto.Time` and `Ecto.DateTime` respectively.
   See the Custom types sections below about types that enhance the primitive


### PR DESCRIPTION
Is there any convention in the `mix docs` format that says "replace this with a valid value"?

If you're reading a shell script and you see $FOO you know to either set an environment variable or replace that bit.

I got stuck on `{:array, inner_type}` here and did not 'get' that I should replace the text inner_type with, for example `:string`. It is of course blindingly obvious in retrospect, but it wasn't at the time. :)

This adds a note to clarify what to do with `inner_type`.