### PR TITLE
Add missed commands to execute_ddl callback

### DIFF
--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -13,10 +13,14 @@ defmodule Ecto.Adapter.Migration  do
   @type command ::
     raw :: String.t |
     {:create, Table.t, [table_subcommand]} |
+    {:create_if_not_exists, Table.t, [table_subcommand]} |
     {:alter, Table.t, [table_subcommand]} |
     {:drop, Table.t} |
+    {:drop_if_exists, Table.t} |
     {:create, Index.t} |
-    {:drop, Index.t}
+    {:create_if_not_exists, Index.t} |
+    {:drop, Index.t} |
+    {:drop_if_exists, Index.t}
 
   @typedoc "All commands allowed within the block passed to `table/2`"
   @type table_subcommand ::


### PR DESCRIPTION
Probably documentation at http://hexdocs.pm/ecto/Ecto.Adapter.Migration.html should be updated manually also.