### PR TITLE
[typo] their -> they

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -12,7 +12,7 @@ defmodule Ecto do
 
     * `Ecto.Changeset` - changesets provide a way for developers to filter
       and cast external parameters, as well as a mechanism to track and
-      validate changes before their are sent to the database
+      validate changes before they are sent to the database
 
     * `Ecto.Query` - written in Elixir syntax, queries are used to retrieve
       information from a given repository. Queries in Ecto are secure, avoiding


### PR DESCRIPTION
Fix a small typo in the Ecto main module documentation