### PR TITLE
make date/time/datetime use Ecto.*

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -64,7 +64,8 @@ defmodule Ecto.Integration.TypeTest do
 
     # Datetime
     datetime = {{2014, 04, 17}, {14, 00, 00, 00}}
-    assert [^datetime] = TestRepo.all(from Post, select: type(^datetime, :datetime))
+    ecto_datetime = %Ecto.DateTime{year: 2014, month: 4, day: 17, hour: 14, min: 0, sec: 0, usec: 0}
+    assert [^ecto_datetime] = TestRepo.all(from Post, select: type(^datetime, :datetime))
 
     # Custom wrappers
     assert [1] = TestRepo.all(from Post, select: type(^"1", Elixir.Custom.Permalink))

--- a/lib/ecto/datetime.ex
+++ b/lib/ecto/datetime.ex
@@ -90,6 +90,7 @@ defmodule Ecto.Date do
     do: from_parts(to_i(year), to_i(month), to_i(day))
   def cast(%{year: year, month: month, day: day}),
     do: from_parts(to_i(year), to_i(month), to_i(day))
+  def cast({year, month, day}), do: from_parts(to_i(year), to_i(month), to_i(day))
   def cast(_),
     do: :error
 
@@ -190,6 +191,8 @@ defmodule Ecto.Time do
     do: from_parts(to_i(hour), to_i(min), to_i(Map.get(map, "sec", 0)), to_i(Map.get(map, "usec", 0)))
   def cast(%{hour: hour, min: min} = map),
     do: from_parts(to_i(hour), to_i(min), to_i(Map.get(map, :sec, 0)), to_i(Map.get(map, :usec, 0)))
+  def cast({hour, min, sec}), do: from_parts(to_i(hour), to_i(min), to_i(sec), 0)
+  def cast({hour, min, sec, usec}), do: from_parts(to_i(hour), to_i(min), to_i(sec), to_i(usec))
   def cast(_),
     do: :error
 
@@ -211,6 +214,9 @@ defmodule Ecto.Time do
   """
   def load({hour, min, sec, usec}) do
     {:ok, %Ecto.Time{hour: hour, min: min, sec: sec, usec: usec}}
+  end
+  def load({_, _, _} = time) do
+    {:ok, from_erl(time)}
   end
 
   @doc """
@@ -310,6 +316,16 @@ defmodule Ecto.DateTime do
                to_i(Map.get(map, :usec, 0)))
   end
 
+  def cast({{year, month, day}, {hour, min, sec}}) do
+    from_parts(to_i(year), to_i(month), to_i(day),
+               to_i(hour), to_i(min), to_i(sec), 0)
+  end
+
+  def cast({{year, month, day}, {hour, min, sec, usec}}) do
+    from_parts(to_i(year), to_i(month), to_i(day),
+               to_i(hour), to_i(min), to_i(sec), to_i(usec))
+  end
+
   def cast(_) do
     :error
   end
@@ -333,6 +349,9 @@ defmodule Ecto.DateTime do
   def load({{year, month, day}, {hour, min, sec, usec}}) do
     {:ok, %Ecto.DateTime{year: year, month: month, day: day,
                          hour: hour, min: min, sec: sec, usec: usec}}
+  end
+  def load({{_, _, _}, {_, _, _}} = datetime) do
+    {:ok, erl_load(datetime)}
   end
 
   @doc """

--- a/lib/ecto/datetime.ex
+++ b/lib/ecto/datetime.ex
@@ -105,6 +105,7 @@ defmodule Ecto.Date do
   def dump(%Ecto.Date{year: year, month: month, day: day}) do
     {:ok, {year, month, day}}
   end
+  def dump(_), do: :error
 
   @doc """
   Converts a date triplet into an `Ecto.Date`.
@@ -112,6 +113,7 @@ defmodule Ecto.Date do
   def load({year, month, day}) do
     {:ok, %Ecto.Date{year: year, month: month, day: day}}
   end
+  def load(_), do: :error
 
   @doc """
   Converts `Ecto.Date` to a readable string representation.
@@ -208,6 +210,7 @@ defmodule Ecto.Time do
   def dump(%Ecto.Time{hour: hour, min: min, sec: sec, usec: usec}) do
     {:ok, {hour, min, sec, usec}}
   end
+  def dump(_), do: :error
 
   @doc """
   Converts a time tuple like the one returned by `dump/1` into an `Ecto.Time`.
@@ -218,6 +221,7 @@ defmodule Ecto.Time do
   def load({_, _, _} = time) do
     {:ok, from_erl(time)}
   end
