### PR TITLE
WIP: Add ownership

### DIFF
--- a/integration_test/cases/migrator.exs
+++ b/integration_test/cases/migrator.exs
@@ -10,7 +10,7 @@ defmodule Ecto.Integration.MigratorTest do
   alias Ecto.Migration.SchemaMigration
 
   setup do
-    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool, Ecto.Adapters.SQL.Sandbox)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo, Ecto.Adapters.SQL.Sandbox)
     TestRepo.delete_all(SchemaMigration)
     :ok
   end

--- a/integration_test/cases/migrator.exs
+++ b/integration_test/cases/migrator.exs
@@ -10,6 +10,8 @@ defmodule Ecto.Integration.MigratorTest do
   alias Ecto.Migration.SchemaMigration
 
   setup do
+    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool,
+                                                   Ecto.Adapters.SQL.Sandbox)
     TestRepo.delete_all(SchemaMigration)
     :ok
   end

--- a/integration_test/cases/migrator.exs
+++ b/integration_test/cases/migrator.exs
@@ -10,8 +10,7 @@ defmodule Ecto.Integration.MigratorTest do
   alias Ecto.Migration.SchemaMigration
 
   setup do
-    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool,
-                                                   Ecto.Adapters.SQL.Sandbox)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool, Ecto.Adapters.SQL.Sandbox)
     TestRepo.delete_all(SchemaMigration)
     :ok
   end

--- a/integration_test/cases/pool.exs
+++ b/integration_test/cases/pool.exs
@@ -12,8 +12,8 @@ defmodule Ecto.Integration.PoolTest do
   repo = Application.get_env(:ecto, Ecto.Integration.TestRepo) ||
          raise "could not find configuration for Ecto.Integration.TestRepo"
 
-  Application.put_env(:ecto, __MODULE__.MockRepo,
-                      [pool: pool, pool_size: 1] ++ repo)
+  new_opts = [pool: pool, pool_size: 1, use_ownership: false]
+  Application.put_env(:ecto, __MODULE__.MockRepo, new_opts ++ repo)
 
   defmodule MockRepo do
     use Ecto.Repo, otp_app: :ecto

--- a/integration_test/cases/pool.exs
+++ b/integration_test/cases/pool.exs
@@ -12,7 +12,7 @@ defmodule Ecto.Integration.PoolTest do
   repo = Application.get_env(:ecto, Ecto.Integration.TestRepo) ||
          raise "could not find configuration for Ecto.Integration.TestRepo"
 
-  new_opts = [pool: pool, pool_size: 1, use_ownership: false]
+  new_opts = [pool: pool, pool_size: 1]
   Application.put_env(:ecto, __MODULE__.MockRepo, new_opts ++ repo)
 
   defmodule MockRepo do

--- a/integration_test/mysql/all_test.exs
+++ b/integration_test/mysql/all_test.exs
@@ -2,7 +2,7 @@ Code.require_file "../sql/escape.exs", __DIR__
 Code.require_file "../sql/lock.exs", __DIR__
 Code.require_file "../sql/migration.exs", __DIR__
 Code.require_file "../sql/sql.exs", __DIR__
-Code.require_file "../sql/test_transaction.exs", __DIR__
+# Code.require_file "../sql/test_transaction.exs", __DIR__
 Code.require_file "../sql/transaction.exs", __DIR__
 Code.require_file "../cases/interval.exs", __DIR__
 Code.require_file "../cases/joins.exs", __DIR__

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -26,7 +26,7 @@ alias Ecto.Integration.TestRepo
 Application.put_env(:ecto, TestRepo,
   adapter: Ecto.Adapters.MySQL,
   url: "ecto://root@localhost/ecto_test",
-  pool: Ecto.Pools.Ownership.Server,
+  pool: Ecto.Pools.Ownership,
   ownership_pool: pool)
 
 defmodule Ecto.Integration.TestRepo do
@@ -50,8 +50,7 @@ defmodule Ecto.Integration.Case do
   use ExUnit.CaseTemplate
 
   setup do
-    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool,
-                                                   Ecto.Adapters.SQL.Sandbox)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool, Ecto.Adapters.SQL.Sandbox)
     :ok
   end
 end
@@ -63,9 +62,9 @@ _   = Ecto.Storage.down(TestRepo)
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
-Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool)
+Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool)
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)
 Process.flag(:trap_exit, true)
 
-Ecto.Pools.Ownership.Server.ownership_checkin(TestRepo.Pool)
+Ecto.Pools.Ownership.ownership_checkin(TestRepo.Pool)

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -26,7 +26,8 @@ alias Ecto.Integration.TestRepo
 Application.put_env(:ecto, TestRepo,
   adapter: Ecto.Adapters.MySQL,
   url: "ecto://root@localhost/ecto_test",
-  pool: Ecto.Adapters.SQL.Sandbox)
+  pool: pool,
+  use_ownership: true)
 
 defmodule Ecto.Integration.TestRepo do
   use Ecto.Integration.Repo, otp_app: :ecto
@@ -48,14 +49,9 @@ end
 defmodule Ecto.Integration.Case do
   use ExUnit.CaseTemplate
 
-  setup_all do
-    Ecto.Adapters.SQL.begin_test_transaction(TestRepo, [])
-    on_exit fn -> Ecto.Adapters.SQL.rollback_test_transaction(TestRepo, []) end
-    :ok
-  end
-
   setup do
-    Ecto.Adapters.SQL.restart_test_transaction(TestRepo, [])
+    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool,
+                                                   Ecto.Adapters.SQL.Sandbox)
     :ok
   end
 end
@@ -67,5 +63,9 @@ _   = Ecto.Storage.down(TestRepo)
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
+Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool, nil)
+
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)
 Process.flag(:trap_exit, true)
+
+Ecto.Pools.Ownership.Server.ownership_checkin(TestRepo.Pool)

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -26,8 +26,8 @@ alias Ecto.Integration.TestRepo
 Application.put_env(:ecto, TestRepo,
   adapter: Ecto.Adapters.MySQL,
   url: "ecto://root@localhost/ecto_test",
-  pool: pool,
-  use_ownership: true)
+  pool: Ecto.Pools.Ownership.Server,
+  ownership_pool: pool)
 
 defmodule Ecto.Integration.TestRepo do
   use Ecto.Integration.Repo, otp_app: :ecto

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -63,7 +63,7 @@ _   = Ecto.Storage.down(TestRepo)
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
-Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool, nil)
+Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool)
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)
 Process.flag(:trap_exit, true)

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -50,7 +50,7 @@ defmodule Ecto.Integration.Case do
   use ExUnit.CaseTemplate
 
   setup do
-    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool, Ecto.Adapters.SQL.Sandbox)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo, Ecto.Adapters.SQL.Sandbox)
     :ok
   end
 end
@@ -62,9 +62,9 @@ _   = Ecto.Storage.down(TestRepo)
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
-Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool)
+Ecto.Pools.Ownership.ownership_checkout(TestRepo)
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)
 Process.flag(:trap_exit, true)
 
-Ecto.Pools.Ownership.ownership_checkin(TestRepo.Pool)
+Ecto.Pools.Ownership.ownership_checkin(TestRepo)

--- a/integration_test/pg/all_test.exs
+++ b/integration_test/pg/all_test.exs
@@ -2,7 +2,7 @@ Code.require_file "../sql/escape.exs", __DIR__
 Code.require_file "../sql/lock.exs", __DIR__
 Code.require_file "../sql/migration.exs", __DIR__
 Code.require_file "../sql/sql.exs", __DIR__
-Code.require_file "../sql/test_transaction.exs", __DIR__
+# Code.require_file "../sql/test_transaction.exs", __DIR__
 Code.require_file "../sql/transaction.exs", __DIR__
 Code.require_file "../cases/interval.exs", __DIR__
 Code.require_file "../cases/joins.exs", __DIR__

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -46,7 +46,7 @@ defmodule Ecto.Integration.Case do
   use ExUnit.CaseTemplate
 
   setup do
