### PR TITLE
Use EEX for changeset error messages

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -134,11 +134,11 @@ defmodule Ecto.Changeset do
                         field: atom, message: error_message}
 
   @number_validators %{
-    less_than:                {&</2,  "must be less than %{count}"},
-    greater_than:             {&>/2,  "must be greater than %{count}"},
-    less_than_or_equal_to:    {&<=/2, "must be less than or equal to %{count}"},
-    greater_than_or_equal_to: {&>=/2, "must be greater than or equal to %{count}"},
-    equal_to:                 {&==/2, "must be equal to %{count}"},
+    less_than:                {&</2,  "must be less than <%= count %>"},
+    greater_than:             {&>/2,  "must be greater than <%= count %>"},
+    less_than_or_equal_to:    {&<=/2, "must be less than or equal to <%= count %>"},
+    greater_than_or_equal_to: {&>=/2, "must be greater than or equal to <%= count %>"},
+    equal_to:                 {&==/2, "must be equal to <%= count %>"},
   }
 
   @relations [:embed, :assoc]
@@ -1018,15 +1018,15 @@ defmodule Ecto.Changeset do
 
   defp wrong_length(value, value, _opts), do: nil
   defp wrong_length(_length, value, opts), do:
-    {message(opts, "should be %{count} characters"), count: value}
+    {message(opts, "should be <%= count %> characters"), count: value}
 
   defp too_short(length, value, _opts) when length >= value, do: nil
   defp too_short(_length, value, opts), do:
-    {message(opts, "should be at least %{count} characters"), count: value}
+    {message(opts, "should be at least <%= count %> characters"), count: value}
 
   defp too_long(length, value, _opts) when length <= value, do: nil
   defp too_long(_length, value, opts), do:
-    {message(opts, "should be at most %{count} characters"), count: value}
+    {message(opts, "should be at most <%= count %> characters"), count: value}
 
   @doc """
   Validates the properties of a number.

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -655,15 +655,15 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, min: 6)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at least %{count} characters", count: 6}]
+    assert changeset.errors == [title: {"should be at least <%= count %> characters", count: 6}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, max: 4)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at most %{count} characters", count: 4}]
+    assert changeset.errors == [title: {"should be at most <%= count %> characters", count: 4}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be %{count} characters", count: 10}]
+    assert changeset.errors == [title: {"should be <%= count %> characters", count: 10}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10, message: "yada")
     assert changeset.errors == [title: {"yada", count: 10}]
@@ -680,7 +680,7 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{"upvotes" => -1})
                 |> validate_number(:upvotes, greater_than: 0)
     refute changeset.valid?
-    assert changeset.errors == [upvotes: {"must be greater than %{count}", count: 0}]
+    assert changeset.errors == [upvotes: {"must be greater than <%= count %>", count: 0}]
     assert changeset.validations == [upvotes: {:number, [greater_than: 0]}]
 
     # Multiple validations
@@ -694,7 +694,7 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{"upvotes" => 3})
                 |> validate_number(:upvotes, greater_than: 100, less_than: 0)
     refute changeset.valid?
-    assert changeset.errors == [upvotes: {"must be greater than %{count}", count: 100}]
+    assert changeset.errors == [upvotes: {"must be greater than <%= count %>", count: 100}]
 
     # Multiple validations with custom message errors
     changeset = changeset(%{"upvotes" => 3})


### PR DESCRIPTION
Right now serializing errors in JSONAPI format is painful, the detail field ends up being "must be at least %{count} characters" and there is no easy way to sub in the count value. If the error message strings instead use EEX, it is trivial to output them correctly, as shown below.

```elixir
defmodule App.ChangesetView do
  use App.Web, :view

  def render("error.json", %{changeset: changeset}) do
    errors = Enum.map(changeset.errors, fn {field, detail} ->
      %{
        source: %{ pointer: "/data/attributes/#{field}" },
        title: "Invalid Attribute",
        detail: render_detail(detail)
      }
    end)

    %{errors: errors}
  end

  def render_detail({message, values}) do
    EEx.eval_string message, values
  end

  def render_detail(message) do
    message
  end
end
```