### PR TITLE
Allow anonymous functions for casting associations

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -323,10 +323,23 @@ defmodule Ecto.Changeset do
 
   ## Relations
 
-  You can override the relation's `on_cast` setting by providing a key-value pair
-  in the `required` or `optional` list instead of a simple field name. The key
-  will be the relation's name and value the new changeset function. The new
-  function will be used similarily to the one provided in the `on_cast` setting.
+  You can override the relation's `on_cast` setting by providing a 2 item tuple
+  in the `required` or `optional` list instead of a simple field name.
+
+  The key will be the relation's name and value is either the changeset
+  function's name or an anonymous function that accepts a model and params. The
+  new function will be used similarily to the one provided in the `on_cast`
+  setting.
+
+      # Will use Author.custom_changeset/2 as the changeset function
+      cast(post, %{author: %{name: "Paul"}}, ~w(), [{:author, :custom_changeset})
+
+      # Will use my_custom_changeset/2 as the changeset function.
+      cast(post, %{author: %{name: "Paul"}}, ~w(), [{:author, &my_custom_changeset/2}])
+
+      defp my_custom_changeset(model, params) do
+        cast(model, params, ~w(name))
+      end
 
   """
   @spec cast(Ecto.Model.t | t,

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -179,8 +179,12 @@ defmodule Ecto.Changeset.Relation do
                    &do_cast(relation, &1, &2))
   end
 
-  defp do_cast(%{related: model, on_cast: fun} = meta, params, nil) do
-    {:ok, apply(model, fun, [meta.__struct__.build(meta), params])
+  defp do_cast(%{related: model, on_cast: fun} = meta, params, nil) when is_function(fun) do
+    {:ok, fun.(meta.__struct__.build(meta), params) |> put_new_action(:insert)}
+  end
+
+  defp do_cast(%{related: model, on_cast: fun_name} = meta, params, nil) do
+    {:ok, apply(model, fun_name, [meta.__struct__.build(meta), params])
           |> put_new_action(:insert)}
   end
 

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -631,6 +631,22 @@ defmodule Ecto.AssociationTest do
     assert profile.action  == :insert
     assert profile.valid?
     assert changeset.valid?
+
+    changeset = Changeset.cast(%Author{}, %{"profile" => %{}},
+                     [profile: &custom_profile_changeset/2])
+    profile = changeset.changes.profile
+    assert changeset.required == [:profile]
+    assert profile.model.name == "default"
+    assert profile.model.__meta__.source == {nil, "users_profiles"}
+    assert profile.changes == %{}
+    assert profile.errors  == []
+    assert profile.action  == :insert
+    assert profile.valid?
+    assert changeset.valid?
+  end
+
+  defp custom_profile_changeset(model, params) do
+    Ecto.Changeset.cast(model, params, ~w(), ~w(author_id))
   end
 
   test "cast has_one keeps appropriate action from changeset" do
@@ -737,6 +753,19 @@ defmodule Ecto.AssociationTest do
     assert post_change.action  == :insert
     assert post_change.valid?
     assert changeset.valid?
+
+    changeset = Changeset.cast(%Author{}, %{"posts" => [%{"title" => "hello"}]},
+                               [posts: &custom_posts_changeset/2])
+    [post_change] = changeset.changes.posts
+    assert post_change.changes == %{title: "hello"}
+    assert post_change.errors  == []
+    assert post_change.action  == :insert
+    assert post_change.valid?
+    assert changeset.valid?
+  end
+
+  defp custom_posts_changeset(model, params) do
+    Ecto.Changeset.cast(model, params, ~w(), ~w(title))
   end
 
   test "cast has_many without loading" do


### PR DESCRIPTION
This allows user's to pass a custom function for casting associations.

    cast(post, params, ~w(), [{:author, &my_custom_changeset/2}])

Also clarifies documentation on what it expects the value to be. When I
read "key value" I thought it wanted a Map or Keyword list. This commit
changes it to state that it expects a 2 item tuple and adds an example
for clarity.

This can be helpful if your changesets are defined somewhere other than the model itself. It is also helpful even if it is defined on the model because it makes it very clear which function is used

    cast(post, params, ~w(), [{:author, &Author.optional_changeset/2}])