-    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool, Ecto.Adapters.SQL.Sandbox)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo, Ecto.Adapters.SQL.Sandbox)
     :ok
   end
 end
@@ -58,9 +58,9 @@ _   = Ecto.Storage.down(TestRepo)
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
-Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool)
+Ecto.Pools.Ownership.ownership_checkout(TestRepo)
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)
 Process.flag(:trap_exit, true)
 
-Ecto.Pools.Ownership.ownership_checkin(TestRepo.Pool)
+Ecto.Pools.Ownership.ownership_checkin(TestRepo)

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -22,7 +22,7 @@ alias Ecto.Integration.TestRepo
 Application.put_env(:ecto, TestRepo,
   adapter: Ecto.Adapters.Postgres,
   url: "ecto://postgres:postgres@localhost/ecto_test",
-  pool: Ecto.Pools.Ownership.Server,
+  pool: Ecto.Pools.Ownership,
   ownership_pool: pool)
 
 defmodule Ecto.Integration.TestRepo do
@@ -46,8 +46,7 @@ defmodule Ecto.Integration.Case do
   use ExUnit.CaseTemplate
 
   setup do
-    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool,
-                                                   Ecto.Adapters.SQL.Sandbox)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool, Ecto.Adapters.SQL.Sandbox)
     :ok
   end
 end
@@ -59,9 +58,9 @@ _   = Ecto.Storage.down(TestRepo)
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
-Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool)
+Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool)
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)
 Process.flag(:trap_exit, true)
 
-Ecto.Pools.Ownership.Server.ownership_checkin(TestRepo.Pool)
+Ecto.Pools.Ownership.ownership_checkin(TestRepo.Pool)

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -59,7 +59,7 @@ _   = Ecto.Storage.down(TestRepo)
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
-Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool, nil)
+Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool)
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)
 Process.flag(:trap_exit, true)

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -22,8 +22,8 @@ alias Ecto.Integration.TestRepo
 Application.put_env(:ecto, TestRepo,
   adapter: Ecto.Adapters.Postgres,
   url: "ecto://postgres:postgres@localhost/ecto_test",
-  pool: pool,
-  use_ownership: true)
+  pool: Ecto.Pools.Ownership.Server,
+  ownership_pool: pool)
 
 defmodule Ecto.Integration.TestRepo do
   use Ecto.Integration.Repo, otp_app: :ecto

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -237,7 +237,7 @@ defmodule Ecto.Integration.MigrationTest do
   import Ecto.Migrator, only: [up: 4, down: 4]
 
   setup do
-    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo)
     :ok
   end
 

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -237,7 +237,7 @@ defmodule Ecto.Integration.MigrationTest do
   import Ecto.Migrator, only: [up: 4, down: 4]
 
   setup do
-    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool, nil)
+    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool)
     :ok
   end
 

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -237,7 +237,7 @@ defmodule Ecto.Integration.MigrationTest do
   import Ecto.Migrator, only: [up: 4, down: 4]
 
   setup do
-    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool)
     :ok
   end
 

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -236,6 +236,11 @@ defmodule Ecto.Integration.MigrationTest do
   import Ecto.Query, only: [from: 2]
   import Ecto.Migrator, only: [up: 4, down: 4]
 
+  setup do
+    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool, nil)
+    :ok
+  end
+
   test "create and drop table and indexes" do
     assert :ok == up(TestRepo, 20050906120000, CreateMigration, log: false)
     assert :ok == down(TestRepo, 20050906120000, CreateMigration, log: false)

--- a/integration_test/sql/test_transaction.exs
+++ b/integration_test/sql/test_transaction.exs
@@ -12,23 +12,23 @@ defmodule Ecto.Integration.TestTransactionTest do
   end
 
   test "begin, restart and rollback" do
-    assert_transaction(:raw)
+    assert_transaction(:default)
     assert :ok = Ecto.Adapters.SQL.begin_test_transaction(TestRepo)
     assert_transaction(:sandbox)
     assert :ok = Ecto.Adapters.SQL.restart_test_transaction(TestRepo)
     assert_transaction(:sandbox)
     assert :ok = Ecto.Adapters.SQL.rollback_test_transaction(TestRepo)
-    assert_transaction(:raw)
+    assert_transaction(:default)
   after
     Ecto.Adapters.SQL.rollback_test_transaction(TestRepo)
   end
 
   test "restart_test_transaction begins a transaction if one is not running" do
-    assert_transaction(:raw)
+    assert_transaction(:default)
     assert :ok = Ecto.Adapters.SQL.restart_test_transaction(TestRepo)
     assert_transaction(:sandbox)
     assert :ok = Ecto.Adapters.SQL.rollback_test_transaction(TestRepo)
-    assert_transaction(:raw)
+    assert_transaction(:default)
   after
     Ecto.Adapters.SQL.rollback_test_transaction(TestRepo)
   end

--- a/integration_test/sql/transaction.exs
+++ b/integration_test/sql/transaction.exs
@@ -12,6 +12,7 @@ defmodule Ecto.Integration.TransactionTest do
   end
 
   setup do
+    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool, nil)
     PoolRepo.delete_all "transactions"
     :ok
   end

--- a/integration_test/sql/transaction.exs
+++ b/integration_test/sql/transaction.exs
@@ -12,7 +12,7 @@ defmodule Ecto.Integration.TransactionTest do
   end
 
   setup do
-    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool, nil)
+    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool)
     PoolRepo.delete_all "transactions"
     :ok
   end

--- a/integration_test/sql/transaction.exs
+++ b/integration_test/sql/transaction.exs
@@ -12,7 +12,7 @@ defmodule Ecto.Integration.TransactionTest do
   end
 
   setup do
-    Ecto.Pools.Ownership.Server.ownership_checkout(TestRepo.Pool)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool)
     PoolRepo.delete_all "transactions"
     :ok
   end

--- a/integration_test/sql/transaction.exs
+++ b/integration_test/sql/transaction.exs
@@ -12,7 +12,7 @@ defmodule Ecto.Integration.TransactionTest do
   end
 
   setup do
-    Ecto.Pools.Ownership.ownership_checkout(TestRepo.Pool)
+    Ecto.Pools.Ownership.ownership_checkout(TestRepo)
     PoolRepo.delete_all "transactions"
     :ok
   end

--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -63,13 +63,13 @@ defmodule Ecto.Adapters.SQL.Sandbox do
   end
 
   @doc false
-  def open_transaction(pool, timeout) do
+  def checkout_transaction(pool, timeout) do
     checkout(pool, :transaction, timeout)
   end
 
   @doc false
-  def close_transaction(pool, ref, _) do
-    GenServer.cast(pool, {:checkin, ref})
+  def close_transaction(_pool, _ref, _timeout) do
+    :ok
   end
 
   @doc false
@@ -84,7 +84,7 @@ defmodule Ecto.Adapters.SQL.Sandbox do
     _ = Process.flag(:trap_exit, true)
     {shutdown, params} = Keyword.pop(opts, :shutdown, 5_000)
     {:ok, %{module: module, conn: nil, queue: :queue.new(), fun: nil,
-            ref: nil, monitor: nil, mode: :raw, params: params,
+            ref: nil, monitor: nil, mode: :default, params: params,
             shutdown: shutdown}}
   end
 
@@ -103,10 +103,10 @@ defmodule Ecto.Adapters.SQL.Sandbox do
   ## Checkout
 
   @doc false
-  def handle_call({:checkout, ref, fun}, {pid, _}, %{ref: nil} = s) do
+  def handle_call({:checkout, ref, fun}, {pid, _}, %{ref: nil, mode: mode} = s) do
     %{module: module, conn: conn} = s
     mon = Process.monitor(pid)
-    {:reply, {:ok, {module, conn}}, %{s | fun: fun, ref: ref, monitor: mon}}
+    {:reply, {:ok, {module, conn}, mode}, %{s | fun: fun, ref: ref, monitor: mon}}
   end
   def handle_call({:checkout, ref, fun}, {pid, _} = from, %{queue: q} = s) do
     mon = Process.monitor(pid)
