### PR TITLE
Add search path to from queries

### DIFF
--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -152,12 +152,12 @@ defmodule Ecto.Adapters.MySQL do
   end
 
   @doc false
-  def insert(_repo, {source, _model}, _params, _autogen, [_|_] = returning, _opts) do
+  def insert(_repo, {search_path, source, _model}, _params, _autogen, [_|_] = returning, _opts) do
     raise ArgumentError, "MySQL does not support :read_after_writes in models. " <>
                          "The following fields in #{inspect source} have tagged as such: #{inspect returning}"
   end
 
-  def insert(repo, {source, _model}, params, {pk, :id, nil}, [], opts) do
+  def insert(repo, {search_path, source, _model}, params, {pk, :id, nil}, [], opts) do
     {fields, values} = :lists.unzip(params)
     sql = @conn.insert(source, fields, [])
     case Ecto.Adapters.SQL.query(repo, sql, values, opts) do
@@ -171,7 +171,7 @@ defmodule Ecto.Adapters.MySQL do
   end
 
   @doc false
-  def update(repo, {source, _model}, fields, filter, _autogenerate, returning, opts) do
+  def update(repo, {search_path, source, _model}, fields, filter, _autogenerate, returning, opts) do
     {fields, values1} = :lists.unzip(fields)
     {filter, values2} = :lists.unzip(filter)
     sql = @conn.update(source, fields, filter, returning)
@@ -182,7 +182,7 @@ defmodule Ecto.Adapters.MySQL do
   end
 
   @doc false
-  def delete(repo, {source, _model}, filter, _autogenerate, opts) do
+  def delete(repo, {search_path, source, _model}, filter, _autogenerate, opts) do
     {filter, values} = :lists.unzip(filter)
     case Ecto.Adapters.SQL.query(repo, @conn.delete(source, filter, []), values, opts) do
       %{num_rows: 0} -> {:error, :stale}

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -80,14 +80,14 @@ defmodule Ecto.Adapters.SQL do
         end
       end
 
-      def insert(repo, {source, _model}, params, _autogenerate, returning, opts) do
+      def insert(repo, {search_path, source, _model}, params, _autogenerate, returning, opts) do
         {fields, values} = :lists.unzip(params)
         sql = @conn.insert(source, fields, returning)
         Ecto.Adapters.SQL.model(repo, sql, values, returning, opts)
       end
 
       @doc false
-      def update(repo, {source, _model}, fields, filter, _autogenerate, returning, opts) do
+      def update(repo, {search_path, source, _model}, fields, filter, _autogenerate, returning, opts) do
         {fields, values1} = :lists.unzip(fields)
         {filter, values2} = :lists.unzip(filter)
         sql = @conn.update(source, fields, filter, returning)
@@ -95,7 +95,7 @@ defmodule Ecto.Adapters.SQL do
       end
 
       @doc false
-      def delete(repo, {source, _model}, filter, _autogenarate, opts) do
+      def delete(repo, {search_path, source, _model}, filter, _autogenarate, opts) do
         {filter, values} = :lists.unzip(filter)
         Ecto.Adapters.SQL.model(repo, @conn.delete(source, filter, []), values, [], opts)
       end

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -59,14 +59,14 @@ defmodule Ecto.Query.Builder.From do
           # Get the source at runtime so no unnecessary compile time
           # dependencies between modules are added
           source = quote do: unquote(model).__schema__(:source)
-          {1, query(source, model)}
+          {1, query(nil, source, model)}
 
         source when is_binary(source) ->
           # When a binary is used, there is no model
-          {1, query(source, nil)}
+          {1, query(nil, source, nil)}
 
         {source, model} when is_binary(source) ->
-          {1, query(source, model)}
+          {1, query(nil, source, model)}
 
         other ->
           {nil, other}
@@ -76,8 +76,8 @@ defmodule Ecto.Query.Builder.From do
     {quoted, binds, count_bind}
   end
 
-  defp query(source, model) do
-    {:%, [], [Ecto.Query, {:%{}, [], [from: {source, model}]}]}
+  defp query(search_path, source, model) do
+    {:%, [], [Ecto.Query, {:%{}, [], [from: {search_path, source, model}]}]}
   end
 
   @doc """

--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -15,13 +15,14 @@ end
 
 defimpl Ecto.Queryable, for: BitString do
   def to_query(source) when is_binary(source),
-    do: %Ecto.Query{from: {source, nil}}
+    do: %Ecto.Query{from: {source, source, nil}}
 end
 
 defimpl Ecto.Queryable, for: Atom do
   def to_query(module) do
     try do
-      %Ecto.Query{from: {module.__schema__(:source), module}}
+      source = module.__schema__(:source)
+      %Ecto.Query{from: {source, source, module}}
     rescue
       UndefinedFunctionError ->
         message = if :code.is_loaded(module) do
@@ -39,6 +40,7 @@ defimpl Ecto.Queryable, for: Atom do
 end
 
 defimpl Ecto.Queryable, for: Tuple do
-  def to_query(from = {source, model}) when is_binary(source) and is_atom(model),
+  def to_query(from = {search_path, source, model})
+    when is_binary(search_path) and is_binary(source) and is_atom(model),
     do: %Ecto.Query{from: from}
 end

--- a/lib/ecto/repo/model.ex
+++ b/lib/ecto/repo/model.ex
@@ -49,7 +49,7 @@ defmodule Ecto.Repo.Model do
       changeset = Callbacks.__apply__(model, :before_insert, changeset)
       changes = validate_changes(:insert, changeset, model, fields, id_types)
 
-      {:ok, values} = adapter.insert(repo, {source, model}, changes, autogen, return, opts)
+      {:ok, values} = adapter.insert(repo, {source, source, model}, changes, autogen, return, opts)
 
       changeset = load_into_changeset(changeset, model, values, id_types)
       Callbacks.__apply__(model, :after_insert, changeset).model
@@ -88,7 +88,7 @@ defmodule Ecto.Repo.Model do
 
         values =
           if changes != [] do
-            case adapter.update(repo, {source, model}, changes, filters, autogen, return, opts) do
+            case adapter.update(repo, {source, source, model}, changes, filters, autogen, return, opts) do
               {:ok, values} ->
                 values
               {:error, :stale} ->
@@ -136,7 +136,7 @@ defmodule Ecto.Repo.Model do
       filters = add_pk_filter!(changeset.filters, struct)
       filters = Planner.fields(model, :delete, filters, adapter.id_types(repo))
 
-      case adapter.delete(repo, {source, model}, filters, autogen, opts) do
+      case adapter.delete(repo, {source, source, model}, filters, autogen, opts) do
         {:ok, _} -> nil
         {:error, :stale} ->
           raise Ecto.StaleModelError, model: struct, action: :delete


### PR DESCRIPTION
refs: https://github.com/elixir-lang/ecto/issues/739

@josevalim was trying to figure out where you were going with adding `"search_path"`. Is it so that if user provides, `{search_path, Model}`, then we store in `:from` - `{search_path, model.__schema__(:source), model}`?
