### PR TITLE
Ensure embedded models have primary keys on update and delete

### DIFF
--- a/lib/ecto/embedded.ex
+++ b/lib/ecto/embedded.ex
@@ -235,6 +235,16 @@ defmodule Ecto.Embedded do
     end
   end
 
+  defp generate_id(changeset, callback, model, _embed, _adapter)
+      when callback in [:before_update, :before_delete] do
+    case get_pk(changeset, model |> primary_key |> elem(0)) do
+      {:ok, value} when not is_nil(value) ->
+        changeset
+      _other ->
+        raise Ecto.MissingPrimaryKeyError, struct: changeset.model
+    end
+  end
+
   defp generate_id(changeset, _callback, _model, _embed, _adapter) do
     changeset
   end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -364,7 +364,7 @@ defmodule Ecto.RepoTest do
     assert model.embed.sub_embed == %{sub_embed | id: id}
   end
 
-  test "handles embeds on update" do
+  test "skips embeds on update when not changing" do
     embed = %MyEmbed{x: "xyz"}
 
     # Leaves embeds untouched when updatting model
@@ -390,6 +390,10 @@ defmodule Ecto.RepoTest do
     assert [{:after_update, MyModel}, {:before_update, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
     assert model.embeds == [embed]
+  end
+
+  test "inserting embeds on update" do
+    embed = %MyEmbed{x: "xyz"}
 
     # Inserting the embed
     changeset = Ecto.Changeset.change(%MyModel{id: 1}, embed: embed)
@@ -410,14 +414,28 @@ defmodule Ecto.RepoTest do
     assert id
     assert model.embeds == [%{embed | id: id}]
 
+    embed = %{embed | id: @uuid}
+
     # Inserting embed with id already provided
-    embed_id = %{embed | id: @uuid}
-    changeset = Ecto.Changeset.change(%MyModel{id: 1}, embed: embed_id)
+    changeset = Ecto.Changeset.change(%MyModel{id: 1}, embed: embed)
     model = TestRepo.update!(changeset)
     assert [{:after_update, MyModel}, {:after_insert, MyEmbed},
             {:before_insert, MyEmbed}, {:before_update, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
-    assert model.embed == embed_id
+    assert model.embed == embed
+  end
+
+  test "changing embeds on update" do
+    embed = %MyEmbed{x: "xyz"}
+
+    # Raises if there's no id
+    embed_changeset = Ecto.Changeset.change(embed, x: "abc")
+    changeset = Ecto.Changeset.change(%MyModel{id: 1, embed: embed}, embed: embed_changeset)
+    assert_raise Ecto.MissingPrimaryKeyError, fn ->
+      TestRepo.update!(changeset)
+    end
+
+    embed = %{embed | id: @uuid}
 
     # Changing the embed
     embed_changeset = Ecto.Changeset.change(embed, x: "abc")
@@ -426,14 +444,26 @@ defmodule Ecto.RepoTest do
     assert [{:after_update, MyModel}, {:after_update, MyEmbed},
             {:before_update, MyEmbed}, {:before_update, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
-    assert model.embed == %MyEmbed{x: "abc"}
+    assert model.embed == %{embed | x: "abc"}
 
     changeset = Ecto.Changeset.change(%MyModel{id: 1, embeds: [embed]}, embeds: [embed_changeset])
     model = TestRepo.update!(changeset)
     assert [{:after_update, MyModel}, {:after_update, MyEmbed},
             {:before_update, MyEmbed}, {:before_update, MyModel} | _] =
       Agent.get(CallbackAgent, &get_models/1)
-    assert model.embeds == [%MyEmbed{x: "abc"}]
+    assert model.embeds == [%{embed | x: "abc"}]
+  end
+
+  test "removing embeds on update" do
+    embed = %MyEmbed{x: "xyz"}
+
+    # Raises if there's no id
+    changeset = Ecto.Changeset.change(%MyModel{id: 1, embed: embed}, embed: nil)
+    assert_raise Ecto.MissingPrimaryKeyError, fn ->
+      TestRepo.update!(changeset)
+    end
+
+    embed = %{embed | id: @uuid}
 
     # Deleting the embed
     changeset = Ecto.Changeset.change(%MyModel{id: 1, embed: embed}, embed: nil)
@@ -453,7 +483,7 @@ defmodule Ecto.RepoTest do
 
   test "handles nested embeds on update" do
     sub_embed = %SubEmbed{y: "xyz"}
-    embed = %MyEmbed{x: "xyz"}
+    embed = %MyEmbed{id: @uuid, x: "xyz"}
     embed_changeset = Ecto.Changeset.change(embed, sub_embed: sub_embed)
     changeset = Ecto.Changeset.change(%MyModel{id: 1, embed: embed}, embed: embed_changeset)
     model = TestRepo.update!(changeset)


### PR DESCRIPTION
Closes #830

I've also split test into couple smaller ones - it was hard to find the one failing with so many cases in one test.