### PR TITLE
[1170] Cast must validate that the key be present if required

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -501,19 +501,20 @@ defmodule Ecto.Changeset do
         case Relation.cast(relation, value, current, on_cast) do
           {:ok, change, relation_valid?, false} when change != current ->
             missing_relation(%{changeset | changes: Map.put(changes, key, change),
-                               valid?: changeset.valid? && relation_valid?}, key, current, required?)
+                               valid?: changeset.valid? && relation_valid?}, key, current, required?, relation)
           {:ok, _, _, _} ->
-            missing_relation(changeset, key, current, required?)
+            missing_relation(changeset, key, current, required?, relation)
           :error ->
             %{changeset | errors: [{key, "is invalid"} | changeset.errors], valid?: false}
         end
       :error ->
-        missing_relation(changeset, key, current, required?)
+        missing_relation(changeset, key, current, required?, relation)
     end
   end
 
-  defp missing_relation(%{changes: changes, errors: errors} = changeset, name, current, required?) do
-    if required? and is_nil(Map.get(changes, name, current)) do
+  defp missing_relation(%{changes: changes, errors: errors} = changeset, name, current, required?, relation) do
+    current_changes = Map.get(changes, name, current)
+    if required? and Relation.empty?(relation, current_changes) do
       %{changeset | errors: [{name, "can't be blank"} | errors], valid?: false}
     else
       changeset

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -339,7 +339,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == []
+    assert changeset.errors == [posts: "can't be blank"]
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.changes == %{}

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -371,15 +371,14 @@ defmodule Ecto.Changeset.HasAssocTest do
 
   test "cast has_many when required" do
     # Still no error because the loaded association is an empty list
-    changeset = cast(%Author{}, %{}, :posts, required: true)
+    changeset = cast(%Author{}, %{posts: [%{title: "hello"}]}, :posts, required: true)
     assert changeset.required == [:posts]
-    assert changeset.changes == %{}
     assert changeset.errors == []
 
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == []
+    assert changeset.errors == [posts: "can't be blank"]
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.required == [:posts]


### PR DESCRIPTION
I have integrated with the Relation.empty? function and also changed some tests to validate this behaviour