### PR TITLE
Allow decoding result without blocking connection

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -22,10 +22,14 @@ if Code.ensure_loaded?(Mariaex.Connection) do
         value -> value
       end
 
-      case Mariaex.Connection.query(conn, sql, params, opts) do
-        {:ok, res}        -> {:ok, Map.from_struct(res)}
-        {:error, _} = err -> err
-      end
+      Mariaex.Connection.query(conn, sql, params, [decode: :manual] ++ opts)
+    end
+
+    def decode({:ok, res}, mapper) do
+      {:ok, Mariaex.Connection.decode(res, mapper) |> Map.from_struct}
+    end
+    def decode({:error, _} = err, _mapper) do
+      err
     end
 
     defp normalize_port(port) when is_binary(port), do: String.to_integer(port)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -28,10 +28,14 @@ if Code.ensure_loaded?(Postgrex.Connection) do
         value -> value
       end
 
-      case Postgrex.Connection.query(conn, sql, params, opts) do
-        {:ok, res}        -> {:ok, Map.from_struct(res)}
-        {:error, _} = err -> err
-      end
+      Postgrex.Connection.query(conn, sql, params, [decode: :manual] ++ opts)
+    end
+
+    def decode({:ok, res}, mapper) do
+      {:ok, Postgrex.Result.decode(res, mapper) |> Map.from_struct}
+    end
+    def decode({:error, _} = err, _mapper) do
+      err
     end
 
     defp normalize_port(port) when is_binary(port), do: String.to_integer(port)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -176,7 +176,7 @@ defmodule Ecto.Adapters.SQL do
   @spec query!(Ecto.Repo.t, String.t, [term], Keyword.t) ::
                %{rows: nil | [tuple], num_rows: non_neg_integer} | no_return
   def query!(repo, sql, params, opts \\ []) do
-    query!(repo, sql, params, nil, opts)
+    query!(repo, sql, params, fn x -> x end, opts)
   end
 
   defp query!(repo, sql, params, mapper, opts) do
@@ -218,7 +218,7 @@ defmodule Ecto.Adapters.SQL do
   @spec query(Ecto.Repo.t, String.t, [term], Keyword.t) ::
               {:ok, %{rows: nil | [tuple], num_rows: non_neg_integer}} | {:error, Exception.t}
   def query(repo, sql, params, opts \\ []) do
-    query(repo, sql, params, nil, opts)
+    query(repo, sql, params, fn x -> x end, opts)
   end
 
   defp query(repo, sql, params, mapper, opts) do
@@ -245,8 +245,8 @@ defmodule Ecto.Adapters.SQL do
     end
 
     case Pool.run(pool_mod, pool, pool_timeout, query_fun) do
-      {:ok, {result, entry}} ->
-        decode(result, entry, mapper)
+      {:ok, {mod, result, entry}} ->
+        decode(mod, result, entry, mapper)
       {:error, :noconnect} ->
         :noconnect
       {:error, :noproc} ->
@@ -256,34 +256,21 @@ defmodule Ecto.Adapters.SQL do
   end
 
   defp query(mod, conn, _queue_time, sql, params, false, opts) do
-    {mod.query(conn, sql, params, opts), nil}
+    {mod, mod.query(conn, sql, params, opts), nil}
   end
   defp query(mod, conn, queue_time, sql, params, true, opts) do
     {query_time, result} = :timer.tc(mod, :query, [conn, sql, params, opts])
     entry = %Ecto.LogEntry{query: sql, params: params, connection_pid: conn,
                            query_time: query_time, queue_time: queue_time}
-    {result, entry}
+    {mod, result, entry}
   end
 
-  defp decode(result, nil, nil) do
-    {result, nil}
+  defp decode(mod, result, nil, mapper) do
+    {mod.decode(result, mapper), nil}
   end
-  defp decode(result, nil, mapper) do
-    {decode(result, mapper), nil}
-  end
-  defp decode(result, entry, nil) do
-    {result, %{entry | result: result}}
-  end
-  defp decode(result, %{query_time: query_time} = entry, mapper) do
-    {decode_time, decoded} = :timer.tc(fn -> decode(result, mapper) end)
+  defp decode(mod, result, %{query_time: query_time} = entry, mapper) do
+    {decode_time, decoded} = :timer.tc(mod, :decode, [result, mapper])
     {decoded, %{entry | result: decoded, query_time: query_time + decode_time}}
-  end
-
-  defp decode({:ok, %{rows: rows} = res}, mapper) when is_list(rows) do
-    {:ok, %{res | rows: Enum.map(rows, mapper)}}
-  end
-  defp decode(other, _mapper) do
-    other
   end
 
   defp log(_repo, nil), do: :ok
@@ -484,7 +471,7 @@ defmodule Ecto.Adapters.SQL do
 
   @doc false
   def model(repo, conn, sql, values, returning, opts) do
-    case query(repo, sql, values, nil, opts) do
+    case query(repo, sql, values, fn x -> x end, opts) do
       {:ok, %{rows: nil, num_rows: 1}} ->
         {:ok, []}
       {:ok, %{rows: [values], num_rows: 1}} ->

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -268,9 +268,9 @@ defmodule Ecto.Adapters.SQL do
   defp decode(mod, result, nil, mapper) do
     {mod.decode(result, mapper), nil}
   end
