### PR TITLE
Remove __schema__(:autogenerate) from docs

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -238,8 +238,6 @@ defmodule Ecto.Schema do
   * `__schema__(:read_after_writes)` - Non-virtual fields that must be read back
     from the database after every write (insert or update);
 
-  * `__schema__(:autogenerate)` - Non-virtual fields that are auto generated on insert;
-
   * `__schema__(:autogenerate_id)` - Primary key that is auto generated on insert;
 
   Furthermore, both `__struct__` and `__changeset__` functions are


### PR DESCRIPTION
Seems the clause was removed in 184592c13e8603b29f623958d3738d9d6f73bcaa. Please merge to remove corresponding doc.