### PR TITLE
Ecto.UUID optimization

### DIFF
--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -86,3 +86,14 @@ defmodule Ecto.UUID do
   defp lower(<<>>, acc),
     do: acc
 end
+
+defimpl String.Chars, for: Ecto.UUID do
+  def to_string(%Ecto.UUID{string: s}), do: s
+end
+
+defimpl Inspect, for: Ecto.UUID do
+
+  def inspect(%Ecto.UUID{string: s}, _opts) do
+    "#Ecto.UUID<" <> s <> ">"
+  end
+end

--- a/test/ecto/model/autogenerate_test.exs
+++ b/test/ecto/model/autogenerate_test.exs
@@ -17,18 +17,18 @@ defmodule Ecto.Model.AutogenerateTest do
 
   test "autogenerates values" do
     model = TestRepo.insert!(%MyModel{})
-    assert byte_size(model.z) == 36
+    assert byte_size(model.z.string) == 36
 
     changeset = Ecto.Changeset.cast(%MyModel{}, %{}, [], [])
     model = TestRepo.insert!(changeset)
-    assert byte_size(model.z) == 36
+    assert byte_size(model.z.string) == 36
 
     changeset = Ecto.Changeset.cast(%MyModel{}, %{z: nil}, [], [])
     model = TestRepo.insert!(changeset)
-    assert byte_size(model.z) == 36
+    assert byte_size(model.z.string) == 36
 
     changeset = Ecto.Changeset.cast(%MyModel{}, %{z: @uuid}, [:z], [])
     model = TestRepo.insert!(changeset)
-    assert model.z == @uuid
+    assert model.z.string == @uuid
   end
 end

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -1,13 +1,14 @@
 defmodule Ecto.UUIDTest do
   use ExUnit.Case, async: true
 
-  @test_uuid "601d74e4-a8d3-4b6e-8365-eddb4c893327"
+  @test_uuid_string "601d74e4-a8d3-4b6e-8365-eddb4c893327"
   @test_uuid_binary <<0x60, 0x1D, 0x74, 0xE4, 0xA8, 0xD3, 0x4B, 0x6E,
                       0x83, 0x65, 0xED, 0xDB, 0x4C, 0x89, 0x33, 0x27>>
+  @test_uuid %Ecto.UUID{string: @test_uuid_string, binary: @test_uuid_binary}
 
   test "cast" do
-    assert Ecto.UUID.cast(@test_uuid) == {:ok, @test_uuid}
-    assert Ecto.UUID.cast(@test_uuid_binary) == :error
+    assert Ecto.UUID.cast(@test_uuid_string) == {:ok, @test_uuid}
+    assert Ecto.UUID.cast(@test_uuid_binary) == {:ok, @test_uuid}
     assert Ecto.UUID.cast(nil) == :error
   end
 
@@ -15,7 +16,7 @@ defmodule Ecto.UUIDTest do
     assert Ecto.UUID.load(@test_uuid_binary) == {:ok, @test_uuid}
     assert Ecto.UUID.load("") == :error
     assert_raise RuntimeError, ~r"trying to load string UUID as Ecto.UUID:", fn ->
-      Ecto.UUID.load(@test_uuid)
+      Ecto.UUID.load(@test_uuid_string)
     end
   end
 
@@ -25,6 +26,7 @@ defmodule Ecto.UUIDTest do
   end
 
   test "generate" do
-    assert << _::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96 >> = Ecto.UUID.generate
+    %Ecto.UUID{string: s} = Ecto.UUID.generate
+    assert << _::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96 >> = s
   end
 end

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -29,4 +29,14 @@ defmodule Ecto.UUIDTest do
     %Ecto.UUID{string: s} = Ecto.UUID.generate
     assert << _::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96 >> = s
   end
+
+  test "to_string" do
+    uuid = Ecto.UUID.generate
+    assert to_string(uuid) == uuid.string
+  end
+
+  test "inspect protocol" do
+    uuid = Ecto.UUID.generate
+    assert inspect(uuid) == "#Ecto.UUID<" <> uuid.string <> ">"
+  end
 end


### PR DESCRIPTION
This changes the UUID representation to a struct containing both the binary and string representations.
This avoids unnecessary conversions when actively generating UUIDs (as opposed to letting the server generate them).