### PR TITLE
Move pattern match to function signature for consistency

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -937,9 +937,7 @@ defmodule Ecto.Changeset do
 
   """
   @spec validate_change(t, atom, (atom, term -> [error])) :: t
-  def validate_change(changeset, field, validator) when is_atom(field) do
-    %{changes: changes, errors: errors} = changeset
-
+  def validate_change(%{changes: changes, errors: errors} = changeset, field, validator) when is_atom(field) do
     value = Map.get(changes, field)
     new   = if is_nil(value), do: [], else: validator.(field, value)
 


### PR DESCRIPTION
It looks like similar functions are pattern matching in the function signature

(new to elixir)