### PR TITLE
Allow map in Repo.get_by. Closes #1133

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -381,6 +381,8 @@ defmodule Ecto.Integration.RepoTest do
     assert post1 == TestRepo.get_by!(Post, id: post1.id, text: post1.text)
     assert post2 == TestRepo.get_by!(Post, id: to_string(post2.id)) # With casting
 
+    assert post1 == TestRepo.get_by!(Post, %{id: post1.id})
+
     assert_raise Ecto.NoResultsError, fn ->
       TestRepo.get_by!(Post, id: post2.id, text: "hey")
     end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -288,7 +288,7 @@ defmodule Ecto.Repo do
       MyRepo.get_by(Post, title: "My post")
 
   """
-  defcallback get_by(Ecto.Queryable.t, Keyword.t, Keyword.t) :: Ecto.Schema.t | nil | no_return
+  defcallback get_by(Ecto.Queryable.t, Keyword.t | Map.t, Keyword.t) :: Ecto.Schema.t | nil | no_return
 
   @doc """
   Similar to `get_by/3` but raises `Ecto.NoResultsError` if no record was found.
@@ -306,7 +306,7 @@ defmodule Ecto.Repo do
       MyRepo.get_by!(Post, title: "My post")
 
   """
-  defcallback get_by!(Ecto.Queryable.t, Keyword.t, Keyword.t) :: Ecto.Schema.t | nil | no_return
+  defcallback get_by!(Ecto.Queryable.t, Keyword.t | Map.t, Keyword.t) :: Ecto.Schema.t | nil | no_return
 
   @doc """
   Fetches a single result from the query.

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -189,7 +189,7 @@ defmodule Ecto.Repo.Queryable do
   end
 
   defp query_for_get_by(_repo, queryable, clauses) do
-    Ecto.Query.where(queryable, [], ^clauses)
+    Ecto.Query.where(queryable, [], ^Enum.to_list(clauses))
   end
 
   defp assert_model!(query) do

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -97,6 +97,7 @@ defmodule Ecto.RepoTest do
 
   test "validates get_by" do
     TestRepo.get_by(MyModel, id: 123)
+    TestRepo.get_by(MyModel, %{id: 123})
 
     message = ~r"value `:atom` in `where` cannot be cast to type :id in query"
     assert_raise Ecto.CastError, message, fn ->


### PR DESCRIPTION
This assumes we don't want to support maps in other clauses, like `where`, which I am totally fine with keep kwlists as is for other query functions.