### PR TITLE
Inferred rollback for "create index" is broken for MySQL

### DIFF
--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -253,12 +253,25 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  defmodule InferredDropIndexMigration do
+    use Ecto.Migration
+
+    def change do
+      create index(:posts, [:title])
+    end
+  end
+
   import Ecto.Query, only: [from: 2]
   import Ecto.Migrator, only: [up: 4, down: 4]
 
   test "create and drop table and indexes" do
     assert :ok == up(TestRepo, 20050906120000, CreateMigration, log: false)
     assert :ok == down(TestRepo, 20050906120000, CreateMigration, log: false)
+  end
+
+  test "correctly infers how to drop index" do
+    assert :ok == up(TestRepo, 20050906120000, InferredDropIndexMigration, log: false)
+    assert :ok == down(TestRepo, 20050906120000, InferredDropIndexMigration, log: false)
   end
 
   test "supports references" do

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -133,7 +133,7 @@ defmodule Ecto.Migration.Runner do
   end
 
   defp execute_in_direction(repo, :backward, level, {command, %Index{}=index}) when command in @creates do
-    log_and_execute_ddl(repo, level, {:drop_if_exists, index})
+    log_and_execute_ddl(repo, level, {:drop, index})
   end
 
   defp execute_in_direction(repo, :backward, level, {:drop, %Index{}=index}) do

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -277,7 +277,7 @@ defmodule Ecto.MigrationTest do
   test "backward: creates an index" do
     create index(:posts, [:title])
     flush
-    assert {:drop_if_exists, %Index{}} = last_command()
+    assert {:drop, %Index{}} = last_command()
   end
 
   test "backward: drops an index" do

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -89,7 +89,7 @@ defmodule Ecto.MigratorTest do
 
     assert output =~ "== Running Ecto.MigratorTest.ChangeMigration.change/0 backward"
     assert output =~ "drop table posts"
-    assert output =~ "drop index if exists posts_title_index"
+    assert output =~ "drop index posts_title_index"
     assert output =~ ~r"== Migrated in \d.\ds"
 
     output = capture_log fn ->
@@ -107,7 +107,7 @@ defmodule Ecto.MigratorTest do
 
     assert output =~ "== Running Ecto.MigratorTest.ChangeMigrationPrefix.change/0 backward"
     assert output =~ "drop table foo.comments"
-    assert output =~ "drop index if exists foo.posts_title_index"
+    assert output =~ "drop index foo.posts_title_index"
     assert output =~ ~r"== Migrated in \d.\ds"
 
     output = capture_log fn ->


### PR DESCRIPTION
~~This is just a test case for now.~~  This is a test case and a possible fix. If you run the test on mysql without the fix, it fails as follows.

```
1) test correctly infers how to drop index (Ecto.Integration.MigrationTest)
     integration_test/sql/migration.exs:272
     ** (ArgumentError) MySQL adapter does not support drop if exists for index
     stacktrace:
       (ecto) lib/ecto/adapters/mysql/connection.ex:701: Ecto.Adapters.MySQL.Connection.error!/2
       (ecto) lib/ecto/adapters/mysql.ex:84: Ecto.Adapters.MySQL.execute_ddl/3
       (ecto) lib/ecto/migration/runner.ex:74: anonymous fn/2 in Ecto.Migration.Runner.flush/0
       (elixir) lib/enum.ex:1387: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto) lib/ecto/migration/runner.ex:72: Ecto.Migration.Runner.flush/0
       (stdlib) timer.erl:181: :timer.tc/2
       (ecto) lib/ecto/migration/runner.ex:23: Ecto.Migration.Runner.run/6
       (ecto) lib/ecto/migrator.ex:113: Ecto.Migrator.attempt/6
       (ecto) lib/ecto/migrator.ex:93: anonymous fn/4 in Ecto.Migrator.do_down/4
       (ecto) lib/ecto/migrator.ex:83: Ecto.Migrator.down/4
       integration_test/sql/migration.exs:274
```