### PR TITLE
makes repo url easier to see

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -42,7 +42,9 @@ defmodule Ecto do
         database: "ecto_simple",
         username: "postgres",
         password: "postgres",
-        hostname: "localhost"
+        hostname: "localhost",
+        # OR use a URL to connect instead
+        url: "postgres://postgres:postgres@localhost/ecto_simple"
 
   Each repository in Ecto defines a `start_link/0` function that needs to be invoked
   before using the repository. In general, this function is not called directly,


### PR DESCRIPTION
This is documented under https://hexdocs.pm/ecto/Ecto.Repo.html but many people like myself have not had a chance to read over all of the docs before trying this out. Having this more visible will be much easier for beginners who need to connect to a remote DB.