### PR TITLE
Fix example of validate_confirmation

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1216,10 +1216,10 @@ defmodule Ecto.Changeset do
   ## Examples
 
       validate_confirmation(changeset, :email)
-      validate_confirmation(changeset, :password, message: "passwords do not match")
+      validate_confirmation(changeset, :password, message: "does not match password")
 
       cast(model, params, ~w(password), ~w())
-      |> validate_confirmation(:password, message: "passwords do not match")
+      |> validate_confirmation(:password, message: "does not match password")
 
   """
   @spec validate_confirmation(t, atom, Enum.t) :: t


### PR DESCRIPTION
An example message is a bit confusing.
![](https://i.gyazo.com/c460ada53d9e10827c606e920e8e9de2.png)