### PR TITLE
Adding a validation error to the "[field]_confirmation" field instead of the main field

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1177,11 +1177,13 @@ defmodule Ecto.Changeset do
   def validate_confirmation(changeset, field, opts \\ []) do
     validate_change changeset, field, {:confirmation, opts}, fn _, _ ->
       param = Atom.to_string(field)
+      error_param = "#{param}_confirmation"
+      error_field = String.to_atom(error_param)
       value = Map.get(changeset.params, param)
 
-      case Map.fetch(changeset.params, "#{param}_confirmation") do
+      case Map.fetch(changeset.params, error_param) do
         {:ok, ^value} -> []
-        {:ok, _}      -> [{field, message(opts, "does not match confirmation")}]
+        {:ok, _}      -> [{error_field, message(opts, "does not match confirmation")}]
         :error        -> []
       end
     end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -724,17 +724,17 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{"title" => "title", "title_confirmation" => nil})
                 |> validate_confirmation(:title)
     refute changeset.valid?
-    assert changeset.errors == [title: "does not match confirmation"]
+    assert changeset.errors == [title_confirmation: "does not match confirmation"]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
                 |> validate_confirmation(:title)
     refute changeset.valid?
-    assert changeset.errors == [title: "does not match confirmation"]
+    assert changeset.errors == [title_confirmation: "does not match confirmation"]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
                 |> validate_confirmation(:title, message: "doesn't match field below")
     refute changeset.valid?
-    assert changeset.errors == [title: "doesn't match field below"]
+    assert changeset.errors == [title_confirmation: "doesn't match field below"]
 
     # Skip when no parameter
     changeset = changeset(%{"title" => "title"})


### PR DESCRIPTION
I think it's more logical to add an error to the field which an user is supposed to enter the confirmation information into