### PR TITLE
Change casting embeds

### DIFF
--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -150,6 +150,10 @@ defmodule Ecto.RepoTest do
     assert_raise Ecto.QueryError, fn ->
       TestRepo.update_all from(e in MyModel, order_by: e.x), set: [x: "321"]
     end
+
+    changeset = Ecto.Changeset.change(%MyEmbed{})
+    assert catch_error(TestRepo.update_all MyModel, set: [embed: %MyEmbed{}])
+    assert catch_error(TestRepo.update_all MyModel, set: [embed: changeset])
   end
 
   test "validates delete_all" do

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -98,9 +98,9 @@ defmodule Ecto.TypeTest do
     assert {:ok, %{a: 1, id: @uuid_tagged}} ==
            dump(type, changeset, &Ecto.TestAdapter.dump/2)
 
-    assert %Model{a: 1} = cast(type, %{"a" => 1})
-    assert :error == cast(type, %{})
-    assert :error == cast(type, 1)
+    assert :error == cast(type, %{"a" => 1})
+
+    assert match?(:any, type)
   end
 
   test "embeds_many" do
@@ -120,9 +120,8 @@ defmodule Ecto.TypeTest do
     assert {:ok, [%{a: 1, id: @uuid_tagged}]} ==
            dump(type, [changeset, deleted], &Ecto.TestAdapter.dump/2)
 
-    assert [%Model{a: 1}] = cast(type, [%{"a" => 1}])
-    assert :error == cast(type, nil)
-    assert :error == cast(type, [%{}])
-    assert :error == cast(type, [[]])
+    assert :error == cast(type, [%{"a" => 1}])
+
+    assert match?({:array, :any}, type)
   end
 end


### PR DESCRIPTION
* Casting with `Ecto.Type.cast/2` is not allowed
* `Ecto.Type.match?` considers `:any` to match embeds_one, and
  `{:array, :any}` to match embeds_many