### PR TITLE
Remove Range.t from validate_number/3 typespec

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1145,7 +1145,7 @@ defmodule Ecto.Changeset do
       validate_number(changeset, :the_answer_to_life_the_universe_and_everything, equal_to: 42)
 
   """
-  @spec validate_number(t, atom, Range.t | [Keyword.t]) :: t
+  @spec validate_number(t, atom, [Keyword.t]) :: t
   def validate_number(changeset, field, opts) do
     validate_change changeset, field, {:number, opts}, fn
       field, value ->


### PR DESCRIPTION
While a range would be nice, that isn't the current behavior. The `validate_number/3` function only accepts keywords and raises an error when a range is provided.

Alternatively, I'd like to explore adding range support to `validate_number/3`.