### PR TITLE
fis integration_test/sql to pass under mysql

### DIFF
--- a/integration_test/mysql/all_test.exs
+++ b/integration_test/mysql/all_test.exs
@@ -1,4 +1,5 @@
 Code.require_file "../sql/escape.exs", __DIR__
+Code.require_file "../sql/lock.exs", __DIR__
 Code.require_file "../sql/migration.exs", __DIR__
 Code.require_file "../sql/sql.exs", __DIR__
 Code.require_file "../sql/test_transaction.exs", __DIR__

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -3,6 +3,7 @@ ExUnit.start exclude: [:array_type, :read_after_writes, :case_sensitive,
                        :uses_usec, :strict_savepoint]
 
 # Configure Ecto for support and tests
+Application.put_env(:ecto, :lock_for_update, "FOR UPDATE")
 Application.put_env(:ecto, :primary_key_type, :id)
 
 # Load support files


### PR DESCRIPTION
When I was running tests yesterday, I noticed the integration_test/sql failure under MySQL. Thisi s because of the assertion in one of tests that checks if lock_for_update has been set globally. This is a direct result of change ebcda6bbc875e51b73863524edc03d9ef8de62ed when the option was copied to pg/test_helper.exs but *not* to mysql/test_helper.exs. I am uncertain if that was intentional or simply frogotten by @josevalim to do so.

As far as I can tell, simply adding the option back makes the integration_test/sql to pass again under MySQL. I assume those test should pass under all SQL adapters...

Is that the correct behavior and good fix?