### PR TITLE
Rename column

### DIFF
--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -108,6 +108,24 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  defmodule RenameColumnMigration do
+    use Ecto.Migration
+
+    def up do
+      create table(:rename_col_migration) do
+        add :to_be_renamed, :integer
+      end
+
+      rename table(:rename_col_migration), :to_be_renamed, to: :was_renamed
+
+      execute "INSERT INTO rename_col_migration (was_renamed) VALUES (1)"
+    end
+
+    def down do
+      drop table(:rename_col_migration)
+    end
+  end
+
   defmodule OnDeleteMigration do
     use Ecto.Migration
 
@@ -281,7 +299,14 @@ defmodule Ecto.Integration.MigrationTest do
     :ok = down(TestRepo, 20090906120000, DropColumnMigration, log: false)
   end
 
-  @tag :rename
+  @tag :rename_column
+  test "rename column" do
+    assert :ok == up(TestRepo, 20150718120000, RenameColumnMigration, log: false)
+    assert 1 == TestRepo.one from p in "rename_col_migration", select: p.was_renamed
+    :ok = down(TestRepo, 20150718120000, RenameColumnMigration, log: false)
+  end
+
+  @tag :rename_table
   test "rename table" do
     assert :ok == up(TestRepo, 20150712120000, RenameMigration, log: false)
     assert :ok == down(TestRepo, 20150712120000, RenameMigration, log: false)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -538,6 +538,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       "ALTER TABLE #{quote_table(current_table.name)} RENAME TO #{quote_table(new_table.name)}"
     end
 
+    def execute_ddl({:rename, %Table{}=table, current_column, new_column}) do
+      "ALTER TABLE #{quote_table(table.name)} RENAME #{quote_name(current_column)} TO #{quote_name(new_column)}"
+    end
+
     def execute_ddl(string) when is_binary(string), do: string
 
     def execute_ddl(keyword) when is_list(keyword),

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -474,6 +474,17 @@ defmodule Ecto.Migration do
   end
 
   @doc """
+  Renames a column outside of the `alter` statement. Note that unlike `rename/3` it is not necessary
+  to include a column type for this command as the type will always be inferred from the current column.
+
+  ## Examples
+      rename table(:posts), :title, to: :summary
+  """
+  def rename(%Table{} = table, current_column, to: new_column) when is_atom(current_column) and is_atom(new_column) do
+    Runner.execute {:rename, table, current_column, new_column}
+  end
+
+  @doc """
   Generates a fragment to be used as default value.
 
   ## Examples

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -157,6 +157,10 @@ defmodule Ecto.Migration.Runner do
   end
   defp reverse({:rename, %Table{}=table_current, %Table{}=table_new}),
     do: {:rename, table_new, table_current}
+  defp reverse({:rename, %Table{}=table_current, %Table{}=table_new}),
+    do: {:rename, table_new, table_current}
+  defp reverse({:rename, %Table{}=table, current_column, new_column}),
+    do: {:rename, table, new_column, current_column}
   defp reverse(_command), do: false
 
   defp table_reverse([]),   do: []
@@ -209,4 +213,6 @@ defmodule Ecto.Migration.Runner do
     do: "drop index if exists #{index.name}"
   defp command({:rename, %Table{} = current_table, %Table{} = new_table}),
     do: "rename table #{current_table.name} to #{new_table.name}"
+  defp command({:rename, %Table{} = table, current_column, new_column}),
+    do: "rename column #{current_column} to #{new_column} on table #{table.name}"
 end

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -599,6 +599,17 @@ defmodule Ecto.Adapters.MySQLTest do
     assert SQL.execute_ddl(rename) == ~s|RENAME TABLE `posts` TO `new_posts`|
   end
 
+  test "rename column" do
+    rename = {:rename, table(:posts), :given_name, :first_name}
+    assert SQL.execute_ddl(rename) ==
+      [
+        "SELECT @column_type := COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'posts' AND COLUMN_NAME = 'given_name' LIMIT 1",
+        "SET @rename_stmt = concat('ALTER TABLE `posts` CHANGE COLUMN `given_name` `first_name` ', @column_type)",
+        "PREPARE rename_stmt FROM @rename_stmt",
+        "EXECUTE rename_stmt"
+      ]
+  end
+
   # Unsupported types and clauses
 
   test "arrays" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -653,6 +653,11 @@ defmodule Ecto.Adapters.PostgresTest do
     assert SQL.execute_ddl(rename) == ~s|ALTER TABLE "posts" RENAME TO "new_posts"|
   end
 
+  test "rename column" do
+    rename = {:rename, table(:posts), :given_name, :first_name}
+    assert SQL.execute_ddl(rename) == ~s|ALTER TABLE "posts" RENAME "given_name" TO "first_name"|
+  end
+
   defp remove_newlines(string) do
     string |> String.strip |> String.replace("\n", " ")
   end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -137,6 +137,13 @@ defmodule Ecto.MigrationTest do
                {:remove, :views}]}
   end
 
+  test "forward: rename column" do
+    rename table(:posts), :given_name, to: :first_name
+    flush
+
+    assert last_command() == {:rename, %Table{name: :posts}, :given_name, :first_name}
+  end
+
   test "forward: drops a table" do
     drop table(:posts)
     flush
@@ -204,6 +211,13 @@ defmodule Ecto.MigrationTest do
       end
       flush
     end
+  end
+
+  test "backward: rename column" do
+    rename table(:posts), :given_name, to: :first_name
+    flush
+
+    assert last_command() == {:rename, %Table{name: :posts}, :first_name, :given_name}
   end
 
   test "backward: drops a table" do


### PR DESCRIPTION
This adds support for renaming columns. It comes in two forms:

*Alter Table Form*
```elixir
alter table(:foo) do
  rename :bar, :baz
end
```

*Outside Alter Table Form*
```elixir
rename table(:foo), :bar, :baz
```