### PR TITLE
Doc fix for sample code

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -125,7 +125,7 @@ defmodule Ecto.Changeset do
                   end
 
                   def changeset(model, params) do
-                    cast(model, params, [:string], [:delete])
+                    cast(model, params, [:body], [:delete])
                     |> maybe_mark_for_deletion
                   end
 


### PR DESCRIPTION
I believe the sample code is incorrect, and the required param should be ```[:body]``` and not ```[:string]```