### PR TITLE
Pass --no-password to fix psql hanging. Closes #1127

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -128,6 +128,7 @@ defmodule Ecto.Adapters.Postgres do
     host = database[:hostname] || System.get_env("PGHOST") || "localhost"
     args = args ++ ["--quiet",
                     "--host", host,
+                    "--no-password",
                     "--set", "ON_ERROR_STOP=1",
                     "--set", "VERBOSITY=verbose",
                     "--no-psqlrc",


### PR DESCRIPTION
When the password is nil or blank string, the psql
password env vars are not set, which causing psql to
prompt for password and hang for the end user. This
flag tells psql to never prompt for a password so an
error can be reported to the user accordingly.