### PR TITLE
Handle adding references/foreign key constraint in alter table

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -489,6 +489,16 @@ if Code.ensure_loaded?(Mariaex.Connection) do
       assemble(["ADD", quote_name(name), column_type(type, opts), column_options(name, opts)])
     end
 
+    defp column_change({:modify, name, %Reference{} = ref, opts}) do
+      assemble([
+        "MODIFY", quote_name(name), "BIGINT UNSIGNED,",
+        "ADD CONSTRAINT", quote_name("#{name}_fk"),
+        "FOREIGN KEY (#{quote_name(name)}) REFERENCES",
+        "#{quote_name(ref.table)}(#{quote_name(ref.column)})" <>
+        reference_on_delete(ref.on_delete)
+      ])
+    end
+
     defp column_change({:modify, name, type, opts}) do
       assemble(["MODIFY", quote_name(name), column_type(type, opts)])
     end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -524,6 +524,15 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       assemble(["ADD COLUMN", quote_name(name), column_type(type, opts), column_options(opts)])
     end
 
+    defp column_change({:modify, name, %Reference{} = ref, opts}) do
+      assemble([
+        "ADD CONSTRAINT", quote_name("#{name}_fk"),
+        "FOREIGN KEY (#{quote_name(name)}) REFERENCES",
+        "#{quote_name(ref.table)}(#{quote_name(ref.column)})" <>
+        reference_on_delete(ref.on_delete)
+      ])
+    end
+
     defp column_change({:modify, name, type, opts}) do
       assemble(["ALTER COLUMN", quote_name(name), "TYPE", column_type(type, opts)])
     end

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -523,6 +523,18 @@ defmodule Ecto.Adapters.MySQLTest do
     """ |> String.strip |> String.replace("\n", " ")
   end
 
+  test "alter table with adding foreign key constraint" do
+    alter = {:alter, table(:posts),
+              [{:modify, :user_id, references(:users, on_delete: :delete_all), []}]
+            }
+
+    assert SQL.execute_ddl(alter) == """
+    ALTER TABLE `posts`
+    MODIFY `user_id` BIGINT UNSIGNED,
+    ADD CONSTRAINT `user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
+    """ |> String.strip |> String.replace("\n", " ")
+  end
+
   test "create index" do
     create = {:create, index(:posts, [:category_id, :permalink])}
     assert SQL.execute_ddl(create) ==

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -537,6 +537,26 @@ defmodule Ecto.Adapters.PostgresTest do
     """ |> String.strip |> String.replace("\n", " ")
   end
 
+  test "alter table with reference" do
+    alter = {:alter, table(:posts),
+               [{:add, :comment_id, references(:comments), []}]}
+
+    assert SQL.execute_ddl(alter) == """
+    ALTER TABLE "posts" ADD COLUMN "comment_id" integer REFERENCES "comments"("id")
+    """ |> String.strip |> String.replace("\n", " ")
+  end
+
+  test "alter table with adding foreign key constraint" do
+    alter = {:alter, table(:posts),
+              [{:modify, :user_id, references(:users, on_delete: :delete_all), []}]
+            }
+
+    assert SQL.execute_ddl(alter) == """
+    ALTER TABLE "posts"
+    ADD CONSTRAINT "user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE
+    """ |> String.strip |> String.replace("\n", " ")
+  end
+
   test "create index" do
     create = {:create, index(:posts, [:category_id, :permalink])}
     assert SQL.execute_ddl(create) ==


### PR DESCRIPTION
So this is solution for https://github.com/elixir-lang/ecto/issues/722

Please note that MySQL is pretty picky about matching data types on columns foreign keys are being defined with, so in addition to adding foreign key constraint, we need to make sure it is converted to BIGINT UNSIGNED.

I have added integration tests as well, thanks for the tip @josevalim. They are passing for MIX_ENV=mysql and MIX_ENV=pg on my machine running MariaDB and PostgreSQL 9.4 / Arch Linux.

Please let me know if there's anything that can be done better, I'm happy to ammend.