### PR TITLE
Update README to show latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For example, if you want to use PostgreSQL, add to your `mix.exs` file:
 ```elixir
 defp deps do
   [{:postgrex, ">= 0.0.0"},
-   {:ecto, "~> 0.9.0"}]
+   {:ecto, "~> 0.13.1"}]
 end
 ```
 


### PR DESCRIPTION
The version was set to 0.9.0. This causes a problem if you are using the README as a guide :)