### PR TITLE
doc version of pg for jsonb in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $ mix test
 Besides the unit tests above, it is recommended to run the adapter integration tests too:
 
 ```
-# Run only PostgreSQL tests
+# Run only PostgreSQL tests (version of PostgreSQL must be >= 9.4 to support jsonb)
 MIX_ENV=pg mix test
 
 # Run all tests (unit and all adapters/pools)


### PR DESCRIPTION
pg imported jsonb from 9.4, so the tests will fail if version of postgresql is < 9.4