### PR TITLE
Allow external primary keys in nested relations

### DIFF
--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -262,19 +262,15 @@ defmodule Ecto.Changeset.Relation do
   defp map_changes([map | rest], pks, fun, current, acc, valid?, skip?) when is_map(map) do
     pk_values = get_pks(map, pks)
 
-    {model, current} =
+    {model, current, allowed_actions} =
       case Map.fetch(current, pk_values) do
         {:ok, model} ->
-          {model, Map.delete(current, pk_values)}
+          {model, Map.delete(current, pk_values), [:update, :delete]}
         :error ->
-          if Enum.all?(pk_values, &is_nil/1) do
-            {nil, current}
-          else
-            raise Ecto.UnmachedRelationError, new_value: map, old_value: Map.values(current), cardinality: :many
-          end
+          {nil, current, [:insert]}
       end
 
-    changeset = fun.(map, model)
+    changeset = create_changeset!(map, model, fun, allowed_actions)
     map_changes(rest, pks, fun, current, [changeset | acc],
                 valid? && changeset.valid?, skip? && skip?(changeset))
   end
@@ -284,23 +280,35 @@ defmodule Ecto.Changeset.Relation do
   end
 
   defp single_change(new, current_pks, new_pks, fun, current) do
-    current = current_or_nil(new, new_pks, current, current_pks)
-    changeset = fun.(new, current)
+    {current, allowed_actions} =
+      current_or_nil(new, new_pks, current, current_pks)
+
+    changeset = create_changeset!(new, current, fun, allowed_actions)
     {:ok, changeset, changeset.valid?, skip?(changeset)}
   end
 
-  defp current_or_nil(nil, _new_pks, current, _current_pks), do: current
+  defp current_or_nil(nil, _new_pks, current, _current_pks),
+    do: {current, [:update, :delete]}
+  defp current_or_nil(_new, _new_pks, nil, _current_pks),
+    do: {nil, [:insert]}
   defp current_or_nil(new, new_pks, current, current_pks) do
-    new_pk_values = get_pks(new, new_pks)
+    if get_pks(new, new_pks) == get_pks(current, current_pks) do
+      {current, [:update, :delete]}
+    else
+      {nil, [:insert]}
+    end
+  end
 
-    cond do
-      current && new_pk_values == get_pks(current, current_pks) ->
-        current
-      Enum.all?(new_pk_values, &is_nil/1) ->
-        nil
-      true ->
-        raise Ecto.UnmachedRelationError, new_value: new, old_value: current,
-                                          cardinality: :one
+  defp create_changeset!(new, current, fun, allowed_actions) do
+    changeset = fun.(new, current)
+    action = changeset.action
+
+    if action in allowed_actions do
+      changeset
+    else
+      reason = if action == :insert, do: "already exists", else: "does not exist"
+      raise "cannot #{action} related #{inspect changeset.model.__struct__}, " <>
+        "because it #{reason} in the parent model."
     end
   end
 

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -200,29 +200,3 @@ defmodule Ecto.ConstraintError do
     %__MODULE__{message: msg, type: type, constraint: constraint}
   end
 end
-
-defmodule Ecto.UnmachedRelationError do
-  defexception [:message]
-
-  def exception(opts) do
-    old_value = Keyword.fetch!(opts, :old_value)
-    new_value = Keyword.fetch!(opts, :new_value)
-
-    msg =
-      case Keyword.fetch!(opts, :cardinality) do
-        :one  -> "attempted to update model with:"
-        :many -> "attempted to update one of the models with:"
-      end
-
-    msg = """
-    #{msg}
-
-    #{inspect new_value}
-
-    but could not find matching key in:
-
-    #{inspect old_value}
-    """
-    %__MODULE__{message: msg}
-  end
-end

--- a/lib/ecto/repo/model.ex
+++ b/lib/ecto/repo/model.ex
@@ -291,10 +291,11 @@ defmodule Ecto.Repo.Model do
       case Map.get(types, field) do
         {kind, relation} ->
           value = Map.get(struct, field)
+          kind  = kind |> Atom.to_string
           unless Ecto.Changeset.Relation.empty?(relation, value) do
             raise ArgumentError, "model #{inspect struct.__struct__} has value `#{inspect value}` " <>
-              "set for #{kind} named `#{field}`. #{kind}s can only be manipulate via changesets, " <>
-              "be it on insert, update or delete."
+              "set for #{kind} named `#{field}`. #{String.capitalize kind}s can only be " <>
+              "manipulated via changesets, be it on insert, update or delete."
           end
         _ ->
           :ok


### PR DESCRIPTION
For now only the embeds tests are updated. There are other failures due to changes.

We also need a better error message then `error!` - not that helpful :smile: 