### PR TITLE
Raise helpful error when using wrong Ecto types

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -123,8 +123,8 @@ defmodule Ecto.Schema do
   `:string`               | UTF-8 encoded `string`  | "hello"
   `:binary`               | `binary`                | `<<int, int, int, ...>>`
   `{:array, inner_type}`  | `list`                  | `[value, value, value, ...]`
-  `:decimal`              | [`Decimal`](https://github.com/ericmj/decimal) | 
-  `:map`                  | `map` | 
+  `:decimal`              | [`Decimal`](https://github.com/ericmj/decimal) |
+  `:map`                  | `map` |
 
   **Note:** For the `:array` type, replace `inner_type` with one of
   the valid types, such as `:string`.
@@ -1221,11 +1221,32 @@ defmodule Ecto.Schema do
         if Code.ensure_compiled?(type) and function_exported?(type, :type, 0) do
           type
         else
-          raise ArgumentError, "invalid or unknown type #{inspect type} for field #{inspect name}"
+          raise_type_error(name, type)
         end
       true ->
         raise ArgumentError, "invalid type #{inspect type} for field #{inspect name}"
     end
+  end
+
+  defp raise_type_error(name, :datetime) do
+    raise_wrong_ecto_type(name, :datetime, Ecto.DateTime)
+  end
+  defp raise_type_error(name, :date) do
+    raise_wrong_ecto_type(name, :date, Ecto.Date)
+  end
+  defp raise_type_error(name, :time) do
+    raise_wrong_ecto_type(name, :time, Ecto.Time)
+  end
+  defp raise_type_error(name, :uuid) do
+    raise_wrong_ecto_type(name, :uuid, Ecto.UUID)
+  end
+  defp raise_type_error(name, type) do
+    raise ArgumentError, "invalid or unknown type #{inspect type} for field #{inspect name}"
+  end
+
+  defp raise_wrong_ecto_type(name, given_type, real_type) do
+    raise ArgumentError, "invalid or unknown type #{inspect given_type} for field #{inspect name}. " <>
+      "Maybe you meant to use #{inspect real_type} as the type?"
   end
 
   defp check_default!(_name, :binary_id, _default), do: :ok

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -159,6 +159,54 @@ defmodule Ecto.SchemaTest do
     end
   end
 
+  test "raises helpful error for :datetime" do
+    assert_raise ArgumentError, ~r/Maybe you meant to use Ecto.DateTime as the type/, fn ->
+      defmodule ModelInvalidFieldType do
+        use Ecto.Model
+
+        schema "invalidtype" do
+          field :published_at, :datetime
+        end
+      end
+    end
+  end
+
+  test "raises helpful error for :date" do
+    assert_raise ArgumentError, ~r/Maybe you meant to use Ecto.Date as the type/, fn ->
+      defmodule ModelInvalidFieldType do
+        use Ecto.Model
+
+        schema "invalidtype" do
+          field :published_on, :date
+        end
+      end
+    end
+  end
+
+  test "raises helpful error for :time" do
+    assert_raise ArgumentError, ~r/Maybe you meant to use Ecto.Time as the type/, fn ->
+      defmodule ModelInvalidFieldType do
+        use Ecto.Model
+
+        schema "invalidtype" do
+          field :published_time, :time
+        end
+      end
+    end
+  end
+
+  test "raises helpful error for :uuid" do
+    assert_raise ArgumentError, ~r/Maybe you meant to use Ecto.UUID as the type/, fn ->
+      defmodule ModelInvalidFieldType do
+        use Ecto.Model
+
+        schema "invalidtype" do
+          field :author_id, :uuid
+        end
+      end
+    end
+  end
+
   test "fail invalid schema" do
     assert_raise ArgumentError, "schema source must be a string, got: :hello", fn ->
       defmodule SchemaFail do


### PR DESCRIPTION
Right now if you use :datetime, :date, :time, or :uuid it will give an
error like this:

(ArgumentError) invalid or unknown type :datetime for field :published_at

To make it a bit easier to guide users in the right direction the
message adds:

Maybe you meant to set the type to Ecto.DateTime?

Closes #994