### PR TITLE
Adds the option to do a count distinct query

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -694,4 +694,13 @@ defmodule Ecto.Integration.RepoTest do
     TestRepo.delete!(user)
     assert Enum.count(TestRepo.all(Post)) == 1
   end
+
+  test "count distinct" do
+    TestRepo.insert!(%Post{title: "1"})
+    TestRepo.insert!(%Post{title: "1"})
+    TestRepo.insert!(%Post{title: "2"})
+
+    assert [3] == Post |> select([p], count(p.title)) |> TestRepo.all
+    assert [2] == Post |> select([p], count(p.title, :distinct)) |> TestRepo.all
+  end
 end

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -362,6 +362,12 @@ if Code.ensure_loaded?(Mariaex.Connection) do
     end
 
     defp expr({fun, _, args}, sources, query) when is_atom(fun) and is_list(args) do
+      {modifier, args} =
+        case args do
+          [rest, :distinct] -> {"DISTINCT ", [rest]}
+          _ -> {"", args}
+        end
+
       case handle_call(fun, length(args)) do
         {:binary_op, op} ->
           [left, right] = args
@@ -370,7 +376,7 @@ if Code.ensure_loaded?(Mariaex.Connection) do
           <> op_to_binary(right, sources, query)
 
         {:fun, fun} ->
-          "#{fun}(" <> Enum.map_join(args, ", ", &expr(&1, sources, query)) <> ")"
+          "#{fun}(" <> modifier <> Enum.map_join(args, ", ", &expr(&1, sources, query)) <> ")"
       end
     end
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -416,6 +416,12 @@ if Code.ensure_loaded?(Postgrex.Connection) do
     end
 
     defp expr({fun, _, args}, sources, query) when is_atom(fun) and is_list(args) do
+      {modifier, args} =
+        case args do
+         [rest, :distinct] -> {"DISTINCT ", [rest]}
+         _ -> {"", args}
+       end
+
       case handle_call(fun, length(args)) do
         {:binary_op, op} ->
           [left, right] = args
@@ -424,7 +430,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
           <> op_to_binary(right, sources, query)
 
         {:fun, fun} ->
-          "#{fun}(" <> Enum.map_join(args, ", ", &expr(&1, sources, query)) <> ")"
+          "#{fun}(" <> modifier <> Enum.map_join(args, ", ", &expr(&1, sources, query)) <> ")"
       end
     end
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -107,6 +107,13 @@ defmodule Ecto.Query.API do
   def count(value), do: doc! [value]
 
   @doc """
+  Counts the distinct values in given entry.
+
+      from p in Post, select: count(p.id, :distinct)
+  """
+  def count(value, :distinct), do: doc! [value, :distinct]
+
+  @doc """
   Calculates the average for the given entry.
 
       from p in Payment, select: avg(p.value)

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -1,7 +1,7 @@
 defmodule Ecto.Query.Builder do
   @moduledoc false
 
-  @aggregators ~w(count)a
+  @distinct ~w(count)a
 
   alias Ecto.Query
 
@@ -211,7 +211,7 @@ defmodule Ecto.Query.Builder do
   defp split_binary(<<?\\, ??, rest :: binary >>, consumed), do: split_binary(rest, consumed <> <<??>>)
   defp split_binary(<<first :: utf8, rest :: binary>>, consumed), do: split_binary(rest, consumed <> <<first>>)
 
-  defp escape_call({name, _, [arg, :distinct]}, type, params, vars, env) when name in @aggregators do
+  defp escape_call({name, _, [arg, :distinct]}, type, params, vars, env) when name in @distinct do
     {arg, params} = escape(arg, type, params, vars, env)
     distinct = {:{}, [], [:distinct, [], []]}
     expr = {:{}, [], [name, [], [arg, :distinct]]}
@@ -263,7 +263,7 @@ defmodule Ecto.Query.Builder do
     do: [{:raw, h1}]
 
   defp call_type(agg, 1)  when agg in ~w(max count sum min avg)a, do: {:any, :any}
-  defp call_type(agg, 2)  when agg in @aggregators,               do: {:any, :any}
+  defp call_type(agg, 2)  when agg in @distinct,                  do: {:any, :any}
   defp call_type(comp, 2) when comp in ~w(== != < > <= >=)a,      do: {:any, :boolean}
   defp call_type(like, 2) when like in ~w(like ilike)a,           do: {:string, :boolean}
   defp call_type(bool, 2) when bool in ~w(and or)a,               do: {:boolean, :boolean}

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -213,7 +213,6 @@ defmodule Ecto.Query.Builder do
 
   defp escape_call({name, _, [arg, :distinct]}, type, params, vars, env) when name in @distinct do
     {arg, params} = escape(arg, type, params, vars, env)
-    distinct = {:{}, [], [:distinct, [], []]}
     expr = {:{}, [], [name, [], [arg, :distinct]]}
     {expr, params}
   end

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -1,6 +1,8 @@
 defmodule Ecto.Query.Builder do
   @moduledoc false
 
+  @aggregators ~w(count)a
+
   alias Ecto.Query
 
   @typedoc """
@@ -209,6 +211,13 @@ defmodule Ecto.Query.Builder do
   defp split_binary(<<?\\, ??, rest :: binary >>, consumed), do: split_binary(rest, consumed <> <<??>>)
   defp split_binary(<<first :: utf8, rest :: binary>>, consumed), do: split_binary(rest, consumed <> <<first>>)
 
+  defp escape_call({name, _, [arg, :distinct]}, type, params, vars, env) when name in @aggregators do
+    {arg, params} = escape(arg, type, params, vars, env)
+    distinct = {:{}, [], [:distinct, [], []]}
+    expr = {:{}, [], [name, [], [arg, :distinct]]}
+    {expr, params}
+  end
+
   defp escape_call({name, _, args}, type, params, vars, env) do
     {args, params} = Enum.map_reduce(args, params, &escape(&1, type, &2, vars, env))
     expr = {:{}, [], [name, [], args]}
@@ -254,6 +263,7 @@ defmodule Ecto.Query.Builder do
     do: [{:raw, h1}]
 
   defp call_type(agg, 1)  when agg in ~w(max count sum min avg)a, do: {:any, :any}
+  defp call_type(agg, 2)  when agg in @aggregators,               do: {:any, :any}
   defp call_type(comp, 2) when comp in ~w(== != < > <= >=)a,      do: {:any, :boolean}
   defp call_type(like, 2) when like in ~w(like ilike)a,           do: {:string, :boolean}
   defp call_type(bool, 2) when bool in ~w(and or)a,               do: {:boolean, :boolean}

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -73,6 +73,14 @@ defmodule Ecto.Adapters.PostgresTest do
     assert SQL.all(query) == ~s{SELECT m0."x", m0."y" FROM "model" AS m0}
   end
 
+  test "aggregates" do
+    query = Model |> select([r], count(r.x)) |> normalize
+    assert SQL.all(query) == ~s{SELECT count(m0."x") FROM "model" AS m0}
+
+    query = Model |> select([r], count(r.x, :distinct)) |> normalize
+    assert SQL.all(query) == ~s{SELECT count(DISTINCT m0."x") FROM "model" AS m0}
+  end
+
   test "distinct" do
     query = Model |> distinct([r], r.x) |> select([r], {r.x, r.y}) |> normalize
     assert SQL.all(query) == ~s{SELECT DISTINCT ON (m0."x") m0."x", m0."y" FROM "model" AS m0}


### PR DESCRIPTION
  - allows the atom ":distinct" to be passed to the count macro
  - implements count distinct for postgres and mysql
  - issue #874