### PR TITLE
Update moduledoc for Ecto.Query: not is_nil

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -261,7 +261,7 @@ defmodule Ecto.Query do
   require the use of `in`:
 
       def published(query) do
-        from p in query, where: p.published_at != nil
+        from p in query, where: not(is_nil(p.published_a))
       end
 
   Notice we have created a `p` variable to represent each item in the query.
@@ -270,7 +270,7 @@ defmodule Ecto.Query do
 
       def published_multi(query) do
         from [p,o] in query,
-        where: p.published_at != nil and o.published_at != nil
+        where: not(is_nil(p.published_at)) and not(is_nil(o.published_at))
       end
 
   Note the variables `p` and `o` can be named whatever you like


### PR DESCRIPTION
Tonight I was trying to write an Ecto query to find all resources where a given attribute is not nil. The [Ecto.Query docs](http://hexdocs.pm/ecto/Ecto.Query.html) state that this is a valid query:

```elixir
from p in query, where: p.published_at != nil
```
I kept getting [this error](https://github.com/elixir-lang/ecto/blob/master/lib/ecto/query/builder.ex#L149-L152), which I believe came from https://github.com/elixir-lang/ecto/pull/1057 . 

This PR updates the moduledoc to use `not/1` and `is_nil/1`