+  def load(_), do: :error
 
   @doc """
   Converts `Ecto.Time` to a string representation.
@@ -342,6 +346,7 @@ defmodule Ecto.DateTime do
   def dump(%Ecto.DateTime{year: year, month: month, day: day, hour: hour, min: min, sec: sec, usec: usec}) do
     {:ok, {{year, month, day}, {hour, min, sec, usec}}}
   end
+  def dump(_), do: :error
 
   @doc """
   Converts a `{date, time}` tuple into an `Ecto.DateTime`.
@@ -353,6 +358,7 @@ defmodule Ecto.DateTime do
   def load({{_, _, _}, {_, _, _}} = datetime) do
     {:ok, erl_load(datetime)}
   end
+  def load(_), do: :error
 
   @doc """
   Converts `Ecto.DateTime` into an `Ecto.Date`.

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -289,6 +289,18 @@ defmodule Ecto.Type do
       {:ok, %Ecto.Query.Tagged{tag: nil, type: :uuid,
         value: <<125, 91, 237, 80, 232, 236, 74, 116, 184, 99, 235, 151, 127, 61, 185, 46>>}}
 
+      iex> datetime = %Ecto.DateTime{year: 2015, month: 5, day: 27, hour: 11, min: 30, sec: 00, usec: 27}
+      iex> dump(:datetime, datetime, %{})
+      {:ok, {{2015, 5, 27}, {11, 30, 0, 27}}}
+
+      iex> date = %Ecto.Date{year: 2015, month: 5, day: 27}
+      iex> dump(:date, date, %{})
+      {:ok, {2015, 5, 27}}
+
+      iex> time = %Ecto.Time{hour: 11, min: 30, sec: 00, usec: 27}
+      iex> dump(:time, time, %{})
+      {:ok, {11, 30, 0, 27}}
+
   """
   @spec dump(t, term, map) :: {:ok, term} | :error
   def dump(type, nil, _id_types) do
@@ -314,6 +326,12 @@ defmodule Ecto.Type do
       :error
     end
   end
+
+  defp dump(:date, term), do: Ecto.Date.dump(term)
+
+  defp dump(:time, term), do: Ecto.Time.dump(term)
+
+  defp dump(:datetime, term), do: Ecto.DateTime.dump(term)
 
   defp dump(type, value) do
     cond do
@@ -398,6 +416,18 @@ defmodule Ecto.Type do
       iex> load(:binary_id, <<125, 91, 237, 80, 232, 236, 74, 116, 184, 99, 235, 151, 127, 61, 185, 46>>, %{binary_id: Ecto.UUID})
       {:ok, "7d5bed50-e8ec-4a74-b863-eb977f3db92e"}
 
+      iex> datetime = {{2015, 5, 27}, {11, 30, 0, 27}}
+      iex> load(:datetime, datetime, %{})
+      {:ok, %Ecto.DateTime{year: 2015, month: 5, day: 27, hour: 11, min: 30, sec: 00, usec: 27}}
+
+      iex> date = {2015, 5, 27}
+      iex> load(:date, date, %{})
+      {:ok, %Ecto.Date{year: 2015, month: 5, day: 27}}
+
+      iex> time = {11, 30, 0, 27}
+      iex> load(:time, time, %{})
+      {:ok, %Ecto.Time{hour: 11, min: 30, sec: 00, usec: 27}}
+
   """
   @spec load(t, term, map) :: {:ok, term} | :error
   def load({:embed, embed}, value, id_types) do
@@ -424,6 +454,12 @@ defmodule Ecto.Type do
       :error
     end
   end
+
+  defp load(:date, term), do: Ecto.Date.load(term)
+
+  defp load(:time, term), do: Ecto.Time.load(term)
+
+  defp load(:datetime, term), do: Ecto.DateTime.load(term)
 
   defp load(type, value) do
     cond do
@@ -545,6 +581,18 @@ defmodule Ecto.Type do
       iex> cast(:binary_id, "7d5bed50-e8ec-4a74-b863-eb977f3db92e", %{binary_id: Ecto.UUID})
       {:ok, "7d5bed50-e8ec-4a74-b863-eb977f3db92e"}
 
+      iex> datetime = {{2015, 5, 27}, {11, 30, 0, 27}}
+      iex> cast(:datetime, datetime, %{})
+      {:ok, %Ecto.DateTime{year: 2015, month: 5, day: 27, hour: 11, min: 30, sec: 00, usec: 27}}
+
+      iex> date = {2015, 5, 27}
+      iex> cast(:date, date, %{})
+      {:ok, %Ecto.Date{year: 2015, month: 5, day: 27}}
+
+      iex> time = {11, 30, 0, 27}
+      iex> cast(:time, time, %{})
+      {:ok, %Ecto.Time{hour: 11, min: 30, sec: 00, usec: 27}}
+
   """
   @spec cast(t, term, map) :: {:ok, term} | :error
   def cast({:embed, embed}, value, id_types) do