-  defp decode(mod, result, %{query_time: query_time} = entry, mapper) do
+  defp decode(mod, result, entry, mapper) do
     {decode_time, decoded} = :timer.tc(mod, :decode, [result, mapper])
-    {decoded, %{entry | result: decoded, query_time: query_time + decode_time}}
+    {decoded, %Ecto.LogEntry{entry | result: decoded, decode_time: decode_time}}
   end
 
   defp log(_repo, nil), do: :ok

--- a/lib/ecto/adapters/sql/query.ex
+++ b/lib/ecto/adapters/sql/query.ex
@@ -38,6 +38,11 @@ defmodule Ecto.Adapters.SQL.Query do
   """
   defcallback to_constraints(Exception.t) :: Keyword.t
 
+  @doc """
+  Decodes the given result set given the mapper function.
+  """
+  defcallback decode(result, mapper :: (term -> term)) :: result
+
   ## Queries
 
   @doc """

--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -9,6 +9,7 @@ defmodule Ecto.LogEntry do
     * params - the query parameters;
     * result - the query result as an `:ok` or `:error` tuple;
     * query_time - the time spent executing the query in microseconds;
+    * decode_time - the time spent decoding the result in microseconds (it may be nil);
     * queue_time - the time spent to check the connection out in microseconds (it may be nil);
     * connection_pid - the connection process that executed the query
   """
@@ -16,10 +17,11 @@ defmodule Ecto.LogEntry do
   alias Ecto.LogEntry
 
   @type t :: %LogEntry{query: iodata | (t -> iodata), params: [term],
-                       query_time: integer, queue_time: integer, connection_pid: pid | nil,
+                       query_time: integer, decode_time: integer | nil,
+                       queue_time: integer | nil, connection_pid: pid | nil,
                        result: {:ok, term} | {:error, Exception.t}}
-  defstruct query: nil, params: [], query_time: nil, queue_time: nil, result: nil,
-            connection_pid: nil
+  defstruct query: nil, params: [], query_time: nil, decode_time: nil,
+            queue_time: nil, result: nil, connection_pid: nil
 
   @doc """
   Resolves a log entry.
@@ -41,7 +43,7 @@ defmodule Ecto.LogEntry do
   The entry is automatically resolved if it hasn't been yet.
   """
   def to_iodata(entry) do
-    %{query_time: query_time, queue_time: queue_time,
+    %{query_time: query_time, decode_time: decode_time, queue_time: queue_time,
       params: params, query: query, result: result} = entry = resolve(entry)
 
     params = Enum.map params, fn
@@ -50,7 +52,8 @@ defmodule Ecto.LogEntry do
     end
 
     {entry, [query, ?\s, inspect(params, char_lists: false), ?\s, ok_error(result),
-             time("query", query_time, true), time("queue", queue_time, false)]}
+             time("query", query_time, true), time("decode", decode_time, false),
+             time("queue", queue_time, false)]}
   end
 
   defp ok_error({:ok, _}),    do: "OK"

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Ecto.Mixfile do
     [{:poolboy, "~> 1.4"},
      {:sbroker, "~> 0.7", optional: true},
      {:decimal, "~> 1.0"},
-     {:postgrex, "~> 0.9.1", optional: true},
+     {:postgrex, "~> 0.10", optional: true},
      {:mariaex, "~> 0.4.1", optional: true},
      {:poison, "~> 1.0", optional: true},
      {:ex_doc, "~> 0.10", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,5 @@
   "mariaex": {:hex, :mariaex, "0.4.1"},
   "poison": {:hex, :poison, "1.3.1"},
   "poolboy": {:hex, :poolboy, "1.4.2"},
-  "postgrex": {:hex, :postgrex, "0.9.1"},
+  "postgrex": {:hex, :postgrex, "0.10.0"},
   "sbroker": {:hex, :sbroker, "0.7.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"decimal": {:hex, :decimal, "1.1.0"},
+%{"connection": {:hex, :connection, "1.0.1"},
+  "decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"},
   "inch_ex": {:hex, :inch_ex, "0.2.4"},

--- a/test/ecto/log_entry_test.exs
+++ b/test/ecto/log_entry_test.exs
@@ -40,6 +40,9 @@ defmodule Ecto.LogEntryTest do
 
     entry = %{entry | params: [1, 2, 3], query_time: 2100, queue_time: 100, result: {:error, :error}}
     assert to_binary(entry) == "done [1, 2, 3] ERROR query=2.1ms queue=0.1ms"
+
+    entry = %{entry | params: [1, 2, 3], query_time: 2100, decode_time: 500, queue_time: 100, result: {:error, :error}}
+    assert to_binary(entry) == "done [1, 2, 3] ERROR query=2.1ms decode=0.5ms queue=0.1ms"
   end
 
   test "resolves when converting entry to iodata" do


### PR DESCRIPTION
Warning: WIP while working on required changes to postgrex and benchmark comparisons.

Trying again to handle decoding in the client process. See ericmj/postgrex/pull/108 for an explanation of the proposed changes to the postgresql driver.