### PR TITLE
rewrite a duplicated test case in preload expand

### DIFF
--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -480,11 +480,11 @@ defmodule Ecto.AssociationTest do
            expand(Post, [:comments, :permalink])
 
     assert [{:post, {:assoc, %Ecto.Association.BelongsTo{}, {0, :id}},
-              {nil, [author: {nil, []}, permalink: {nil, []}]}}] =
-           expand(Comment, [:post, post: :author, post: :permalink])
+            {nil, [author: {nil, []}]}}] =
+           expand(Comment, [post: :author])
 
     assert [{:post, {:assoc, %Ecto.Association.BelongsTo{}, {0, :id}},
-             {nil, [author: {nil, []}, permalink: {nil, []}]}}] =
+            {nil, [author: {nil, []}, permalink: {nil, []}]}}] =
            expand(Comment, [:post, post: :author, post: :permalink])
 
     assert [{:posts, {:assoc, %Ecto.Association.Has{}, {0, :author_id}}, {nil, [comments: {nil, [post: {nil, []}]}]}},


### PR DESCRIPTION
I found there're two same test cases for `expand(Comment, [:post, post: :author, post: :permalink])`, so I rewrite the first one :)