### PR TITLE
Add reload to Repo

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -519,6 +519,19 @@ defmodule Ecto.Integration.RepoTest do
     assert TestRepo.get(Post, id).temp == "temp"
   end
 
+  test "reload" do
+    post = TestRepo.insert!(%Post{text: "original"})
+
+    changeset = Ecto.Changeset.change(post, text: "changed")
+    TestRepo.update!(changeset)
+
+    assert post.text == "original"
+
+    post = TestRepo.reload(post)
+
+    assert post.text == "changed"
+  end
+
   ## Assocs
 
   test "has_many assoc" do

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -532,6 +532,16 @@ defmodule Ecto.Integration.RepoTest do
     assert post.text == "changed"
   end
 
+  test "reload!" do
+    post = TestRepo.insert!(%Post{text: "original"})
+
+    TestRepo.delete(post)
+
+    assert_raise Ecto.NoResultsError, fn ->
+      TestRepo.reload!(post)
+    end
+  end
+
   ## Assocs
 
   test "has_many assoc" do

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -156,6 +156,10 @@ defmodule Ecto.Repo do
         Ecto.Repo.Queryable.get(__MODULE__, @adapter, queryable, id, opts)
       end
 
+      def reload!(%{ __struct__: queryable, id: id }, opts \\ []) do
+        Ecto.Repo.Queryable.get!(__MODULE__, @adapter, queryable, id, opts)
+      end
+
       def __adapter__ do
         @adapter
       end
@@ -345,6 +349,20 @@ defmodule Ecto.Repo do
   """
 
   defcallback reload(Ecto.Queryable.t, Keyword.t) :: Ecto.Model.t | nil | no_return
+
+  @doc """
+
+  Similar to `reload/2` but raises `Ecto.NoResultsError` if no record was found.
+
+  ## Options
+
+    * `:timeout` - The time in milliseconds to wait for the call to finish,
+      `:infinity` will wait indefinitely (default: 5000)
+    * `:log` - When false, does not log the query
+
+  """
+
+  defcallback reload!(Ecto.Queryable.t, Keyword.t) :: Ecto.Model.t | nil | no_return
 
   @doc """
   Fetches all entries from the data store matching the given query.

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -152,6 +152,10 @@ defmodule Ecto.Repo do
         Ecto.Repo.Preloader.preload(model_or_models, __MODULE__, preloads)
       end
 
+      def reload(%{ __struct__: queryable, id: id }, opts \\ []) do
+        Ecto.Repo.Queryable.get(__MODULE__, @adapter, queryable, id, opts)
+      end
+
       def __adapter__ do
         @adapter
       end
@@ -324,6 +328,23 @@ defmodule Ecto.Repo do
   """
   defcallback preload([Ecto.Model.t] | Ecto.Model.t, preloads :: term) ::
                       [Ecto.Model.t] | Ecto.Model.t
+
+
+  @doc """
+  Reloads a single model from the data store.
+
+  Returns `nil` if no result was found. If the model in the queryable
+  has no primary key `Ecto.NoPrimaryKeyError` will be raised.
+
+  ## Options
+
+    * `:timeout` - The time in milliseconds to wait for the call to finish,
+      `:infinity` will wait indefinitely (default: 5000)
+    * `:log` - When false, does not log the query
+
+  """
+
+  defcallback reload(Ecto.Queryable.t, Keyword.t) :: Ecto.Model.t | nil | no_return
 
   @doc """
   Fetches all entries from the data store matching the given query.


### PR DESCRIPTION
This adds support for reloading models.

```
post = Repo.insert(%Post{text: "original"})

# post is updated elsewhere to have text "changed"

post = Repo.reload(post)

post.text # => "changed"
```