### PR TITLE
update Ecto.Changeset.unique_contraint/3 docs

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1252,7 +1252,9 @@ defmodule Ecto.Changeset do
 
   Now, when invoking `Repo.insert/2` or `Repo.update/2`, if the
   email already exists, it will be converted into an error and
-  `{:error, changeset}` returned by the repository.
+  `{:error, changeset}` returned by the repository. Note that the error
+  will occur only after hitting the database so it will not be visible
+  until all other validations pass.
 
   ## Options
 


### PR DESCRIPTION
The docs don't explain why there aren't any error messages for uniqueness validation when other validation error messages are present. This can be misleading for beginners and since it is a common feature implemented while learning, it can be useful to have it in the docs.