### PR TITLE
Update changeset docs to import Ecto.Changeset

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -29,6 +29,7 @@ defmodule Ecto.Changeset do
 
       defmodule User do
         use Ecto.Schema
+        import Ecto.Changeset
 
         schema "users" do
           field :name
@@ -116,6 +117,7 @@ defmodule Ecto.Changeset do
 
           defmodule Comment do
             use Ecto.Schema
+            import Ecto.Changeset
 
             schema "comments" do
               field :body, :string


### PR DESCRIPTION
Using Ecto.Schema in Ecto 1.1 does not import Ecto.Changeset. We now
import it manually in the examples.