### PR TITLE
Introduces app_repo configuration variable

### DIFF
--- a/lib/mix/ecto.ex
+++ b/lib/mix/ecto.ex
@@ -22,10 +22,14 @@ defmodule Mix.Ecto do
 
   defp parse_repo([], []) do
     if app = Keyword.get(Mix.Project.config, :app) do
-      case Application.get_env(app, :app_namespace, app) do
-        ^app -> app |> to_string |> Mix.Utils.camelize
-        mod  -> mod |> inspect
-      end |> Module.concat(Repo) |> List.wrap
+      case Application.get_env(app, :app_repo) do
+        nil -> 
+          case Application.get_env(app, :app_namespace, app) do
+            ^app -> app |> to_string |> Mix.Utils.camelize
+            mod  -> mod |> inspect
+          end |> Module.concat(Repo) |> List.wrap
+        repo -> repo
+      end
     else
       Mix.raise "No repository available. Please pass a repo with the -r option."
     end


### PR DESCRIPTION
As discussed previously, a new pull request for introducing the `app_repo` configuration variable that allows specifying a default repo to use for mix tasks. Useful when you have multiple repos or use a repo in a non-standard namespace.