### PR TITLE
show re-assignment for preload in docs

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -317,9 +317,9 @@ defmodule Ecto.Repo do
 
   ## Examples
 
-      Repo.preload posts, :comments
-      Repo.preload posts, comments: :permalinks
-      Repo.preload posts, comments: from(c in Comment, order_by: c.published_at)
+      posts = Repo.preload posts, :comments
+      posts = Repo.preload posts, comments: :permalinks
+      posts = Repo.preload posts, comments: from(c in Comment, order_by: c.published_at)
 
   """
   defcallback preload([Ecto.Model.t] | Ecto.Model.t, preloads :: term) ::


### PR DESCRIPTION
I wasn't sure if there's a better way to show it or if there's a reason the docs don't have it, but the lack of re-assignment for the models being preloaded can be misleading to those that are newer and more prone to forgetting about immutability.

http://hexdocs.pm/ecto/Ecto.Repo.html#c:update/2 shows re-assignment for update.