@@ -115,7 +115,7 @@ defmodule Ecto.Adapters.SQL.Sandbox do
 
   ## Break
 
-  def handle_call({:break, ref}, from, %{mode: :raw, ref: ref} = s) do
+  def handle_call({:break, ref}, from, %{mode: :default, ref: ref} = s) do
     s = demonitor(s)
     GenServer.reply(from, :ok)
     s = s
@@ -171,7 +171,7 @@ defmodule Ecto.Adapters.SQL.Sandbox do
   def handle_info({:DOWN, mon, _, _, _}, %{monitor: mon, fun: :run} = s) do
     {:noreply, dequeue(%{s | fun: nil, monitor: nil, ref: nil})}
   end
-  def handle_info({:DOWN, mon, _, _, _}, %{monitor: mon, mode: :raw} = s) do
+  def handle_info({:DOWN, mon, _, _, _}, %{monitor: mon, mode: :default} = s) do
     s = %{s | fun: nil, monitor: nil, ref: nil}
       |> reset()
       |> dequeue()
@@ -210,8 +210,8 @@ defmodule Ecto.Adapters.SQL.Sandbox do
   defp checkout(pool, fun, timeout) do
     ref = make_ref()
     case :timer.tc(fn() -> do_checkout(pool, ref, fun, timeout) end) do
-      {queue_time, {:ok, mod_conn}} ->
-        {:ok, ref, mod_conn, queue_time}
+      {queue_time, {:ok, mod_conn, mode}} ->
+        {:ok, ref, mod_conn, mode, queue_time}
       {_, {:error, _} = error} ->
         error
     end
@@ -253,11 +253,11 @@ defmodule Ecto.Adapters.SQL.Sandbox do
     %{s | fun: nil, ref: nil, monitor: nil}
   end
 
-  defp dequeue(%{queue: q} = s) do
+  defp dequeue(%{queue: q, mode: mode} = s) do
     case :queue.out(q) do
       {{:value, {:checkout, from, ref, fun, mon}}, q} ->
         %{module: module, conn: conn} = s
-        GenServer.reply(from, {:ok, {module, conn}})
+        GenServer.reply(from, {:ok, {module, conn}, mode})
         %{s | ref: ref, fun: fun, monitor: mon, queue: q}
       {{:value, {query, log, opts, from}}, q} ->
         {reply, s} = handle_query(query, log, opts, %{s | queue: q})
@@ -280,7 +280,7 @@ defmodule Ecto.Adapters.SQL.Sandbox do
   defp begin(%{ref: nil, mode: :sandbox} = s, _) do
     {{:error, :sandbox}, s}
   end
-  defp begin(%{ref: nil, mode: :raw, module: module} = s, query!) do
+  defp begin(%{ref: nil, mode: :default, module: module} = s, query!) do
     begin_sql = module.begin_transaction()
     query!.(s, begin_sql)
     savepoint_sql = module.savepoint("ecto_sandbox")
@@ -288,18 +288,18 @@ defmodule Ecto.Adapters.SQL.Sandbox do
     {:ok, %{s | mode: :sandbox}}
   end
 
-  defp restart(%{ref: nil, mode: :raw} = s, query!), do: begin(s, query!)
+  defp restart(%{ref: nil, mode: :default} = s, query!), do: begin(s, query!)
   defp restart(%{ref: nil, mode: :sandbox, module: module} = s, query!) do
     sql = module.rollback_to_savepoint("ecto_sandbox")
     query!.(s, sql)
     {:ok, s}
   end
 
-  defp rollback(%{ref: nil, mode: :raw} = s, _), do: {:ok, s}
+  defp rollback(%{ref: nil, mode: :default} = s, _), do: {:ok, s}
   defp rollback(%{ref: nil, mode: :sandbox, module: module} = s, query!) do
     sql = module.rollback()
     query!.(s, sql)
-    {:ok, %{s | mode: :raw}}
+    {:ok, %{s | mode: :default}}
   end
 
   defp query!(%{module: module, conn: conn}, sql, log, opts) do

--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -28,7 +28,17 @@ defmodule Ecto.Adapters.SQL.Sandbox do
   end
 
   def open_transaction(_pool, _worker, _timeout) do
-    raise "#{inspect __MODULE__}.open_transaction/3 should never be called"
+    raise """
+    If you want to use ownership with SQL sandbox, configure your repo like this:
+
+        config :ecto, MyRepo,
+          pool: Ecto.Pools.Ownership,
+          ownership_pool: AnyPool)
+
+    In your test setup call ownership_checkout passing the sandbox as second option:
+
+        Ecto.Pools.Ownership.ownership_checkout(MyRepo, Ecto.Adapters.SQL.Sandbox)
+    """
   end
 
   def ownership_checkout(module, conn) do

--- a/lib/ecto/pool.ex
+++ b/lib/ecto/pool.ex
@@ -32,6 +32,8 @@ defmodule Ecto.Pool do
 
   @type conn :: {module, pid}
 
+  @type mode :: :normal | :sandbox
+
   defcallback open_transaction(t, worker, timeout) :: :ok
 
   @doc """
@@ -70,7 +72,7 @@ defmodule Ecto.Pool do
   `{:error, :noconnect}` if a connection is not available.
   """
   defcallback checkout(t, timeout) ::
-    {:ok, worker, conn, queue_time} |
+    {:ok, worker, conn, mode, queue_time} |
     {:error, :noproc | :noconnect}
 
   @doc """

--- a/lib/ecto/pool.ex
+++ b/lib/ecto/pool.ex
@@ -28,6 +28,12 @@ defmodule Ecto.Pool do
   """
   @type queue_time :: non_neg_integer
 
+  @type worker :: any
+
+  @type conn :: {module, pid}
+
+  defcallback open_transaction(t, worker, timeout) :: :ok
+
   @doc """
   Start a pool of connections.
 
@@ -65,7 +71,7 @@ defmodule Ecto.Pool do
   """
   defcallback checkout(t, timeout) ::
     {:ok, worker, conn, queue_time} |
-    {:error, :noproc | :noconnect} when worker: any, conn: {module, pid}
+    {:error, :noproc | :noconnect}
 
   @doc """
   Checkin a worker/connection to the pool.
@@ -73,7 +79,7 @@ defmodule Ecto.Pool do
   Called when the top level `run/4` finishes, if `break/2` was not called
   inside the fun.
   """
-  defcallback checkin(t, worker, timeout) :: :ok when worker: any
+  defcallback checkin(t, worker, timeout) :: :ok
 
   @doc """
   Break the current transaction or run.
@@ -81,7 +87,7 @@ defmodule Ecto.Pool do
   Called when the function has failed and the connection should no longer be
   available to to the calling process.
   """
-  defcallback break(t, worker, timeout) :: :ok when worker: any
+  defcallback break(t, worker, timeout) :: :ok
 
   @doc """
   Open a transaction with a connection from the pool.
@@ -97,9 +103,9 @@ defmodule Ecto.Pool do
   Returns `{:error, :noproc}` if the pool is not alive and
   `{:error, :noconnect}` if a connection is not available.
   """
-  defcallback open_transaction(t, timeout) ::
+  defcallback checkout_transaction(t, timeout) ::
     {:ok, worker, conn, queue_time} |
-    {:error, :noproc | :noconnect} when worker: any, conn: {module, pid}
+    {:error, :noproc | :noconnect}
 
   @doc """
   Close the transaction and signal to the worker the work with the connection
@@ -108,7 +114,7 @@ defmodule Ecto.Pool do
   Called once the transaction at `depth` `1` is finished, if the transaction
   is not broken with `break/2`.
   """
