### PR TITLE
Adding using option to modify

### DIFF
--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -65,6 +65,25 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  defmodule AlterColumnMigrationWithUsing do
+    use Ecto.Migration
+
+    def up do
+      create table(:alter_col_migration_with_using) do
+        add :to_be_modified, :json
+      end
+      execute "INSERT INTO alter_col_migration_with_using (to_be_modified) VALUES ('{\"foo\":\"bar\"}')"
+
+      alter table(:alter_col_migration_with_using) do
+        modify :to_be_modified, :jsonb, using: "to_be_modified::jsonb"
+      end
+    end
+
+    def down do
+      drop table(:alter_col_migration_with_using)
+    end
+  end
+
   defmodule AlterForeignKeyMigration do
     use Ecto.Migration
 
@@ -217,6 +236,13 @@ defmodule Ecto.Integration.MigrationTest do
     assert :ok == up(TestRepo, 20080906120000, AlterColumnMigration, log: false)
     assert "foo" == TestRepo.one from p in "alter_col_migration", select: p.to_be_modified
     :ok = down(TestRepo, 20080906120000, AlterColumnMigration, log: false)
+  end
+
+  @tag :modify_column
+  test "modify column with using" do
+    assert :ok == up(TestRepo, 20080906120000, AlterColumnMigrationWithUsing, log: false)
+    assert %{"foo" => "bar"} == TestRepo.one from p in "alter_col_migration_with_using", select: p.to_be_modified
+    :ok = down(TestRepo, 20080906120000, AlterColumnMigrationWithUsing, log: false)
   end
 
   @tag :modify_foreign_key

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -574,7 +574,8 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     end
 
     defp column_change({:modify, name, type, opts}) do
-      assemble(["ALTER COLUMN", quote_name(name), "TYPE", column_type(type, opts)])
+      using = Keyword.get(opts, :using, nil)
+      assemble(["ALTER COLUMN", quote_name(name), "TYPE", column_type(type, opts), if_do(using, "USING #{using}")])
     end
 
     defp column_change({:remove, name}), do: "DROP COLUMN #{quote_name(name)}"

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -465,6 +465,8 @@ defmodule Ecto.Migration do
     * `:size` - the size of the type (for example the numbers of characters). Default is no size.
     * `:precision` - the precision for a numberic type. Default is no precision.
     * `:scale` - the scale of a numberic type. Default is 0 scale.
+    * `:using` - casting you'd like postgres to use if modifying type. String is sent directly 
+    to the postgres adapter. Default is no using. 
   """
   def modify(column, type, opts \\ []) when is_atom(column) do
     Runner.subcommand {:modify, column, type, opts}


### PR DESCRIPTION
This is only supported in postgres. It is useful for when postgres cannot autocast a field to its new type. The default behaviour is to drop the column and then change it. 

And postgres surprisingly doesn't know how to cast from json to jsonb so my test shows an example..