### PR TITLE
Add unique_ids function in Repo.Preloader

### DIFF
--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -83,7 +83,7 @@ defmodule Ecto.Repo.Preloader do
   ## Association preloading
 
   defp preload_assoc(structs, module, repo, prefix, assoc, related_key, preloads_or_query) do
-    case ids(structs, module, assoc) do
+    case unique_ids(structs, module, assoc) do
       [] ->
         {:assoc, assoc, HashDict.new}
       ids when is_list(preloads_or_query) ->
@@ -105,6 +105,11 @@ defmodule Ecto.Repo.Preloader do
     end
     loaded = preload_each(repo.all(%{query | prefix: prefix}), repo, preloads)
     {:assoc, assoc, assoc_dict(card, related_key, loaded)}
+  end
+
+  defp unique_ids(structs, module, assoc) do
+    ids(structs, module, assoc)
+    |> Enum.uniq
   end
 
   defp ids(structs, module, assoc) do


### PR DESCRIPTION
This function only calls the ids function with the same parameters but after collecting all the ids, it goes through `Enum.uniq/1` to only use unique ids in the final query.

I don’t know if a better solution would have been to only add the id if it’s not present while in the list comprehension `for id <- ...` https://github.com/elixir-lang/ecto/blob/master/lib/ecto/repo/preloader.ex#L114