### PR TITLE
Explain how to build the docs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ MIX_ENV=pg mix test
 mix test.all
 ```
 
+In addition, build the docs locally to review any changes:
+
+```
+$ MIX_ENV=docs mix docs
+```
+
 ## License
 
 Copyright 2012 Plataformatec


### PR DESCRIPTION
I found that `mix docs` alone does not work in a clean checkout, even after `mix deps.get`:

`** (Mix) The task docs could not be found`

If you run `MIX_ENV=docs mix docs` *once* then subsequently `mix docs` alone will work.

I can't quite explain why that is yet... apparently it has access to everything in deps/ regardless of the environment that is set?  Otherwise, without MIX_ENV set, it should default to 'dev' which can't see the ex_doc dependency.

For now, this always works, and experienced users will know when they can leave off the MIX_ENV bit.