### PR TITLE
Correctly shutdown adapter application after migrating

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -118,6 +118,9 @@ defmodule Ecto.Adapters.SQL do
         :ok
       end
 
+      @doc false
+      def __adapter__, do: @adapter
+
       defoverridable [prepare: 2, execute: 6,
                       insert: 6, update: 7, delete: 5,
                       execute_ddl: 3, embed_id: 1,

--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
   @doc false
   def run(args, migrator \\ &Ecto.Migrator.run/4) do
     repo = parse_repo(args)
-    adapter = repo.__adapter__
+    adapter = repo.__adapter__.__adapter__
 
     {opts, _, _} = OptionParser.parse args,
       switches: [all: :boolean, step: :integer, to: :integer, quiet: :boolean],

--- a/test/mix/tasks/ecto.migrate_test.exs
+++ b/test/mix/tasks/ecto.migrate_test.exs
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Ecto.MigrateTest do
     end
 
     def __adapter__ do
-      :ecto
+      Ecto.Adapters.Postgres
     end
 
     def __repo__ do


### PR DESCRIPTION
Looks like there was a simple mistake when shutting down the adapter application after migrating. Both `Repo`s and `Adapter`s have an `@adapter` and the `Repo`'s was used in the migration instead of the application name in the `Adapter`, which results in the following error after migrating: 

```
** (MatchError) no match of right hand side value: {:error, {Ecto.Adapters.Postgres, {'no such file or directory', 'Elixir.Ecto.Adapters.Postgres.app'}}}
    lib/mix/tasks/ecto.migrate.ex:53: Mix.Tasks.Ecto.Migrate.run/2
    (mix) lib/mix/task.ex:291: Mix.Task.run_alias/3
    (mix) lib/mix/task.ex:243: Mix.Task.run/2
    (mix) lib/mix/task.ex:291: Mix.Task.run_alias/3
    (mix) lib/mix/task.ex:243: Mix.Task.run/2
    (mix) lib/mix/cli.ex:55: Mix.CLI.run_task/2
```

Not sure if this is the best way to grab the adapters application name, so feel free to fix this up a bit.