### PR TITLE
Improved support for PG check and exclusion constraints

### DIFF
--- a/integration_test/pg/check_constraint_test.exs
+++ b/integration_test/pg/check_constraint_test.exs
@@ -1,0 +1,69 @@
+defmodule Ecto.Integration.CheckConstraintTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Integration.TestRepo
+  import Ecto.Migrator, only: [up: 4, down: 4]
+
+  defmodule CheckConstraintMigration do
+    use Ecto.Migration
+
+    @table table(:products)
+
+    def change do
+      create @table do
+        add :price, :integer
+      end
+      create constraint(@table.name, "positive_price", check: "price > 0")
+    end
+  end
+
+  defmodule CheckConstraintModel do
+    use Ecto.Integration.Schema
+
+    schema "products" do
+      field :price, :integer
+    end
+  end
+
+  test "creating, using, and dropping a check constraint" do
+    assert :ok == up(TestRepo, 20120806000000, CheckConstraintMigration, log: false)
+
+    # When the changeset doesn't expect the db error
+    changeset = Ecto.Changeset.change(%CheckConstraintModel{}, price: -10)
+    exception =
+      assert_raise(Ecto.ConstraintError, ~r/constraint error when attempting to insert model/, fn ->
+        TestRepo.insert(changeset)
+      end
+      )
+    assert exception.message =~ "check: positive_price"
+    assert exception.message =~ "The changeset has not defined any constraint."
+
+    # When the changeset does expect the db error, but doesn't give a custom message
+    changeset = Ecto.Changeset.change(%CheckConstraintModel{}, price: -10)
+    {:error, changeset} =
+      changeset
+      |> Ecto.Changeset.check_constraint(:price, name: :positive_price)
+      |> TestRepo.insert()
+    assert changeset.errors == [price: "violates check 'positive_price'"]
+    assert changeset.model.__meta__.state == :built
+
+    # When the changeset does expect the db error and gives a custom message
+    changeset = Ecto.Changeset.change(%CheckConstraintModel{}, price: -10)
+    {:error, changeset} =
+      changeset
+      |> Ecto.Changeset.check_constraint(:price, name: :positive_price, message: "price must be greater than 0")
+      |> TestRepo.insert()
+    assert changeset.errors == [price: "price must be greater than 0"]
+    assert changeset.model.__meta__.state == :built
+
+    # When the change does not violate the check constraint
+    changeset = Ecto.Changeset.change(%CheckConstraintModel{}, price: 10)
+    {:ok, changeset} =
+      changeset
+      |> Ecto.Changeset.check_constraint(:price, name: :positive_price, message: "price must be greater than 0")
+      |> TestRepo.insert()
+    assert is_integer(changeset.id)
+
+    assert :ok == down(TestRepo, 20120806000000, CheckConstraintMigration, log: false)
+  end
+end

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1395,6 +1395,25 @@ defmodule Ecto.Changeset do
   end
 
   ## Constraints
+  @doc """
+  Checks for a check constraint in the given field.
+
+  The check constraint works by relying on the database to check
+  if the check constraint has been violated or not and, if so,
+  Ecto converts it into a changeset error.
+
+  ## Options
+
+    * `:message` - the message in case the constraint check fails.
+      Defaults to something like "violates check 'products_price_check'"
+    * `:name` - the name of the constraint. Required.
+
+  """
+  def check_constraint(changeset, field, opts \\ []) do
+    constraint = opts[:name] || raise ArgumentError, "must supply the name of the constraint"
+    message    = opts[:message] || "violates check '#{constraint}'"
+    add_constraint(changeset, :check, to_string(constraint), field, message)
+  end
 
   @doc """
   Checks for a unique constraint in the given field.

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -828,6 +828,21 @@ defmodule Ecto.ChangesetTest do
   end
 
   ## Constraints
+  test "check_constraint/3" do
+    changeset = change(%Post{}) |> check_constraint(:title, name: :title_must_be_short)
+    assert changeset.constraints ==
+           [%{type: :check, field: :title, constraint: "title_must_be_short",
+              message: "violates check 'title_must_be_short'"}]
+
+    changeset = change(%Post{}) |> check_constraint(:title, name: :title_must_be_short, message: "cannot be more than 15 characters")
+    assert changeset.constraints ==
+           [%{type: :check, field: :title, constraint: "title_must_be_short",
+              message: "cannot be more than 15 characters"}]
+
+    assert_raise ArgumentError, ~r/supply the name/, fn ->
+      check_constraint(:title, message: "cannot be more than 15 characters")
+    end
+  end
 
   test "unique_constraint/3" do
     changeset = change(%Post{}) |> unique_constraint(:title)


### PR DESCRIPTION
Postgres supports ["check constraints"](http://www.postgresql.org/docs/9.5/static/ddl-constraints.html#DDL-CONSTRAINTS-CHECK-CONSTRAINTS), which validate a row to say that,
for example, `price` must be greater than `0`, or `end_time` must be
greater than `start_time`. This PR is meant to add support for such
checks.

I did **not** ask about this on the mailing list, so if you don't want this
feature, that's OK. :blush: I'm new to Elixir and Phoenix and wanted
to see if I could figure this out. So I'm asking for feedback before I
go further.

FWIW, of all the constraints [Postgres supports](http://www.postgresql.org/docs/9.5/static/ddl-constraints.html), check constraints are
the only ones Ecto doesn't yet support, so I thought this might be a useful
addition.

What works so far:

- Adding a constraint when adding a column in a migration
- Capturing the error returned by Postgres if a constraint is violated
- Turning that into a readable error on the changeset

What's still missing:

- Ability to `modify` an existing column to add a constraint
- Ability to remove constraints
- Ability to add table constraints (not tied to a single column; 
eg, `end_time` must be greater than `start_time`)

I'm currently tinkering with this in my `Rumbl` app from "Programming Phoenix".
I added an `other_description` column to `videos` and gave it a
constraint, like this:

```elixir
def change do
  alter table(:videos) do
    add :other_description, :string,
      check: check("char_length(other_description) < 5",
      name: "other_description_must_be_short")
  end
end
```

Then I added the constraint to `Video` like this:

```elixir
def changeset(model, params \\ :empty) do
   model
   |> cast(params, @required_fields, @optional_fields)
   |> foreign_key_constraint(:category_id)
   |> check_constraint(:other_description, name: :other_description_must_be_short)
end
```

With that much, adding a long description gives the user this error:

![constraint_error_no_message_given](https://cloud.githubusercontent.com/assets/338814/12066255/27ab5d58-afb3-11e5-879b-8d635c5ff8e7.png)

If I instead use

```elixir
|> check_constraint(:other_description,
  name: :other_description_must_be_short,
  message:  "must be less than 5 characters"
)
```

The user sees:

![constraint_error_with_message](https://cloud.githubusercontent.com/assets/338814/12066269/544e79ee-afb3-11e5-9807-e9ed777fb337.png)

Should I keep working on this? If so, what feedback do you have so far?