### PR TITLE
Change array/embeds_many behaviour

### DIFF
--- a/lib/ecto/embedded.ex
+++ b/lib/ecto/embedded.ex
@@ -70,20 +70,18 @@ defmodule Ecto.Embedded do
     do_change(value, current, mod)
   end
 
-  # We accept nil here to make is easier to mark embeds recursively
-  # for deletion, otherwise we would need to guess what to pass [] or nil
   def change(%Embedded{cardinality: :many, container: :array, embed: mod},
-             value, current) when is_list(value) or is_nil(value) do
+             value, current) when is_list(value) do
     {pk, _} = primary_key(mod)
     current = process_current(current, pk)
 
     changeset_fun = &do_change(&1, &2, mod)
-    pk_fun = fn
-      %Changeset{model: model} -> Map.fetch(model, pk)
-      model -> Map.fetch(model, pk)
-    end
-    map_changes(value || [], pk_fun, changeset_fun, current, [], true) |> elem(1)
+    pk_fun = &model_or_changeset_pk(&1, pk)
+    map_changes(value, pk_fun, changeset_fun, current, [], true) |> elem(1)
   end
+
+  defp model_or_changeset_pk(%Changeset{model: model}, pk), do: Map.fetch(model, pk)
+  defp model_or_changeset_pk(model, pk), do: Map.fetch(model, pk)
 
   defp do_change(value, nil, mod) do
     fields    = mod.__schema__(:fields)

--- a/lib/ecto/repo/model.ex
+++ b/lib/ecto/repo/model.ex
@@ -200,7 +200,13 @@ defmodule Ecto.Repo.Model do
   end
 
   defp delete_changes(changeset, model) do
-    embeds    = model.__schema__(:embeds) |> Enum.map(&{&1, nil})
+    types = changeset.types
+    embeds =
+      Enum.map(model.__schema__(:embeds), fn field ->
+        {:embed, embed} = Map.get(types, field)
+        {field, Ecto.Embedded.empty(embed)}
+      end)
+
     changeset = %{changeset | changes: %{}}
     Ecto.Changeset.change(changeset, embeds)
   end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -796,10 +796,12 @@ defmodule Ecto.Schema do
   @doc false
   def __field__(mod, name, type, pk?, opts) do
     check_type!(name, type, opts[:virtual])
-    check_default!(name, type, opts[:default])
+
+    default = default_for_type(type, opts)
+    check_default!(name, type, default)
 
     Module.put_attribute(mod, :changeset_fields, {name, type})
-    put_struct_field(mod, name, opts[:default])
+    put_struct_field(mod, name, default)
 
     unless opts[:virtual] do
       if raw = opts[:read_after_writes] do
@@ -1076,5 +1078,13 @@ defmodule Ecto.Schema do
   defp autogenerate_id(type) do
     id = if Ecto.Type.primitive?(type), do: type, else: type.type
     if id in [:id, :binary_id], do: id, else: nil
+  end
+
+  defp default_for_type({:array, _}, opts) do
+    Keyword.get(opts, :default, [])
+  end
+
+  defp default_for_type(_, opts) do
+    Keyword.get(opts, :default)
   end
 end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -32,6 +32,7 @@ defmodule Ecto.RepoTest do
       field :x, :string
       field :y, :binary
       embeds_one :embed, MyEmbed
+      embeds_many :embeds, MyEmbed
     end
 
     before_insert :store_changeset, [:before_insert]
@@ -235,11 +236,16 @@ defmodule Ecto.RepoTest do
 
   test "adds embeds to changeset as empty on insert" do
     TestRepo.insert!(%MyModel{embed: %MyEmbed{}})
-    assert Agent.get(CallbackAgent, &get_changes/1) == %{id: nil, embed: nil, x: nil, y: nil}
+    assert Agent.get(CallbackAgent, &get_changes/1) ==
+      %{id: nil, embed: nil, embeds: [], x: nil, y: nil}
+
+    TestRepo.insert!(%MyModel{embeds: [%MyEmbed{}]})
+    assert Agent.get(CallbackAgent, &get_changes/1) ==
+      %{id: nil, embed: nil, embeds: [], x: nil, y: nil}
   end
 
   test "skip adding embeds to changeset on update" do
-    TestRepo.update!(%MyModel{id: 5, embed: %MyEmbed{}})
+    TestRepo.update!(%MyModel{id: 5, embed: %MyEmbed{}, embeds: [%MyEmbed{}]})
     assert Agent.get(CallbackAgent, &get_changes/1) == %{x: nil, y: nil}
   end
 
@@ -258,19 +264,38 @@ defmodule Ecto.RepoTest do
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == nil
 
