### PR TITLE
fix(Ecto.Adapters.SQL): ensure binary_ids work with unique_constrant

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -66,8 +66,9 @@ defmodule Ecto.Adapters.SQL do
       def insert(repo, model_meta, params, {key, :binary_id, nil}, returning, opts) do
         {req, resp} = Ecto.Adapters.SQL.bingenerate(key)
         case insert(repo, model_meta, req ++ params, nil, returning, opts) do
-          {:ok, values}     -> {:ok, resp ++ values}
-          {:error, _} = err -> err
+          {:ok, values}         -> {:ok, resp ++ values}
+          {:error, _} = err     -> err
+          {:invalid, _} = err   -> err
         end
       end
 


### PR DESCRIPTION
Previously when using binary_ids, invalid constraints would raise:

 > (CaseClauseError) no case clause matching: {:invalid, [unique:
 > "users_email_index"]}

This adds the missing clause to the case statement for binary_ids.

I wanted to add a test for this too, but couldn't find the correct location for it. If someone could point me in the right direction then I'll add it in.