### PR TITLE
index/unique_index can now take a single atom

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -445,9 +445,14 @@ defmodule Ecto.Migration do
       create index(:products, [:user_id], where: "price = 0", name: :free_products_index)
 
   """
-  def index(table, columns, opts \\ []) when is_atom(table) and is_list(columns) do
-    index = struct(%Index{table: table, columns: columns}, opts)
-    %{index | name: index.name || default_index_name(index)}
+  def index(table, columns, opts \\ []) when is_atom(table) do
+    cond do
+      is_list(columns) ->
+        index = struct(%Index{table: table, columns: columns}, opts)
+        %{index | name: index.name || default_index_name(index)}
+      is_atom(columns) ->
+        index(table, [columns], opts)
+    end
   end
 
   @doc """
@@ -455,8 +460,11 @@ defmodule Ecto.Migration do
 
   See `index/3` for more information.
   """
-  def unique_index(table, columns, opts \\ []) when is_atom(table) and is_list(columns) do
-    index(table, columns, [unique: true] ++ opts)
+  def unique_index(table, columns, opts \\ []) when is_atom(table) do
+    cond do
+      is_list(columns) -> index(table, columns, [unique: true] ++ opts)
+      is_atom(columns) -> unique_index(table, [columns], opts)
+    end
   end
 
   defp default_index_name(index) do

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -34,14 +34,23 @@ defmodule Ecto.MigrationTest do
   end
 
   test "creates an index" do
+    assert index(:posts, :title) ==
+           %Index{table: :posts, unique: false, name: :posts_title_index, columns: [:title]}
+
     assert index(:posts, [:title]) ==
            %Index{table: :posts, unique: false, name: :posts_title_index, columns: [:title]}
     assert index(:posts, ["lower(title)"]) ==
            %Index{table: :posts, unique: false, name: :posts_lower_title_index, columns: ["lower(title)"]}
     assert index(:posts, [:title], name: :foo, unique: true) ==
            %Index{table: :posts, unique: true, name: :foo, columns: [:title]}
-    assert unique_index(:posts, [:title], name: :foo) ==
-           %Index{table: :posts, unique: true, name: :foo, columns: [:title]}
+
+
+    assert unique_index(:posts, :title, name: :foo1) ==
+           %Index{table: :posts, unique: true, name: :foo1, columns: [:title]}
+
+    assert unique_index(:posts, [:title], name: :foo2) ==
+           %Index{table: :posts, unique: true, name: :foo2, columns: [:title]}
+
   end
 
   test "creates a reference" do


### PR DESCRIPTION
When starting to use phoenix/ecto it through me for a loop that I couldn't do:

    add index(:posts, :title)

Instead you'd normally have to do:

    add index(:posts, [:title])

This PR allows for a single atom to be passed to `index` as well as `unique_index`