@@ -589,6 +637,12 @@ defmodule Ecto.Type do
       _         -> :error
     end
   end
+
+  defp cast(:date, term), do: Ecto.Date.cast(term)
+
+  defp cast(:time, term), do: Ecto.Time.cast(term)
+
+  defp cast(:datetime, term), do: Ecto.DateTime.cast(term)
 
   defp cast(type, value) do
     cond do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -13,6 +13,7 @@ defmodule Ecto.ChangesetTest do
       field :uuid, :binary_id
       field :upvotes, :integer, default: 0
       field :topics, {:array, :string}
+      field :published_at, :datetime
       embeds_one :author, Author
     end
   end
@@ -194,6 +195,18 @@ defmodule Ecto.ChangesetTest do
     assert changeset.changes  == %{body: "new body"}
     assert changeset.required == [:title]
     assert changeset.optional == [:body]
+  end
+
+  test "cast/4: works on casting a datetime field" do
+    date = %Ecto.DateTime{year: 2015, month: 5, day: 1, hour: 10, min: 8, sec: 0}
+    params = %{"published_at" => date}
+    struct = %Post{}
+
+    changeset = cast(struct, params, ~w(published_at), ~w())
+    assert changeset.params == params
+    assert changeset.model  == struct
+    assert changeset.changes == %{published_at: date}
+    assert changeset.valid?
   end
 
   ## Changeset functions

--- a/test/ecto/datetime_test.exs
+++ b/test/ecto/datetime_test.exs
@@ -28,6 +28,21 @@ defmodule Ecto.DateTest do
            :error
   end
 
+  test "cast erl date" do
+    assert Ecto.Date.cast({2015, 12, 31}) == {:ok, @date}
+    assert Ecto.Date.cast({2015, 13, 31}) == :error
+  end
+
+  test "dump itself into a date triplet" do
+    assert Ecto.Date.dump(@date) == {:ok, {2015, 12, 31}}
+    assert Ecto.Date.dump({2015, 12, 31}) == :error
+  end
+
+  test "load a date triplet" do
+    assert Ecto.Date.load({2015, 12, 31}) == {:ok, @date}
+    assert Ecto.Date.load(@date) == :error
+  end
+
   test "to_string" do
     assert to_string(@date) == "2015-12-31"
     assert Ecto.Date.to_string(@date) == "2015-12-31"
@@ -95,6 +110,24 @@ defmodule Ecto.TimeTest do
            :error
     assert Ecto.Time.cast(%{hour: 23, min: nil}) ==
            :error
+  end
+
+  test "cast tuple" do
+    assert Ecto.Time.cast({23, 50, 07}) == {:ok, @time}
+    assert Ecto.Time.cast({12, 40, 33, 30000}) == {:ok, @time_usec}
+    assert Ecto.Time.cast({00, 61, 33}) == :error
+  end
+
+  test "dump itself into a time tuple" do
+    assert Ecto.Time.dump(@time) == {:ok, {23, 50, 7, 0}}
+    assert Ecto.Time.dump(@time_usec) == {:ok, {12, 40, 33, 30000}}
+    assert Ecto.Time.dump({23, 50, 07}) == :error
+  end
+
+  test "load tuple" do
+    assert Ecto.Time.load({23, 50, 07}) == {:ok, @time}
+    assert Ecto.Time.load({12, 40, 33, 30000}) == {:ok, @time_usec}
+    assert Ecto.Time.load(@time) == :error
   end
 
   test "to_string" do
@@ -179,6 +212,24 @@ defmodule Ecto.DateTimeTest do
 
     assert Ecto.DateTime.cast(%{year: 2015, month: 1, day: 23, hour: 23, min: nil}) ==
            :error
+  end
+
+  test "cast tuple" do
+    assert Ecto.DateTime.cast({{2015, 1, 23}, {23, 50, 07}}) == {:ok, @datetime}
+    assert Ecto.DateTime.cast({{2015, 1, 23}, {23, 50, 07, 8000}}) == {:ok, @datetime_usec}
+    assert Ecto.DateTime.cast({{2015, 1, 23}, {25, 50, 07, 8000}}) == :error
+  end
+
+  test "dump itself to a tuple" do
+    assert Ecto.DateTime.dump(@datetime) == {:ok, {{2015, 1, 23}, {23, 50, 07, 0}}}
+    assert Ecto.DateTime.dump(@datetime_usec) == {:ok, {{2015, 1, 23}, {23, 50, 07, 8000}}}
+    assert Ecto.DateTime.dump({{2015, 1, 23}, {23, 50, 07}}) == :error
+  end
+
+  test "load tuple" do
+    assert Ecto.DateTime.load({{2015, 1, 23}, {23, 50, 07}}) == {:ok, @datetime}
+    assert Ecto.DateTime.load({{2015, 1, 23}, {23, 50, 07, 8000}}) == {:ok, @datetime_usec}
+    assert Ecto.DateTime.load(@datetime) == :error
   end
 
   test "from_date" do

