### PR TITLE
typo fixes

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -21,7 +21,7 @@ defmodule Ecto.Changeset do
   in the database.
 
   However, constraints can only be checked in a safe way when performing
-  the operation in the database. As consequence, validations are
+  the operation in the database. As a consequence, validations are
   always checked before constraints. Constraints won't even be
   checked in case validations failed.
 
@@ -45,11 +45,11 @@ defmodule Ecto.Changeset do
         end
       end
 
-  In the `changeset/2` function above, we define two validations,
-  one for checking the e-mail format and another to check the age,
+  In the `changeset/2` function above, we define two validations -
+  one for checking the e-mail format and another to check the age -
   as well as a unique constraint in the email field.
 
-  Let's suppose the e-mail is given but the age is invalid, the
+  Let's suppose the e-mail is given but the age is invalid.  The
   changeset would have the following errors:
 
       changeset = User.changeset(%User{}, %{age: 0, email: "mary@example.com"})
@@ -65,7 +65,7 @@ defmodule Ecto.Changeset do
       {:error, changeset} = Repo.insert(changeset)
       changeset.errors #=> [email: "has already been taken"]
 
-  Validations and constraints define a explicit boundary when the check
+  Validations and constraints define an explicit boundary when the check
   happens. By moving constraints to the database, we also provide a safe,
   correct and data-race free means of checking the user input.
 
@@ -221,7 +221,7 @@ defmodule Ecto.Changeset do
   Converts the given `params` into a changeset for `model`
   keeping only the set of `required` and `optional` keys.
 
-  This functions receives a model and some `params`, and casts the `params`
+  This function receives a model and some `params`, and casts the `params`
   according to the schema information from `model`. `params` is a map with
   string keys or a map with atom keys containing potentially unsafe data.
 


### PR DESCRIPTION
Small grammatical and typo fixes.
"" -> "a"
"a" -> "an"
"functions" -> "function"