-  defcallback close_transaction(t, worker, timeout) :: :ok when worker: any
+  defcallback close_transaction(t, worker, timeout) :: :ok
 
   @doc """
   Runs a fun using a connection from a pool.

--- a/lib/ecto/pools/ownership.ex
+++ b/lib/ecto/pools/ownership.ex
@@ -1,0 +1,191 @@
+defmodule Ecto.Pools.Ownership do
+
+  defmodule Strategy do
+    use Behaviour
+    alias Ecto.Pool
+
+    defcallback ownership_checkout(module, pid) :: Pool.mode
+    defcallback ownership_checkin(module, pid) :: Pool.mode
+  end
+
+  defmodule Server do
+    use GenServer
+
+    @behaviour Ecto.Pool
+    @timeout 5_000
+
+    def start_link(_, _) do
+      raise "#{inspect __MODULE__}.start_link/2 should never be called"
+    end
+
+    def start_link(adapter, repo, opts) do
+      pool     = Keyword.fetch!(opts, :pool)
+      name     = Keyword.fetch!(opts, :pool_name)
+      opts     = Keyword.put(opts, :pool_name, Module.concat(name, Inner))
+
+      adapter_opts = {adapter, repo, opts}
+      GenServer.start_link(__MODULE__, {pool, adapter_opts}, [name: name])
+    end
+
+    def ownership_checkout(pool, strategy, timeout \\ @timeout) do
+      case GenServer.call(pool, {:ownership_checkout, strategy, timeout}, timeout) do
+        :ok ->
+          :ok
+        {:error, :already_checked_out} ->
+          raise ArgumentError, "process already owns a worker"
+      end
+    end
+
+    def ownership_checkin(pool, timeout \\ @timeout) do
+      case GenServer.call(pool, {:ownership_checkin, timeout}, timeout) do
+        :ok ->
+          :ok
+        {:error, :not_checked_out} ->
+          raise ArgumentError, "process doesn't own a worker"
+      end
+    end
+
+    def checkout(pool, timeout) do
+      {worker, mod_conn, mode} =
+        GenServer.call(pool, :get_checkout, timeout)
+        |> maybe_raise
+      # TODO: queue_time
+      {:ok, worker, mod_conn, mode, 0}
+    end
+
+    def checkin(_pool, _worker, _timeout) do
+      :ok
+    end
+
+    def break(pool, worker, timeout) do
+      GenServer.call(pool, {:break, worker, timeout}, timeout)
+      |> maybe_raise
+    end
+
+    def checkout_transaction(pool, timeout) do
+      {fun, {worker, mod_conn, mode}} =
+        GenServer.call(pool, {:open_transaction, timeout}, timeout)
+        |> maybe_raise
+
+      fun.()
+      # TODO: queue_time
+      {:ok, worker, mod_conn, mode, 0}
+    end
+
+    def open_transaction(_pool, _worker, _timeout) do
+      raise "#{inspect __MODULE__}.open_transaction/3 should never be called"
+    end
+
+    def close_transaction(pool, worker, timeout) do
+      fun =
+        GenServer.call(pool, {:close_transaction, worker, timeout}, timeout)
+        |> maybe_raise
+
+      fun.()
+    end
+
+    defp maybe_raise({:error, :not_checked_out}),
+      do: raise(ArgumentError, "process doesn't own a worker")
+    defp maybe_raise(:ok),
+      do: :ok
+    defp maybe_raise({:ok, value}),
+      do: value
+
+
+    def init({module, {adapter, repo, opts}}) do
+      {:ok, pid} = adapter.start_link(repo, opts)
+      {:ok, %{module: module,
+              pool: pid,
+              owners: %{}}}
+    end
+
+    def handle_call({:ownership_checkout, strategy, timeout}, {pid, _ref}, s) do
+      case Map.fetch(s.owners, pid) do
+        {:ok, _} ->
+          {:reply, {:error, :already_checked_out}, s}
+        :error ->
+          checkout = retrieve_worker(timeout, s)
+          {worker, {module, conn}, :default, _queue_time} = checkout
+          mode = if strategy,
+                   do: strategy.ownership_checkout(module, conn),
+                 else: :default
+
+
+          checkout = {worker, {module, conn}, mode}
+          s = monitor_owner(pid, checkout, strategy, s)
+          {:reply, :ok, s}
+      end
+    end
+
+    def handle_call({:ownership_checkin, timeout}, {pid, _ref}, s) do
+      case Map.fetch(s.owners, pid) do
+        {:ok, {_ref, {worker, {module, conn}, _mode}, strategy}} ->
+          if strategy, do: strategy.ownership_checkin(module, conn)
+          s.module.checkin(s.pool, worker, timeout)
+          {:reply, :ok, s}
+        :error ->
+          {:reply, {:error, :not_checked_out}, s}
+      end
+    end
+
+    def handle_call(:get_checkout, {pid, _ref}, s) do
+      maybe_get_worker(pid, s, fn {_ref, checkout, _strategy} ->
+        {:reply, {:ok, checkout}, s}
+      end)
+    end
+
+    def handle_call({:break, worker, timeout}, {pid, _ref}, s) do
+      maybe_get_worker(pid, s, fn {_ref, {my_worker, _mod_conn, _mode}, _strategy} ->
+        ^my_worker = worker
+        s.module.break(s.pool, worker, timeout)
+        # Should we do same as :DOWN here? I am thinking no
+        {:reply, :ok, s}
+      end)
+    end
+
+    def handle_call({:open_transaction, timeout}, {pid, _ref}, s) do
+      maybe_get_worker(pid, s, fn {_ref, {worker, _mod_conn, _mode} = checkout, _strategy} ->
+        fun = fn -> s.module.open_transaction(s.pool, worker, timeout) end
+        {:reply, {:ok, {fun, checkout}}, s}
+      end)
+    end
+
+    def handle_call({:close_transaction, worker, timeout}, {pid, _ref}, s) do
+      maybe_get_worker(pid, s, fn {_ref, {my_worker, _mod_conn, _mode}, _strategy} ->
+        ^my_worker = worker
+        fun = fn -> s.module.close_transaction(s.pool, worker, timeout) end
+        {:reply, {:ok, fun}, s}
+      end)
+    end
+
+    def handle_info({:DOWN, ref, :process, pid, _reason}, s) do
+      case Map.fetch(s.owners, pid) do
+        {:ok, {^ref, {worker, {module, conn}, _mode}, strategy}} ->
+          if strategy, do: strategy.ownership_checkin(module, conn)
+          s.module.checkin(s.pool, worker, @timeout)
+          {:noreply, s}
+        :error ->
+          {:noreply, s}
+      end
+    end
+
+    defp maybe_get_worker(owner, s, fun) do
+      case Map.fetch(s.owners, owner) do
+        {:ok, value} ->
+          fun.(value)
+        :error ->
+          {:reply, {:error, :not_checked_out}, s}
+      end
+    end
+
+    defp retrieve_worker(timeout, s) do
+      {:ok, worker, conn, mode, queue_time} = s.module.checkout(s.pool, timeout)
+      {worker, conn, mode, queue_time}
+    end
+
+    defp monitor_owner(owner, checkout, strategy, s) do
+      ref = Process.monitor(owner)
+      %{s | owners: Map.put(s.owners, owner, {ref, checkout, strategy})}
+    end
+  end
+end

--- a/lib/ecto/pools/ownership.ex
+++ b/lib/ecto/pools/ownership.ex
@@ -139,7 +139,8 @@ defmodule Ecto.Pools.Ownership do
     Supervisor.start_link(connection, opts)
   end
 
-  def ownership_checkout(pool, strategy \\ nil, timeout \\ @timeout) do
+  def ownership_checkout(repo, strategy \\ nil, timeout \\ @timeout) do
+    {_, pool, _, } = repo.__pool__
     case GenServer.call(pool, {:ownership_checkout, strategy, timeout}, timeout) do
       :ok ->
         :ok
@@ -148,13 +149,10 @@ defmodule Ecto.Pools.Ownership do
     end
   end
 
-  def ownership_checkin(pool, timeout \\ @timeout) do
-    case GenServer.call(pool, {:ownership_checkin, timeout}, timeout) do
-      :ok ->
-        :ok
-      {:error, :not_checked_out} ->
-        raise ArgumentError, "process doesn't own a worker"
-    end
+  def ownership_checkin(repo, timeout \\ @timeout) do
+    {_, pool, _, } = repo.__pool__
+    GenServer.call(pool, {:ownership_checkin, timeout}, timeout)
+    |> maybe_raise
   end
 
   def checkout(pool, timeout) do

--- a/lib/ecto/pools/ownership.ex
+++ b/lib/ecto/pools/ownership.ex
@@ -125,7 +125,7 @@ defmodule Ecto.Pools.Ownership do
       sup_name     = Module.concat(name, Elixir.ServerSup)
 
       :ets.new(name, [:named_table, :public, read_concurrency: true])
-      :ets.insert(name, {:metadata, sup_name, pool_name, pool})
+      :ets.insert(name, {:metadata, sup_name})
 
       children = [
         supervisor(ServerSup, [sup_name, pool, pool_name, name]),

--- a/lib/ecto/pools/ownership.ex
+++ b/lib/ecto/pools/ownership.ex
@@ -7,11 +7,95 @@ defmodule Ecto.Pools.Ownership do
     defcallback ownership_checkin(module, pid) :: Pool.mode
   end
 
-  defmodule Supervisor do
-    use Elixir.Supervisor
+  defmodule Server do
+    use GenServer
+
+    @timeout 5_000
+
+    def start_link(pool, pool_name, ets) do
+      GenServer.start_link(__MODULE__, {pool, pool_name, ets})
+    end
+
+    def init({module, pool, ets}) do
+      Process.flag(:trap_exit, true)
+      {:ok, %{module: module,
+              pool: pool,
+              ets: ets,
+              owner: nil,
+              ref: nil,
+              checkout: nil,
+              strategy: nil}}
+    end
+
+    def handle_call({:ownership_checkout, strategy, timeout}, {pid, _ref}, s) do
+      case s.module.checkout(s.pool, timeout) do
+        {:ok, worker, {module, conn}, :default, _queue_time} ->
+          mode = if strategy,
+                   do: strategy.ownership_checkout(module, conn),
+                 else: :default
+
+          checkout = {worker, {module, conn}, mode}
+
+          s = monitor_owner(pid, s)
+          s = %{s | strategy: strategy, checkout: checkout}
+          {:reply, {:ok, checkout}, s}
+        {:error, _} = error ->
+          {:stop, :normal, error, s}
+      end
+    end
+
+    def handle_call({:ownership_checkin, timeout}, _from, s) do
+      checkin(timeout, s)
+      {:stop, :normal, :ok, s}
+    end
+
+    def handle_info({:DOWN, ref, :process, pid, _reason}, %{ref: ref, owner: pid} = s) do
+      checkin(@timeout, s)
+      {:stop, :normal, s}
+    end
+
+    def terminate(_reason, s) do
+      if s.owner do
+        :ets.delete(s.ets, s.owner)
+      end
+    end
+
+    defp checkin(timeout, s) do
+      {worker, {module, conn}, _} = s.checkout
+      if s.strategy, do: s.strategy.ownership_checkin(module, conn)
+      s.module.checkin(s.pool, worker, timeout)
+    end
+
+    defp monitor_owner(owner, %{owner: nil, ref: nil} = s) do
+      ref = Process.monitor(owner)
+      %{s | owner: owner, ref: ref}
+    end
+  end
+
+  defmodule ServerSup do
+    use Supervisor
+
+    def start_link(name, pool, pool_name, ets) do
+      Supervisor.start_link(__MODULE__, {pool, pool_name, ets}, name: name)
+    end
+
+    def init({pool, pool_name, ets}) do
+      children = [
+        worker(Server, [pool, pool_name, ets], restart: :temporary)
+      ]
+      supervise(children, strategy: :simple_one_for_one)
+    end
+
+    def new_owner(name) do
+      Supervisor.start_child(name, [])
+    end
+  end
+
+  defmodule Sup do
+    use Supervisor
 
     def start_link(connection, opts) do
-      Elixir.Supervisor.start_link(__MODULE__, {connection, opts})
+      Supervisor.start_link(__MODULE__, {connection, opts})
     end
 
     def init({connection, opts}) do
@@ -19,116 +103,16 @@ defmodule Ecto.Pools.Ownership do
       name         = Keyword.fetch!(opts, :pool_name)
       pool_name    = Module.concat(name, Inner)
       pool_opts    = Keyword.put(opts, :pool_name, pool_name)
+      sup_name     = Module.concat(name, Elixir.ServerSup)
+
+      :ets.new(name, [:named_table, :public, read_concurrency: true])
+      :ets.insert(name, {:metadata, sup_name, pool_name, pool})
 
       children = [
-        worker(Ecto.Pools.Ownership.Server, [name, pool, pool_name]),
+        supervisor(ServerSup, [sup_name, pool, pool_name, name]),
         supervisor(pool, [connection, pool_opts])
       ]
       supervise(children, strategy: :rest_for_one)
-    end
-  end
-
-  defmodule Server do
-    use GenServer
-
-    @timeout 5_000
-
-    def start_link(name, pool, pool_name) do
-      GenServer.start_link(__MODULE__, {pool, pool_name}, [name: name])
-    end
-
-    def init({module, pool}) do
-      {:ok, %{module: module,
-              pool: pool,
-              owners: %{}}}
-    end
-
-    def handle_call({:ownership_checkout, strategy, timeout}, {pid, _ref}, s) do
-      case Map.fetch(s.owners, pid) do
-        {:ok, _} ->
-          {:reply, {:error, :already_checked_out}, s}
-        :error ->
-          checkout = retrieve_worker(timeout, s)
-          {worker, {module, conn}, :default, _queue_time} = checkout
-          mode = if strategy,
-                   do: strategy.ownership_checkout(module, conn),
-                 else: :default
-
-
-          checkout = {worker, {module, conn}, mode}
-          s = monitor_owner(pid, checkout, strategy, s)
-          {:reply, :ok, s}
-      end
-    end
-
-    def handle_call({:ownership_checkin, timeout}, {pid, _ref}, s) do
-      case Map.fetch(s.owners, pid) do
-        {:ok, {_ref, {worker, {module, conn}, _mode}, strategy}} ->
-          if strategy, do: strategy.ownership_checkin(module, conn)
-          s.module.checkin(s.pool, worker, timeout)
-          {:reply, :ok, s}
-        :error ->
-          {:reply, {:error, :not_checked_out}, s}
-      end
-    end
-
-    def handle_call(:get_checkout, {pid, _ref}, s) do
-      maybe_get_worker(pid, s, fn {_ref, checkout, _strategy} ->
-        {:reply, {:ok, checkout}, s}
-      end)
-    end
-
-    def handle_call({:break, worker, timeout}, {pid, _ref}, s) do
-      maybe_get_worker(pid, s, fn {_ref, {my_worker, _mod_conn, _mode}, _strategy} ->
-        ^my_worker = worker
-        s.module.break(s.pool, worker, timeout)
-        {:reply, :ok, s}
-      end)
-    end
-
-    def handle_call({:open_transaction, timeout}, {pid, _ref}, s) do
-      maybe_get_worker(pid, s, fn {_ref, {worker, _mod_conn, _mode} = checkout, _strategy} ->
-        fun = fn -> s.module.open_transaction(s.pool, worker, timeout) end
-        {:reply, {:ok, {fun, checkout}}, s}
-      end)
-    end
-
-    def handle_call({:close_transaction, worker, timeout}, {pid, _ref}, s) do
-      maybe_get_worker(pid, s, fn {_ref, {my_worker, _mod_conn, _mode}, _strategy} ->
-        ^my_worker = worker
-        fun = fn -> s.module.close_transaction(s.pool, worker, timeout) end
-        {:reply, {:ok, fun}, s}
-      end)
-    end
-
-    def handle_info({:DOWN, ref, :process, pid, _reason}, s) do
-      case Map.fetch(s.owners, pid) do
-        {:ok, {^ref, {worker, {module, conn}, _mode}, strategy}} ->
-          if strategy, do: strategy.ownership_checkin(module, conn)
-          s.module.checkin(s.pool, worker, @timeout)
-          {:noreply, s}
-        :error ->
-          {:noreply, s}
-      end
-    end
-
-    defp maybe_get_worker(owner, s, fun) do
-      case Map.fetch(s.owners, owner) do
-        {:ok, value} ->
-          fun.(value)
-        :error ->
-          {:reply, {:error, :not_checked_out}, s}
-      end
-    end
-
-    defp retrieve_worker(timeout, s) do
-      {:ok, worker, conn, mode, queue_time} = s.module.checkout(s.pool, timeout)
-      {worker, conn, mode, queue_time}
-    end
-
-    defp monitor_owner(owner, checkout, strategy, s) do
-      ref = Process.monitor(owner)
-      %{s | owners: Map.put(s.owners, owner, {ref, checkout, strategy})}
     end
   end
 
@@ -136,30 +120,47 @@ defmodule Ecto.Pools.Ownership do
   @timeout 5_000
 
   def start_link(connection, opts) do
-    Supervisor.start_link(connection, opts)
+    Sup.start_link(connection, opts)
   end
 
   def ownership_checkout(repo, strategy \\ nil, timeout \\ @timeout) do
-    {_, pool, _, } = repo.__pool__
-    case GenServer.call(pool, {:ownership_checkout, strategy, timeout}, timeout) do
-      :ok ->
-        :ok
-      {:error, :already_checked_out} ->
-        raise ArgumentError, "process already owns a worker"
+    {_, pool, _} = repo.__pool__
+
+    if :ets.member(pool, self) do
+      raise "process already owns a worker"
+    else
+      supervisor = :ets.lookup_element(pool, :metadata, 2)
+      {:ok, pid} = ServerSup.new_owner(supervisor)
+
+      case GenServer.call(pid, {:ownership_checkout, strategy, timeout}) do
+        {:ok, checkout} ->
+          unless :ets.insert_new(pool, {self, pid, checkout}) do
+            GenServer.call(pid, {:ownership_checkin, timeout}, timeout)
+            raise "race condition"
+          end
+        {:error, _} = error ->
+          error
+      end
     end
   end
 
   def ownership_checkin(repo, timeout \\ @timeout) do
     {_, pool, _, } = repo.__pool__
-    GenServer.call(pool, {:ownership_checkin, timeout}, timeout)
-    |> maybe_raise
+    if :ets.member(pool, self) do
+      [{_, pid, _}] = :ets.lookup(pool, self)
+      GenServer.call(pid, {:ownership_checkin, timeout}, timeout)
+    else
+      raise "process doesn't own a worker"
+    end
   end
 
-  def checkout(pool, timeout) do
-    {worker, mod_conn, mode} =
-      GenServer.call(pool, :get_checkout, timeout)
-      |> maybe_raise
-    {:ok, worker, mod_conn, mode, 0}
+  def checkout(pool, _timeout) do
+    case :ets.lookup(pool, self) do
+      [{_, _, {worker, mod_conn, mode}}] ->
+        {:ok, worker, mod_conn, mode, 0}
+      [] ->
+        raise "..."
+    end
   end
 
   def checkin(_pool, _worker, _timeout) do
@@ -167,17 +168,23 @@ defmodule Ecto.Pools.Ownership do
   end
 
   def break(pool, worker, timeout) do
-    GenServer.call(pool, {:break, worker, timeout}, timeout)
-    |> maybe_raise
+    if :ets.member(pool, self) do
+      [{:metadata, _supervisor, inner_pool, module}] = :ets.lookup(pool, :metadata)
+      module.break(inner_pool, worker, timeout)
+    else
+      raise "..."
+    end
   end
 
   def checkout_transaction(pool, timeout) do
-    {fun, {worker, mod_conn, mode}} =
-      GenServer.call(pool, {:open_transaction, timeout}, timeout)
-      |> maybe_raise
-
-    fun.()
-    {:ok, worker, mod_conn, mode, 0}
+    if :ets.member(pool, self) do
+      [{:metadata, _supervisor, inner_pool, module}] = :ets.lookup(pool, :metadata)
+      [{_, _, {worker, mod_conn, mode}}] = :ets.lookup(pool, self)
+      module.open_transaction(inner_pool, worker, timeout)
+      {:ok, worker, mod_conn, mode, 0}
+    else
+      raise "..."
+    end
   end
 
   def open_transaction(_pool, _worker, _timeout) do
@@ -185,17 +192,11 @@ defmodule Ecto.Pools.Ownership do
   end
 
   def close_transaction(pool, worker, timeout) do
-    fun =
-      GenServer.call(pool, {:close_transaction, worker, timeout}, timeout)
-      |> maybe_raise
-
-    fun.()
+    if :ets.member(pool, self) do
+      [{:metadata, _supervisor, inner_pool, module}] = :ets.lookup(pool, :metadata)
+      module.close_transaction(inner_pool, worker, timeout)
+    else
+      raise "..."
+    end
   end
-
-  defp maybe_raise({:error, :not_checked_out}),
-    do: raise(ArgumentError, "process doesn't own a worker")
-  defp maybe_raise(:ok),
-    do: :ok
-  defp maybe_raise({:ok, value}),
-    do: value
 end

--- a/lib/ecto/pools/ownership.ex
+++ b/lib/ecto/pools/ownership.ex
@@ -43,7 +43,7 @@ defmodule Ecto.Pools.Ownership do
       GenServer.start_link(__MODULE__, {pool, pool_name}, [name: name])
     end
 
-    def ownership_checkout(pool, strategy, timeout \\ @timeout) do
+    def ownership_checkout(pool, strategy \\ nil, timeout \\ @timeout) do
       case GenServer.call(pool, {:ownership_checkout, strategy, timeout}, timeout) do
         :ok ->
           :ok
@@ -65,7 +65,6 @@ defmodule Ecto.Pools.Ownership do
       {worker, mod_conn, mode} =
         GenServer.call(pool, :get_checkout, timeout)
         |> maybe_raise
-      # TODO: queue_time
       {:ok, worker, mod_conn, mode, 0}
     end
 
@@ -84,7 +83,6 @@ defmodule Ecto.Pools.Ownership do
         |> maybe_raise
 
       fun.()
-      # TODO: queue_time
       {:ok, worker, mod_conn, mode, 0}
     end
 
@@ -153,7 +151,6 @@ defmodule Ecto.Pools.Ownership do
       maybe_get_worker(pid, s, fn {_ref, {my_worker, _mod_conn, _mode}, _strategy} ->
         ^my_worker = worker
         s.module.break(s.pool, worker, timeout)
-        # Should we do same as :DOWN here? I am thinking no
         {:reply, :ok, s}
       end)
     end

--- a/lib/ecto/pools/poolboy.ex
+++ b/lib/ecto/pools/poolboy.ex
@@ -39,17 +39,13 @@ defmodule Ecto.Pools.Poolboy do
   end
 
   @doc false
-  def open_transaction(pool, timeout) do
+  def checkout_transaction(pool, timeout) do
     checkout(pool, :transaction, timeout)
   end
 
   @doc false
-  def close_transaction(pool, worker, _) do
-    try do
-      Worker.checkin(worker)
-    after
-      :poolboy.checkin(pool, worker)
-    end
+  def close_transaction(_pool, worker, _) do
+    Worker.checkin(worker)
   end
 
   @doc false
@@ -81,7 +77,7 @@ defmodule Ecto.Pools.Poolboy do
   defp checkout(pool, fun, timeout) do
     case :timer.tc(fn() -> do_checkout(pool, fun, timeout) end) do
       {queue_time, {:ok, worker, mod_conn}} ->
-        {:ok, worker, mod_conn, queue_time}
+        {:ok, worker, mod_conn, :default, queue_time}
       {_queue_time, {:error, _} = error} ->
         error
     end

--- a/lib/ecto/pools/poolboy.ex
+++ b/lib/ecto/pools/poolboy.ex
@@ -28,6 +28,10 @@ defmodule Ecto.Pools.Poolboy do
     :poolboy.start_link(pool_opts, {conn_mod, conn_opts})
   end
 
+  def open_transaction(_pool, worker, timeout) do
+    Worker.checkout(worker, :transaction, timeout)
+  end
+
   @doc false
   def checkout(pool, timeout) do
     checkout(pool, :run, timeout)

--- a/lib/ecto/pools/sojourn_broker.ex
+++ b/lib/ecto/pools/sojourn_broker.ex
@@ -44,6 +44,10 @@ defmodule Ecto.Pools.SojournBroker do
     Supervisor.start_link(children, sup_opts)
   end
 
+  def open_transaction(_pool, _worker, _timeout) do
+    :ok
+  end
+
   @doc false
   def checkout(pool, timeout) do
     ask(pool, :run, timeout)

--- a/lib/ecto/pools/sojourn_broker.ex
+++ b/lib/ecto/pools/sojourn_broker.ex
@@ -44,7 +44,8 @@ defmodule Ecto.Pools.SojournBroker do
     Supervisor.start_link(children, sup_opts)
   end
 
-  def open_transaction(_pool, _worker, _timeout) do
+  def open_transaction(_pool, {worker, ref}, _timeout) do
+    Worker.open_transaction(worker, ref)
     :ok
   end
 

--- a/lib/ecto/pools/sojourn_broker.ex
+++ b/lib/ecto/pools/sojourn_broker.ex
@@ -55,13 +55,13 @@ defmodule Ecto.Pools.SojournBroker do
   end
 
   @doc false
-  def open_transaction(pool, timeout) do
+  def checkout_transaction(pool, timeout) do
     ask(pool, :transaction, timeout)
   end
 
   @doc false
-  def close_transaction(_, {worker, ref}, _) do
-    Worker.done(worker, ref)
+  def close_transaction(_, _, _) do
+    :ok
   end
 
   @doc false
@@ -74,9 +74,9 @@ defmodule Ecto.Pools.SojournBroker do
   defp ask(pool, fun, timeout) do
     case :sbroker.ask(pool, {fun, self()}) do
       {:go, ref, {worker, :lazy}, _, queue_time} ->
-          lazy_connect(worker, ref, queue_time, timeout)
+        lazy_connect(worker, ref, queue_time, timeout)
       {:go, ref, {worker, mod_conn}, _, queue_time} ->
-          {:ok, {worker, ref}, mod_conn, queue_time}
+        {:ok, {worker, ref}, mod_conn, :default, queue_time}
       {:drop, _} ->
         {:error, :noconnect}
     end
@@ -109,7 +109,7 @@ defmodule Ecto.Pools.SojournBroker do
         :erlang.raise(class, reason, stack)
     else
       {connect_time, {:ok, mod_conn}} ->
-        {:ok, {worker, ref}, mod_conn, queue_time + connect_time}
+        {:ok, {worker, ref}, mod_conn, :default, queue_time + connect_time}
       {_, {:error, :noconnect} = error} ->
         Worker.done(worker, ref)
         error

--- a/lib/ecto/pools/sojourn_broker/worker.ex
+++ b/lib/ecto/pools/sojourn_broker/worker.ex
@@ -30,6 +30,10 @@ defmodule Ecto.Pools.SojournBroker.Worker do
     GenServer.cast(worker, {:done, ref})
   end
 
+  def open_transaction(worker, ref) do
+    GenServer.cast(worker, {:open_transaction, ref})
+  end
+
   ## Callbacks
 
   def init({module, broker, opts}) do
@@ -99,6 +103,13 @@ defmodule Ecto.Pools.SojournBroker.Worker do
     s = s
       |> demonitor()
       |> ask()
+    {:noreply, s}
+  end
+
+  ## Open transaction
+
+  def handle_cast({:open_transaction, ref}, %{ref: ref} = s) do
+    s = %{s | fun: :transaction}
     {:noreply, s}
   end
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -64,16 +64,10 @@ defmodule Ecto.Repo do
       {otp_app, adapter, pool, config} = Ecto.Repo.Supervisor.parse_config(__MODULE__, opts)
       @otp_app otp_app
       @adapter adapter
+      @pool pool
       @config  config
       @query_cache config[:query_cache] || __MODULE__
       @before_compile adapter
-
-      if config[:use_ownership] do
-        {pool, name, timeout} = pool
-        @pool {Ecto.Pools.Ownership.Server, name, timeout}
-      else
-        @pool pool
-      end
 
       require Logger
       @log_level config[:log_level] || :debug

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -65,9 +65,15 @@ defmodule Ecto.Repo do
       @otp_app otp_app
       @adapter adapter
       @config  config
-      @pool pool
       @query_cache config[:query_cache] || __MODULE__
       @before_compile adapter
+
+      if config[:use_ownership] do
+        {pool, name, timeout} = pool
+        @pool {Ecto.Pools.Ownership.Server, name, timeout}
+      else
+        @pool pool
+      end
 
       require Logger
       @log_level config[:log_level] || :debug

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -113,14 +113,17 @@ defmodule Ecto.Repo.Supervisor do
       |> Keyword.put_new(:pool, default_pool)
       |> Keyword.put_new(:pool_name, Module.concat(name, Pool))
 
-    children = [
-      supervisor(adapter, [repo, opts])
-    ]
+     children =
+      if opts[:use_ownership] do
+        [supervisor(Ecto.Pools.Ownership.Server, [adapter, repo, opts])]
+      else
+        [supervisor(adapter, [repo, opts])]
+      end
 
     if Keyword.get(opts, :query_cache_owner, repo == repo.__query_cache__) do
       :ets.new(repo.__query_cache__, [:set, :public, :named_table, read_concurrency: true])
     end
 
-    supervise(children, strategy: :one_for_one)
+    supervise(children, strategy: :rest_for_one)
   end
 end

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -113,12 +113,7 @@ defmodule Ecto.Repo.Supervisor do
       |> Keyword.put_new(:pool, default_pool)
       |> Keyword.put_new(:pool_name, Module.concat(name, Pool))
 
-    children =
-      if opts[:pool] == Ecto.Pools.Ownership.Server do
-        [supervisor(Ecto.Pools.Ownership.Supervisor, [adapter, repo, opts])]
-      else
-        [supervisor(adapter, [repo, opts])]
-      end
+    children = [supervisor(adapter, [repo, opts])]
 
     if Keyword.get(opts, :query_cache_owner, repo == repo.__query_cache__) do
       :ets.new(repo.__query_cache__, [:set, :public, :named_table, read_concurrency: true])

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -113,9 +113,9 @@ defmodule Ecto.Repo.Supervisor do
       |> Keyword.put_new(:pool, default_pool)
       |> Keyword.put_new(:pool_name, Module.concat(name, Pool))
 
-     children =
-      if opts[:use_ownership] do
-        [supervisor(Ecto.Pools.Ownership.Server, [adapter, repo, opts])]
+    children =
+      if opts[:pool] == Ecto.Pools.Ownership.Server do
+        [supervisor(Ecto.Pools.Ownership.Supervisor, [adapter, repo, opts])]
       else
         [supervisor(adapter, [repo, opts])]
       end
@@ -124,6 +124,6 @@ defmodule Ecto.Repo.Supervisor do
       :ets.new(repo.__query_cache__, [:set, :public, :named_table, read_concurrency: true])
     end
 
-    supervise(children, strategy: :rest_for_one)
+    supervise(children, strategy: :one_for_one)
   end
 end

--- a/test/pool/cases/run.exs
+++ b/test/pool/cases/run.exs
@@ -36,7 +36,7 @@ defmodule Ecto.Pool.RunTest do
     pool = context[:pool]
     {:ok, _} = TestPool.start_link([lazy: false, pool_name: pool])
 
-    TestPool.transaction(pool, @timeout, fn(_, _, _, _) ->
+    TestPool.transaction(pool, @timeout, fn(_, _, _, _, _) ->
       TestPool.run(pool, @timeout, fn({_mod, _conn}, queue_time) ->
         assert is_nil(queue_time)
       end)

--- a/test/pool/cases/transaction.exs
+++ b/test/pool/cases/transaction.exs
@@ -4,7 +4,7 @@ defmodule Ecto.Pool.TransactionTest do
   alias Ecto.Pool
   alias Ecto.TestPool
 
-  @timeout 1000
+  @timeout 5_000
 
   setup context do
     case = context[:case]

--- a/test/pool/cases/transaction.exs
+++ b/test/pool/cases/transaction.exs
@@ -4,7 +4,7 @@ defmodule Ecto.Pool.TransactionTest do
   alias Ecto.Pool
   alias Ecto.TestPool
 
-  @timeout :infinity
+  @timeout 1000
 
   setup context do
     case = context[:case]
@@ -17,7 +17,7 @@ defmodule Ecto.Pool.TransactionTest do
     {:ok, _} = TestPool.start_link([lazy: false, pool_name: pool])
 
     conn1 =
-      TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, queue_time) ->
+      TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, _mode, queue_time) ->
         assert is_integer(queue_time)
         ref = Process.monitor(conn1)
         Process.exit(conn1, :kill)
@@ -25,7 +25,7 @@ defmodule Ecto.Pool.TransactionTest do
         conn1
       end)
 
-    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn2}, queue_time) ->
+    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn2}, _mode, queue_time) ->
       assert is_integer(queue_time)
       assert conn1 != conn2
       refute Process.alive?(conn1)
@@ -38,7 +38,7 @@ defmodule Ecto.Pool.TransactionTest do
     {:ok, _} = TestPool.start_link([lazy: false, pool_name: pool])
 
     TestPool.transaction(pool, @timeout,
-      fn(:opened, ref, {_mod, conn1}, queue_time) ->
+      fn(:opened, ref, {_mod, conn1}, _mode, queue_time) ->
         assert is_integer(queue_time)
         monitor = Process.monitor(conn1)
         assert Pool.break(ref, @timeout) === :ok
@@ -54,7 +54,7 @@ defmodule Ecto.Pool.TransactionTest do
     _ = Process.flag(:trap_exit, true)
     parent = self()
     {:ok, task} = Task.start_link(fn ->
-      TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, _) ->
+      TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, _, _) ->
         send(parent, {:go, self(), conn1})
         :timer.sleep(:infinity)
       end)
@@ -64,7 +64,7 @@ defmodule Ecto.Pool.TransactionTest do
     Process.exit(task, :kill)
     assert_receive {:EXIT, ^task, :killed}, @timeout
 
-    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn2}, _) ->
+    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn2}, _, _) ->
       assert conn1 != conn2
       refute Process.alive?(conn1)
       assert Process.alive?(conn2)
@@ -76,14 +76,14 @@ defmodule Ecto.Pool.TransactionTest do
     {:ok, _} = TestPool.start_link([lazy: false, pool_name: pool])
 
     task = Task.async(fn ->
-      TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, _) ->
+      TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, _, _) ->
         conn1
       end)
     end)
 
     conn1 = Task.await(task, @timeout)
 
-    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn2}, _) ->
+    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn2}, _, _) ->
       assert conn1 == conn2
       assert Process.alive?(conn1)
     end)
@@ -93,9 +93,9 @@ defmodule Ecto.Pool.TransactionTest do
     pool = context[:pool]
     {:ok, _} = TestPool.start_link([lazy: false, pool_name: pool])
 
-    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, queue_time) ->
+    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {_mod, conn1}, _mode, queue_time) ->
       assert is_integer(queue_time)
-      TestPool.transaction(pool, @timeout, fn(:already_open, _ref, {_mod, conn2}, nil) ->
+      TestPool.transaction(pool, @timeout, fn(:already_open, _ref, {_mod, conn2}, _mode, nil) ->
         assert conn1 == conn2
       end)
     end)
@@ -105,7 +105,7 @@ defmodule Ecto.Pool.TransactionTest do
     pool = context[:pool]
     {:ok, _} = TestPool.start_link([pool_name: pool])
 
-    TestPool.transaction(pool, @timeout, fn(_, ref, {_mod, conn}, _) ->
+    TestPool.transaction(pool, @timeout, fn(_, ref, {_mod, conn}, _, _) ->
       mon = Process.monitor(conn)
       TestPool.break(ref, @timeout)
       assert_receive {:DOWN, ^mon, _, _, :shutdown}
@@ -116,7 +116,7 @@ defmodule Ecto.Pool.TransactionTest do
     pool = context[:pool]
     {:ok, _} = TestPool.start_link([pool_name: pool, shutdown: :brutal_kill])
 
-    TestPool.transaction(pool, @timeout, fn(_, ref, {_mod, conn}, _) ->
+    TestPool.transaction(pool, @timeout, fn(_, ref, {_mod, conn}, _, _) ->
       mon = Process.monitor(conn)
       TestPool.break(ref, @timeout)
       assert_receive {:DOWN, ^mon, _, _, :killed}
@@ -127,7 +127,7 @@ defmodule Ecto.Pool.TransactionTest do
     pool = context[:pool]
     {:ok, _} = TestPool.start_link([pool_name: pool, shutdown: 1, trap_exit: true])
 
-    TestPool.transaction(pool, @timeout, fn(_, ref, {_mod, conn}, _) ->
+    TestPool.transaction(pool, @timeout, fn(_, ref, {_mod, conn}, _, _) ->
       mon = Process.monitor(conn)
       :erlang.suspend_process(conn)
       TestPool.break(ref, @timeout)

--- a/test/pool/poolboy/worker_test.exs
+++ b/test/pool/poolboy/worker_test.exs
@@ -20,7 +20,7 @@ defmodule Ecto.Pools.Poolboy.WorkerTest do
     refute :sys.get_state(worker).conn
     :poolboy.checkin(pool, worker)
 
-    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {Connection, conn}, _) ->
+    TestPool.transaction(pool, @timeout, fn(:opened, _ref, {Connection, conn}, _, _) ->
       assert Process.alive?(conn)
     end)
   end

--- a/test/pool/sojourn_broker/worker_test.exs
+++ b/test/pool/sojourn_broker/worker_test.exs
@@ -36,7 +36,7 @@ defmodule Ecto.Pools.SojournBroker.WorkerTest do
     {:ok, _} = TestPool.start_link([pool_name: pool])
 
     conn1 = TestPool.transaction(pool, @timeout,
-      fn(:opened, _ref, {Connection, conn}, _) ->
+      fn(:opened, _ref, {Connection, conn}, _, _) ->
         conn
       end)
 
@@ -49,7 +49,7 @@ defmodule Ecto.Pools.SojournBroker.WorkerTest do
     await_len_r(pool, 0)
 
     conn2 = TestPool.transaction(pool, @timeout,
-      fn(:opened, _ref, {Connection, conn}, _) ->
+      fn(:opened, _ref, {Connection, conn}, _, _) ->
         conn
       end)
 
@@ -61,7 +61,7 @@ defmodule Ecto.Pools.SojournBroker.WorkerTest do
     {:ok, _} = TestPool.start_link([pool_name: pool, size: 1, lazy: false])
 
     conn1 = TestPool.transaction(pool, @timeout,
-      fn(:opened, _ref, {Connection, conn}, _) ->
+      fn(:opened, _ref, {Connection, conn}, _, _) ->
         conn
       end)
 
@@ -74,7 +74,7 @@ defmodule Ecto.Pools.SojournBroker.WorkerTest do
     receive do: ({:DOWN, ^ref, _, _, _} -> :ok)
 
     conn2 = TestPool.transaction(pool, @timeout,
-      fn(:opened, _ref, {Connection, conn}, _) ->
+      fn(:opened, _ref, {Connection, conn}, _, _) ->
         :sys.resume(worker)
         conn
       end)
@@ -82,7 +82,7 @@ defmodule Ecto.Pools.SojournBroker.WorkerTest do
     assert conn1 == conn2
 
     conn3 = TestPool.transaction(pool, @timeout,
-      fn(:opened, _ref, {Connection, conn}, _) ->
+      fn(:opened, _ref, {Connection, conn}, _, _) ->
         conn
       end)
 


### PR DESCRIPTION
Add ownership pool that wraps an inner pool for. When using the ownership pool a process needs to call `ownership_checkout` to be able to use a worker, all subsequent pool checkouts from the process will use the same worker until the process dies or it calls `ownership_checkin`.

This functionality allows to run tests with sandboxed connections in parallel.