### PR TITLE
Add the :disable_safety_warnings for repos

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -34,6 +34,10 @@ defmodule Ecto.Repo do
     * `:url` - an URL that specifies storage information. Read below
       for more information
 
+    * `:disable_safety_warnings` - a boolean that specify whether to ask user
+      for confirmation when dropping a database through the `mix ecto.drop`
+      task. Defaults to `false`; if set to `true`, no confirmation will be asked
+
   ## URLs
 
   Repositories by default support URLs. For example, the configuration

--- a/lib/mix/tasks/ecto.drop.ex
+++ b/lib/mix/tasks/ecto.drop.ex
@@ -28,6 +28,18 @@ defmodule Mix.Tasks.Ecto.Drop do
 
     {opts, _, _} = OptionParser.parse args, switches: [quiet: :boolean]
 
+    if disable_safety_warnings?(repo) or Mix.shell.yes?("Are you sure you want to drop the database for repo #{inspect repo}?") do
+      drop_database(repo, opts)
+    end
+  end
+
+  defp disable_safety_warnings?(repo) do
+    repo.config[:otp_app]
+    |> Application.get_env(repo)
+    |> Keyword.get(:disable_safety_warnings, false)
+  end
+
+  defp drop_database(repo, opts) do
     case Ecto.Storage.down(repo) do
       :ok ->
         unless opts[:quiet] do


### PR DESCRIPTION
If `:disable_safety_warnings` is `false` (which it is by default), `mix ecto.drop` will ask user confirmation before dropping. Related to #934.