### PR TITLE
Imported Ecto.Changeset to Ecto.Model

### DIFF
--- a/lib/ecto/model.ex
+++ b/lib/ecto/model.ex
@@ -36,6 +36,7 @@ defmodule Ecto.Model do
     quote do
       use Ecto.Schema
       import Ecto.Model
+      import Ecto.Changeset
 
       use Ecto.Model.OptimisticLock
       use Ecto.Model.Timestamps


### PR DESCRIPTION
In one of the previous commits `import Ecto.Changeset` and `import Ecto.Query, only: [from: 2]` were deleted and I don't know about the latter but I think the former must still be present because otherwise ecto gives an error and doesn't compile