### PR TITLE
Use a normal exit instead of shutting down

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -41,7 +41,7 @@ defmodule Ecto.Adapters.SQL do
       @doc false
       def stop(pid, timeout) do
         ref = Process.monitor(pid)
-        Process.exit(pid, :shutdown)
+        Process.exit(pid, :normal)
         receive do
           {:DOWN, ^ref, _, _, _} -> :ok
         after


### PR DESCRIPTION
Fixes the issue related to migrations killing mix.

Discussed in https://github.com/elixir-lang/ecto/pull/996