### PR TITLE
Test cases for #890 and #891

### DIFF
--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -660,6 +660,26 @@ defmodule Ecto.AssociationTest do
     end
   end
 
+  # Please note the order is important in this test.
+  test "cast has_many should be composable with :empty" do
+    posts = [%Post{title: "hello", id: 1},
+             %Post{title: "unknown", id: 2},
+             %Post{title: "other", id: 3}]
+    params = [%{"id" => 1, "title" => "hello"},
+              %{"id" => 2, "title" => "unknown"},
+              %{"id" => 3, "title" => "other"}]
+
+    changeset = %Author{posts: posts}
+    |> Changeset.cast(:empty, ~w(posts))
+    |> Changeset.cast(%{"posts" => params}, ~w(posts))
+
+    for post <- (changeset.changes[:posts] || []) do
+       assert post.valid?
+    end
+    assert changeset.valid?
+
+  end
+
   test "cast has_many with invalid params" do
     changeset = Changeset.cast(%Author{}, %{"posts" => "value"}, ~w(posts))
     assert changeset.errors == [posts: "is invalid"]

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -32,6 +32,10 @@ defmodule Ecto.ChangesetTest do
     cast(model, params, ~w(), ~w(title body upvotes topics decimal))
   end
 
+  defp changeset_with_required(model \\ %Post{}, params) do
+    cast(model, params, ~w(title), ~w(body upvotes topics decimal))
+  end
+
   ## cast/4
 
   test "cast/4: with valid string keys" do
@@ -200,6 +204,14 @@ defmodule Ecto.ChangesetTest do
     assert changeset.changes  == %{body: "new body"}
     assert changeset.required == [:title]
     assert changeset.optional == [:body]
+  end
+
+  test "cast/4: works with a changeset when required params are already among changes" do
+    base_changeset = changeset_with_required(%{"title": "the title"})
+    changeset = changeset_with_required(base_changeset, %{body: "new body"})
+    assert changeset.changes[:title] == "the title"
+    assert changeset.errors == []
+    assert changeset.valid?
   end
 
   test "cast/4: works on casting a datetime field" do


### PR DESCRIPTION
#890 was fixed in `0.16.0` though, by not-generating invalid empty changes for relations. The test case can be used to prevent regressions in the future.
#891 is still present, but it may be an inconvenient behaviour rather than a bug.