### PR TITLE
Fixes atom use in queries

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -121,6 +121,8 @@ defmodule Ecto.Query.Builder do
     do: {literal(number, type, vars), params}
   def escape(binary, type, params, vars, _env) when is_binary(binary),
     do: {literal(binary, type, vars), params}
+  def escape(atom, type, params, vars, _env) when is_atom(atom),
+    do: {literal(atom, type, vars), params}
   def escape(boolean, type, params, vars, _env) when is_boolean(boolean),
     do: {literal(boolean, type, vars), params}
   def escape(nil, _type, params, _vars, _env),

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -74,10 +74,6 @@ defmodule Ecto.Query.BuilderTest do
       escape(quote(do: x), [], __ENV__)
     end
 
-    assert_raise Ecto.Query.CompileError, ~r"`:atom` is not a valid query expression", fn ->
-      escape(quote(do: :atom), [], __ENV__)
-    end
-
     assert_raise Ecto.Query.CompileError, ~r"`unknown\(1, 2\)` is not a valid query expression", fn ->
       escape(quote(do: unknown(1, 2)), [], __ENV__)
     end


### PR DESCRIPTION
Related to #953 I have added support for atoms. Not sure if this is a terrible idea of if I have implemented it safely. Also, the test for `escape` are a bit opaque. Halp!?