-    # Only if embed is in changeset
+    model = TestRepo.insert!(%MyModel{embeds: [embed]})
+    assert [{:after_insert, MyModel}, {:before_insert, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == []
+
+    # Rejects if not in changes
     changeset = Ecto.Changeset.change(%MyModel{embed: embed})
     model = TestRepo.insert!(changeset)
     assert [{:after_insert, MyModel}, {:before_insert, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == nil
 
+    changeset = Ecto.Changeset.change(%MyModel{embeds: [embed]})
+    model = TestRepo.insert!(changeset)
+    assert [{:after_insert, MyModel}, {:before_insert, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == []
+
+    # Inserts when in changes
     changeset = Ecto.Changeset.change(%MyModel{}, embed: embed)
     model = TestRepo.insert!(changeset)
     assert [{:after_insert, MyModel}, {:after_insert, MyEmbed},
             {:before_insert, MyEmbed}, {:before_insert, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == embed
+
+    changeset = Ecto.Changeset.change(%MyModel{}, embeds: [embed])
+    model = TestRepo.insert!(changeset)
+    assert [{:after_insert, MyModel}, {:after_insert, MyEmbed},
+            {:before_insert, MyEmbed}, {:before_insert, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == [embed]
   end
 
   test "handles embeds on update" do
@@ -282,12 +307,23 @@ defmodule Ecto.RepoTest do
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == embed
 
+    model = TestRepo.update!(%MyModel{id: 1, embeds: [embed]})
+    assert [{:after_update, MyModel}, {:before_update, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == [embed]
+
     # If embed is not in changeset, embeds are left out
     changeset = Ecto.Changeset.change(%MyModel{id: 1, embed: embed}, x: "abc")
     model = TestRepo.update!(changeset)
     assert [{:after_update, MyModel}, {:before_update, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == embed
+
+    changeset = Ecto.Changeset.change(%MyModel{id: 1, embeds: [embed]}, x: "abc")
+    model = TestRepo.update!(changeset)
+    assert [{:after_update, MyModel}, {:before_update, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == [embed]
 
     # Inserting the embed
     changeset = Ecto.Changeset.change(%MyModel{id: 1}, embed: embed)
@@ -296,6 +332,13 @@ defmodule Ecto.RepoTest do
             {:before_insert, MyEmbed}, {:before_update, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == embed
+
+    changeset = Ecto.Changeset.change(%MyModel{id: 1}, embeds: [embed])
+    model = TestRepo.update!(changeset)
+    assert [{:after_update, MyModel}, {:after_insert, MyEmbed},
+            {:before_insert, MyEmbed}, {:before_update, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == [embed]
 
     # Changeing the embed
     embed_changeset = Ecto.Changeset.change(embed, x: "abc")
@@ -306,6 +349,13 @@ defmodule Ecto.RepoTest do
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == %MyEmbed{x: "abc", id: @uuid}
 
+    changeset = Ecto.Changeset.change(%MyModel{id: 1, embeds: [embed]}, embeds: [embed_changeset])
+    model = TestRepo.update!(changeset)
+    assert [{:after_update, MyModel}, {:after_update, MyEmbed},
+            {:before_update, MyEmbed}, {:before_update, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == [%MyEmbed{x: "abc", id: @uuid}]
+
     # Deleting the embed
     changeset = Ecto.Changeset.change(%MyModel{id: 1, embed: embed}, embed: nil)
     model = TestRepo.update!(changeset)
@@ -313,6 +363,13 @@ defmodule Ecto.RepoTest do
             {:before_delete, MyEmbed}, {:before_update, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == nil
+
+    changeset = Ecto.Changeset.change(%MyModel{id: 1, embed: [embed]}, embeds: [])
+    model = TestRepo.update!(changeset)
+    assert [{:after_update, MyModel}, {:after_delete, MyEmbed},
+            {:before_delete, MyEmbed}, {:before_update, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == []
   end
 
   test "handles embeds on delete" do
@@ -325,6 +382,12 @@ defmodule Ecto.RepoTest do
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == nil
 
+    model = TestRepo.delete!(%MyModel{id: 1, embeds: [embed]})
+    assert [{:after_delete, MyModel}, {:after_delete, MyEmbed},
+            {:before_delete, MyEmbed}, {:before_delete, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == []
+
     # With changeset runs all callbacks
     changeset = Ecto.Changeset.change(%MyModel{id: 1, embed: embed})
     model = TestRepo.delete!(changeset)
@@ -332,5 +395,12 @@ defmodule Ecto.RepoTest do
             {:before_delete, MyEmbed}, {:before_delete, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embed == nil
+
+    changeset = Ecto.Changeset.change(%MyModel{id: 1, embeds: [embed]})
+    model = TestRepo.delete!(changeset)
+    assert [{:after_delete, MyModel}, {:after_delete, MyEmbed},
+            {:before_delete, MyEmbed}, {:before_delete, MyModel} | _] =
+      Agent.get(CallbackAgent, &get_models/1)
+    assert model.embeds == []
   end
 end


### PR DESCRIPTION
* Default for array type fields is [] instead of nil
* Loading nil for array type gives []
* Duping/casting nil for array type fails
* Test embeds_many more thoroughly
* Same behaviour for embeds_many with array

Closes #803 