--- a/test/ecto/model/timestamps_test.exs
+++ b/test/ecto/model/timestamps_test.exs
@@ -44,11 +44,11 @@ defmodule Ecto.Model.TimestampsTest do
 
   test "sets custom inserted_at and updated_at values" do
     default = TestRepo.insert!(%Config{})
-    assert {_, _} = default.created_on
-    assert {_, _} = default.updated_on
+    assert %Ecto.DateTime{} = default.created_on
+    assert %Ecto.DateTime{} = default.updated_on
 
     default = TestRepo.update!(%Config{id: 1})
     refute default.created_on
-    assert {_, _} = default.updated_on
+    assert %Ecto.DateTime{} = default.updated_on
   end
 end

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -105,25 +105,37 @@ defmodule Ecto.TypeTest do
 
   test "datetime types" do
     erlang_datetime = {{2015, 5, 27}, {11, 30, 00}}
-    assert load(:datetime, erlang_datetime, %{}) == {:ok, erlang_datetime}
-    assert dump(:datetime, erlang_datetime, %{}) == {:ok, erlang_datetime}
-    assert cast(:datetime, erlang_datetime, %{}) == {:ok, erlang_datetime}
+    datetime = Ecto.DateTime.from_erl(erlang_datetime)
+    assert load(:datetime, erlang_datetime, %{}) == {:ok, datetime}
+    assert dump(:datetime, datetime, %{}) == {:ok, {{2015, 5, 27}, {11, 30, 0, 0}}}
+    assert cast(:datetime, erlang_datetime, %{}) == {:ok, datetime}
 
     datetime_with_usec = {{2015, 5, 27}, {11, 30, 00, 27}}
-    assert load(:datetime, datetime_with_usec, %{}) == {:ok, datetime_with_usec}
-    assert dump(:datetime, datetime_with_usec, %{}) == {:ok, datetime_with_usec}
-    assert cast(:datetime, datetime_with_usec, %{}) == {:ok, datetime_with_usec}
+    ecto_datetime = %Ecto.DateTime{year: 2015, month: 5, day: 27, hour: 11, min: 30, sec: 00, usec: 27}
+    assert load(:datetime, datetime_with_usec, %{}) == {:ok, ecto_datetime}
+    assert dump(:datetime, ecto_datetime, %{}) == {:ok, datetime_with_usec}
+    assert cast(:datetime, datetime_with_usec, %{}) == {:ok, ecto_datetime}
   end
 
   test "time types" do
     erlang_time = {11, 30, 00}
-    assert load(:time, erlang_time, %{}) == {:ok, erlang_time}
-    assert dump(:time, erlang_time, %{}) == {:ok, erlang_time}
-    assert cast(:time, erlang_time, %{}) == {:ok, erlang_time}
+    time = Ecto.Time.from_erl(erlang_time)
+    assert load(:time, erlang_time, %{}) == {:ok, time}
+    assert dump(:time, time, %{}) == {:ok, {11, 30, 0, 0}}
+    assert cast(:time, erlang_time, %{}) == {:ok, time}
 
     time_with_usec = {11, 30, 00, 27}
-    assert load(:time, time_with_usec, %{}) == {:ok, time_with_usec}
-    assert dump(:time, time_with_usec, %{}) == {:ok, time_with_usec}
-    assert cast(:time, time_with_usec, %{}) == {:ok, time_with_usec}
+    ecto_time = %Ecto.Time{hour: 11, min: 30, sec: 00, usec: 27}
+    assert load(:time, time_with_usec, %{}) == {:ok, ecto_time}
+    assert dump(:time, ecto_time, %{}) == {:ok, time_with_usec}
+    assert cast(:time, time_with_usec, %{}) == {:ok, ecto_time}
+  end
+
+  test "date types" do
+    erlang_date = {2015, 5, 27}
+    date = Ecto.Date.from_erl(erlang_date)
+    assert load(:date, erlang_date, %{}) == {:ok, date}
+    assert dump(:date, date, %{}) == {:ok, {2015, 5, 27}}
+    assert cast(:date, erlang_date, %{}) == {:ok, date}
   end
 end


### PR DESCRIPTION
Resolve #759 

@josevalim I find a problem: `load` and `dump` functions of Ecto.DateTime/Date/Time will raise an error if the params can't match, but Ecto.Type will return `:error`. So we'd better let them of Ecto.* return `:error` for unmatched params? But I'm not sure if it's suitable for Ecto.*. Any idea?