### PR TITLE
@schema_prefix for Ecto schema

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -35,6 +35,9 @@ defmodule Ecto.Schema do
       to `{:id, :id, autogenerate: true}`. When set to
       false, does not define a primary key in the schema;
 
+    * `@schema_prefix` - configures the schema prefix. Defaults `nil`
+      generate queries without prefix;
+
     * `@foreign_key_type` - configures the default foreign key type
       used by `belongs_to` associations. Defaults to `:integer`;
 
@@ -221,6 +224,8 @@ defmodule Ecto.Schema do
   used for runtime introspection of the schema:
 
   * `__schema__(:source)` - Returns the source as given to `schema/2`;
+  * `__schema__(:prefix)` - Returns optional prefix for source provided by
+    `@schema_prefix` schema attribute;
   * `__schema__(:primary_key)` - Returns a list of primary key fields (empty if there is none);
 
   * `__schema__(:fields)` - Returns a list of all non-virtual field names;
@@ -279,6 +284,7 @@ defmodule Ecto.Schema do
       @foreign_key_type :id
       @before_compile Ecto.Schema
       @ecto_embedded false
+      @schema_prefix nil
 
       Module.register_attribute(__MODULE__, :ecto_fields, accumulate: true)
       Module.register_attribute(__MODULE__, :ecto_assocs, accumulate: true)
@@ -311,6 +317,7 @@ defmodule Ecto.Schema do
   """
   defmacro schema(source, [do: block]) do
     quote do
+      prefix = Module.get_attribute(__MODULE__, :schema_prefix)
       source = unquote(source)
 
       unless is_binary(source) do
@@ -320,7 +327,7 @@ defmodule Ecto.Schema do
       Module.register_attribute(__MODULE__, :changeset_fields, accumulate: true)
       Module.register_attribute(__MODULE__, :struct_fields, accumulate: true)
       Module.put_attribute(__MODULE__, :struct_fields,
-                           {:__meta__, %Metadata{state: :built, source: {nil, source}}})
+                           {:__meta__, %Metadata{state: :built, source: {prefix, source}}})
 
       primary_key_fields =
         case @primary_key do
@@ -347,7 +354,7 @@ defmodule Ecto.Schema do
       Module.eval_quoted __ENV__, [
         Ecto.Schema.__defstruct__(@struct_fields),
         Ecto.Schema.__changeset__(@changeset_fields),
-        Ecto.Schema.__schema__(source, fields, primary_key_fields),
+        Ecto.Schema.__schema__(prefix, source, fields, primary_key_fields),
         Ecto.Schema.__types__(fields),
         Ecto.Schema.__assocs__(assocs),
         Ecto.Schema.__embeds__(embeds),
@@ -1042,7 +1049,7 @@ defmodule Ecto.Schema do
   end
 
   @doc false
-  def __schema__(source, fields, primary_key) do
+  def __schema__(prefix, source, fields, primary_key) do
     field_names = Enum.map(fields, &elem(&1, 0))
 
     # Hash is used by the query cache to specify
@@ -1052,6 +1059,7 @@ defmodule Ecto.Schema do
     hash = :erlang.phash2({primary_key, fields})
 
     quote do
+      def __schema__(:prefix),      do: unquote(Macro.escape(prefix))
       def __schema__(:source),      do: unquote(Macro.escape(source))
       def __schema__(:fields),      do: unquote(field_names)
       def __schema__(:primary_key), do: unquote(primary_key)

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -22,6 +22,7 @@ defmodule Ecto.SchemaTest do
 
   test "schema metadata" do
     assert Model.__schema__(:source)             == "mymodel"
+    assert Model.__schema__(:prefix)             == nil
     assert Model.__schema__(:fields)             == [:id, :name, :email, :count, :array, :uuid, :comment_id]
     assert Model.__schema__(:read_after_writes)  == [:email, :count]
     assert Model.__schema__(:primary_key)        == [:id]
@@ -111,6 +112,34 @@ defmodule Ecto.SchemaTest do
     assert %SchemaModel{}.__meta__.state == :built
     assert %SchemaModel{}.__meta__.source == {nil, "users"}
     assert SchemaModel.__schema__(:type, :__meta__) == nil
+  end
+
+  ## Schema prefix
+
+  defmodule SchemaWithPrefix do
+    use Ecto.Schema
+
+    @schema_prefix "tenant_001"
+    schema "company" do
+      field :name
+    end
+  end
+
+  test "schema prefix metadata" do
+    assert SchemaWithPrefix.__schema__(:source) == "company"
+    assert SchemaWithPrefix.__schema__(:prefix) == "tenant_001"
+    assert %SchemaWithPrefix{}.__meta__.source == {"tenant_001", "company"}
+  end
+
+  test "updates meta prefix with put_meta" do
+    model = %SchemaWithPrefix{}
+    assert model.__meta__.source == {"tenant_001", "company"}
+    model = Ecto.put_meta(model, source: "new_company")
+    assert model.__meta__.source == {"tenant_001", "new_company"}
+    model = Ecto.put_meta(model, prefix: "prefix")
+    assert model.__meta__.source == {"prefix", "new_company"}
+    model = Ecto.put_meta(model, prefix: nil)
+    assert model.__meta__.source == {nil, "new_company"}
   end
 
   ## Errors


### PR DESCRIPTION
Define prefix for schema with @schema_prefix attribute
Issues https://github.com/elixir-lang/ecto/issues/1006

For query we need to agree about format:
We current have: `%{query | prefix: "foo"}` 

I see: 
1) use `prefix` key as binary (current usage) to replace all schema prefixes (or only is nil)
    define second key `:build_prefix` as map for all possible schema prefixes.

2) use only `prefix` key as binary (current usage) or map for all possible schema prefixes.

Example to alter prefix on query is here (without error)
https://github.com/Tica2/ecto/commit/7c94a87f45a9ec83f40f111d60e32fac4ee8d4db#diff-975ad8a7b1f8e27ac59595bcdbdd0a07L443
  