### PR TITLE
Fix sample app README wording

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,6 +1,6 @@
 # Simple
 
-To run this example, you need to ensure postgres is up and running with a `postgres` username and `postgres` password. If you want to run with another credentials, just change the settings in the `config/config.exs` file.
+To run this example, you need to ensure postgres is up and running with a `postgres` username and `postgres` password. If you want to run with other credentials, just change the settings in the `config/config.exs` file.
 
 Then, from the command line:
 


### PR DESCRIPTION
Change `with another credentials` → `with other credentials`