### PR TITLE
Underscores the filename when generating a migration file using Mix

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   use Mix.Task
   import Mix.Ecto
   import Mix.Generator
-  import Mix.Utils, only: [camelize: 1]
+  import Mix.Utils, only: [camelize: 1, underscore: 1]
 
   @shortdoc "Generate a new migration for the repo"
 
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
       {_, [name], _} ->
         ensure_repo(repo, args)
         path = Path.relative_to(migrations_path(repo), Mix.Project.app_path)
-        file = Path.join(path, "#{timestamp}_#{name}.exs")
+        file = Path.join(path, "#{timestamp}_#{underscore(name)}.exs")
         create_directory path
         create_file file, migration_template(mod: Module.concat([repo, Migrations, camelize(name)]))
 

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -33,6 +33,12 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
     end
   end
 
+  test "underscores the filename when generating a migration" do
+    run ["-r", to_string(Repo), "MyMigration"]
+    assert [name] = File.ls!(@migrations_path)
+    assert String.match? name, ~r/^\d{14}_my_migration\.exs$/
+  end
+
   test "raises when missing file" do
     assert_raise Mix.Error, fn -> run ["-r", to_string(Repo)] end
   end


### PR DESCRIPTION
Fixes #963 