### PR TITLE
Allows a keyword list to be passed to where

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -703,4 +703,13 @@ defmodule Ecto.Integration.RepoTest do
     assert [3] == Post |> select([p], count(p.title)) |> TestRepo.all
     assert [2] == Post |> select([p], count(p.title, :distinct)) |> TestRepo.all
   end
+
+  test "keyword where" do
+    post1 = TestRepo.insert!(%Post{text: "x", title: "hello"  })
+    post2 = TestRepo.insert!(%Post{text: "y", title: "goodbye"})
+
+    assert [post1, post2] == Post |> where([], []) |> TestRepo.all
+    assert [post1]        == Post |> where([], [title: "hello"]) |> TestRepo.all
+    assert [post1]        == Post |> where([], [title: "hello", id: ^post1.id]) |> TestRepo.all
+  end
 end

--- a/lib/ecto/query/builder/filter.ex
+++ b/lib/ecto/query/builder/filter.ex
@@ -13,7 +13,7 @@ defmodule Ecto.Query.Builder.Filter do
   @spec build(:where | :having, Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
   def build(kind, query, binding, expr, env) do
     binding        = Builder.escape_binding(binding)
-    {expr, params} = Builder.escape(expr, :boolean, %{}, binding, env)
+    {expr, params} = escape(expr, binding, env)
     params         = Builder.escape_params(params)
 
     expr = quote do: %Ecto.Query.QueryExpr{
@@ -37,4 +37,33 @@ defmodule Ecto.Query.Builder.Filter do
     query = Ecto.Queryable.to_query(query)
     %{query | havings: query.havings ++ [expr]}
   end
+
+  @doc """
+  Escapes a where or having clause.
+
+  It allows query expressions that evaluate to a boolean
+  or a keyword list of field names and values. In a keyword
+  list multiple key value pairs will be joined with "and".
+  """
+  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, %{}}
+  def escape([], vars, env) do
+    {[], %{}}
+  end
+
+  def escape(expr, vars, env) when is_list(expr) do
+    {parts, params} =
+      Enum.map_reduce(expr, %{}, fn {field, value}, acc ->
+        {value, params} = Builder.escape(value, {0, field}, acc, vars, env)
+        {[:==, [], [to_field(field), value]], params}
+      end)
+
+    expr = Enum.reduce parts, &[:and, [], [{:{}, [], &1}, {:{}, [], &2}]]
+    {{:{}, [], expr}, params}
+  end
+
+  def escape(expr, vars, env) do
+    Builder.escape(expr, :boolean, %{}, vars, env)
+  end
+
+  defp to_field(field), do: Macro.escape {{:., [], [{:&, [], [0]}, field]}, [], []}
 end


### PR DESCRIPTION
 - keyword arguments will be joined with "and" as a where clause
 - an empty list will return an empt clause
 - Issue #969