### PR TITLE
validate_length/3 for lists

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -982,17 +982,22 @@ defmodule Ecto.Changeset do
   end
 
   @doc """
-  Validates a change is a string of the given length.
+  Validates a change is a string or list of the given length.
 
   ## Options
 
-    * `:is` - the string length must be exactly this value
-    * `:min` - the string length must be greater than or equal to this value
-    * `:max` - the string length must be less than or equal to this value
+    * `:is` - the length must be exactly this value
+    * `:min` - the length must be greater than or equal to this value
+    * `:max` - the length must be less than or equal to this value
     * `:message` - the message on failure, depending on the validation, is one of:
-      * "should be %{count} characters"
-      * "should be at least %{count} characters"
-      * "should be at most %{count} characters"
+      * for strings:
+        * "should be %{count} characters"
+        * "should be at least %{count} characters"
+        * "should be at most %{count} characters"
+      * for lists:
+        * "should have %{count} items"
+        * "should have at least %{count} items"
+        * "should have at most %{count} items"
 
   ## Examples
 
@@ -1000,31 +1005,45 @@ defmodule Ecto.Changeset do
       validate_length(changeset, :title, max: 100)
       validate_length(changeset, :title, min: 3, max: 100)
       validate_length(changeset, :code, is: 9)
+      validate_length(changeset, :topics, is: 2)
 
   """
   @spec validate_length(t, atom, Keyword.t) :: t
   def validate_length(changeset, field, opts) when is_list(opts) do
     validate_change changeset, field, {:length, opts}, fn
-      _, value when is_binary(value) ->
-        length = String.length(value)
-        error  = ((is = opts[:is]) && wrong_length(length, is, opts)) ||
-                 ((min = opts[:min]) && too_short(length, min, opts)) ||
-                 ((max = opts[:max]) && too_long(length, max, opts))
+      _, value ->
+        {type, length} = case value do
+          value when is_binary(value) ->
+            {:string, String.length(value)}
+          value when is_list(value) ->
+            {:list, length(value)}
+        end
+
+        error = ((is = opts[:is]) && wrong_length(type, length, is, opts)) ||
+                ((min = opts[:min]) && too_short(type, length, min, opts)) ||
+                ((max = opts[:max]) && too_long(type, length, max, opts))
+
         if error, do: [{field, error}], else: []
     end
   end
 
-  defp wrong_length(value, value, _opts), do: nil
-  defp wrong_length(_length, value, opts), do:
+  defp wrong_length(_type, value, value, _opts), do: nil
+  defp wrong_length(:string, _length, value, opts), do:
     {message(opts, "should be %{count} characters"), count: value}
+  defp wrong_length(:list, _length, value, opts), do:
+    {message(opts, "should have %{count} items"), count: value}
 
-  defp too_short(length, value, _opts) when length >= value, do: nil
-  defp too_short(_length, value, opts), do:
+  defp too_short(_type, length, value, _opts) when length >= value, do: nil
+  defp too_short(:string, _length, value, opts), do:
     {message(opts, "should be at least %{count} characters"), count: value}
+  defp too_short(:list, _length, value, opts), do:
+    {message(opts, "should have at least %{count} items"), count: value}
 
-  defp too_long(length, value, _opts) when length <= value, do: nil
-  defp too_long(_length, value, opts), do:
+  defp too_long(_type, length, value, _opts) when length <= value, do: nil
+  defp too_long(:string, _length, value, opts), do:
     {message(opts, "should be at most %{count} characters"), count: value}
+  defp too_long(:list, _length, value, opts), do:
+    {message(opts, "should have at most %{count} items"), count: value}
 
   @doc """
   Validates the properties of a number.

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -988,7 +988,7 @@ defmodule Ecto.Changeset do
 
     * `:is` - the string length must be exactly this value
     * `:min` - the string length must be greater than or equal to this value
-    * `:max` - the string lenght must be less than or equal to this value
+    * `:max` - the string length must be less than or equal to this value
     * `:message` - the message on failure, depending on the validation, is one of:
       * "should be %{count} characters"
       * "should be at least %{count} characters"

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -628,7 +628,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.errors == [title: "yada"]
   end
 
-  test "validate_length/3" do
+  test "validate_length/3 with string" do
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, min: 3, max: 7)
     assert changeset.valid?
     assert changeset.errors == []
@@ -654,6 +654,34 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10, message: "yada")
     assert changeset.errors == [title: {"yada", count: 10}]
+  end
+
+  test "validate_length/3 with list" do
+    changeset = changeset(%{"topics" => ["Politics", "Security", "Economy", "Elections"]}) |> validate_length(:topics, min: 3, max: 7)
+    assert changeset.valid?
+    assert changeset.errors == []
+    assert changeset.validations == [topics: {:length, [min: 3, max: 7]}]
+
+    changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, min: 2, max: 2)
+    assert changeset.valid?
+
+    changeset = changeset(%{"topics" => ["Politics", "Security", "Economy"]}) |> validate_length(:topics, is: 3)
+    assert changeset.valid?
+
+    changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, min: 6, foo: true)
+    refute changeset.valid?
+    assert changeset.errors == [topics: {"should have at least %{count} items", count: 6}]
+
+    changeset = changeset(%{"topics" => ["Politics", "Security", "Economy"]}) |> validate_length(:topics, max: 2)
+    refute changeset.valid?
+    assert changeset.errors == [topics: {"should have at most %{count} items", count: 2}]
+
+    changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10)
+    refute changeset.valid?
+    assert changeset.errors == [topics: {"should have %{count} items", count: 10}]
+
+    changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10, message: "yada")
+    assert changeset.errors == [topics: {"yada", count: 10}]
   end
 
   test "validate_number/3" do


### PR DESCRIPTION
`validate_length/3` only supports strings at the moment, but i needed to validate the length of a list and after searching for a validator for this, i ended up extending Ecto with this functionality.

```elixir
changeset = changeset(%{"topics" => ["Politics"]}) |> validate_length(:topics, min: 1)
changeset.valid? # true
changeset.errors # []

changeset = changeset(%{"topics" => []}) |> validate_length(:topics, min: 1)
changeset.valid? # false
changeset.errors # [topics:{"should have at least %{count} items", count: 1}]

changeset = changeset(%{"topics" => ["Politics", "Economy"]}) |> validate_length(:topics, max: 1)
changeset.valid? # false
changeset.errors # [topics:{"should have at most %{count} items", count: 1}]

changeset = changeset(%{"topics" => ["Politics", "Economy"]}) |> validate_length(:topics, is: 1)
changeset.valid? # false
changeset.errors # [topics:{"should have %{count} items", count: 1}]
```

This functionality is quite useful if you have arrays in your model:

```elixir
schema "posts" do
  field :title
  field :body
  field :uuid, :binary_id
  field :decimal, :decimal
  field :upvotes, :integer, default: 0
  field :topics, {:array, :string}                 # <----
  field :published_at, Ecto.DateTime
  has_many :comments, Ecto.ChangesetTest.Comment
  has_one :comment, Ecto.ChangesetTest.Comment
end
```