### PR TITLE
Add a sane timeout value for psql invocations.

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -113,6 +113,7 @@ defmodule Ecto.Adapters.Postgres do
       else
         []
       end
+    env = [{"PGCONNECT_TIMEOUT", "10"} | env]
 
     args = []
 


### PR DESCRIPTION
I ran into this problem when my DB server started acting up, running "mix test" would just stand there doing nothing. However, ecto queries were correctly timing out. It turns out this external psql invocation had a VERY long default timeout and nothing is printed to the screen meanwhile. I'm not sure if there is another timeout that can be given for the SQL commands themselves but this connect_timeout solved my problem by at least telling me what was wrong.