### PR TITLE
Add support for partial indexes

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -579,7 +579,8 @@ if Code.ensure_loaded?(Postgrex.Connection) do
                 "ON",
                 quote_table(index.prefix, index.table),
                 if_do(index.using, "USING #{index.using}"),
-                "(#{fields})"])
+                "(#{fields})",
+                if_do(index.where, "WHERE #{index.where}")])
     end
 
     def execute_ddl({:create_if_not_exists, %Index{}=index}) do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -129,7 +129,8 @@ defmodule Ecto.Migration do
               columns: [],
               unique: false,
               concurrently: false,
-              using: nil
+              using: nil,
+              where: nil
 
     @type t :: %__MODULE__{
       table: atom,
@@ -138,7 +139,8 @@ defmodule Ecto.Migration do
       columns: [atom | String.t],
       unique: boolean,
       concurrently: boolean,
-      using: atom | String.t
+      using: atom | String.t,
+      where: atom | String.t
     }
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -382,6 +382,7 @@ defmodule Ecto.Migration do
     * `:concurrently` - if the index should be created/dropped concurrently
     * `:using` - configures the index type
     * `:prefix` - prefix for the index
+    * `:where` - the conditions for a partial index
 
   ## Adding/dropping indexes concurrently
 
@@ -404,6 +405,17 @@ defmodule Ecto.Migration do
   More information on index types can be found in the [PostgreSQL
   docs](http://www.postgresql.org/docs/9.4/static/indexes-types.html).
 
+  ## Partial indexes
+
+  PostgreSQL supports partial indexes.
+  A partial index is an index built over a subset of a table.
+  The subset is defined by a conditional expression using the `:where` option.
+  The `:where` option can be an atom or a string; its
+  value is passed to the `WHERE` clause as is.
+
+  More information on partial indexes can be found in the [PostgreSQL
+  docs](http://www.postgresql.org/docs/9.4/static/indexes-partial.html).
+
   ## Examples
 
       # Without a name, index defaults to products_category_id_sku_index
@@ -420,6 +432,9 @@ defmodule Ecto.Migration do
 
       # Create an index on custom expressions
       create index(:products, ["lower(name)"], name: :products_lower_name_index)
+
+      # Create a partial index
+      create index(:products, [:user_id], where: "price = 0", name: :free_products_index)
 
   """
   def index(table, columns, opts \\ []) when is_atom(table) and is_list(columns) do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -599,6 +599,12 @@ defmodule Ecto.Adapters.MySQLTest do
            ~s|CREATE UNIQUE INDEX `posts_permalink_index` ON `posts` (`permalink`)|
   end
 
+  test "create unique index with condition" do
+    create = {:create, index(:posts, [:permalink], unique: true, where: "public IS TRUE")}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE UNIQUE INDEX `posts_permalink_index` ON `posts` (`permalink`)|
+  end
+
   test "create an index using a different type" do
     create = {:create, index(:posts, [:permalink], using: :hash)}
     assert SQL.execute_ddl(create) ==

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -669,6 +669,16 @@ defmodule Ecto.Adapters.PostgresTest do
            ~s|CREATE UNIQUE INDEX "posts_permalink_index" ON "posts" ("permalink")|
   end
 
+  test "create unique index with condition" do
+    create = {:create, index(:posts, [:permalink], unique: true, where: "public IS TRUE")}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE UNIQUE INDEX "posts_permalink_index" ON "posts" ("permalink") WHERE public IS TRUE|
+
+    create = {:create, index(:posts, [:permalink], unique: true, where: :public)}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE UNIQUE INDEX "posts_permalink_index" ON "posts" ("permalink") WHERE public|
+  end
+
   test "create index concurrently" do
     create = {:create, index(:posts, [:permalink], concurrently: true)}
     assert SQL.execute_ddl(create) ==


### PR DESCRIPTION
Comes from issue #883.

This PR adds support for the `:where` option.
It currently only allow a string or atom for the `:where`,
which gets added to the string automatically.

``` elixir
create index(:products, [:user_id], where: "price = 0", name: :free_products_index)
```

becomes the SQL
``` sql
CREATE INDEX "free_products_index" ON "products" ("user_id") WHERE price = 0
```