### PR TITLE
Add support for views

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -552,7 +552,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
 
     # DDL
 
-    alias Ecto.Migration.{Table, Index, Reference, Constraint}
+    alias Ecto.Migration.{Table, Index, Reference, Constraint, View}
 
     @drops [:drop, :drop_if_exists]
 
@@ -620,6 +620,12 @@ if Code.ensure_loaded?(Postgrex.Connection) do
 
     def execute_ddl({:drop, %Constraint{}=constraint}) do
       "ALTER TABLE #{quote_table(constraint.prefix, constraint.table)} DROP CONSTRAINT #{quote_name(constraint.name)}"
+    end
+
+    def execute_ddl({:create, %View{}=view}) do
+      materialized = if view.materialized, do: " MATERIALIZED ", else: " "
+
+      "CREATE" <> materialized <> "VIEW #{quote_table(view.prefix, view.name)} AS #{view.query}"
     end
 
     def execute_ddl(string) when is_binary(string), do: string

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -177,6 +177,14 @@ defmodule Ecto.Migration do
                            check: String.t | nil, exclude: String.t | nil}
   end
 
+  defmodule View do
+    @moduledoc """
+    Defines a view or materialized view used in migrations.
+    """
+    defstruct name: nil, materialized: false, prefix: nil, query: nil, with: nil
+    @type t :: %__MODULE__{name: atom, materialized: boolean, with: atom}
+  end
+
   alias Ecto.Migration.Runner
 
   @doc false
@@ -386,6 +394,10 @@ defmodule Ecto.Migration do
   """
   def table(name, opts \\ []) when is_atom(name) do
     struct(%Table{name: name}, opts)
+  end
+
+  def view(name, opts \\ []) when is_atom(name) do
+    struct(%View{name: name}, opts)
   end
 
   @doc ~S"""

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -541,7 +541,7 @@ defmodule Ecto.Adapters.PostgresTest do
   # DDL
 
   import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1,
-                                references: 2, constraint: 2, constraint: 3]
+                                references: 2, constraint: 2, constraint: 3, view: 2]
 
   test "executing a string during migration" do
     assert SQL.execute_ddl("example") == "example"
@@ -743,6 +743,18 @@ defmodule Ecto.Adapters.PostgresTest do
     drop = {:drop, constraint(:products, "price_must_be_positive", prefix: "foo")}
     assert SQL.execute_ddl(drop) ==
     ~s|ALTER TABLE "foo"."products" DROP CONSTRAINT "price_must_be_positive"|
+  end
+
+  test "create view" do
+    create = {:create, view(:outdated, query: "SELECT * FROM products WHERE old = true")}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE VIEW "outdated" AS SELECT * FROM products WHERE old = true|
+  end
+
+  test "create materialized view" do
+    create = {:create, view(:outdated, materialized: true, query: "SELECT * FROM products WHERE old = true")}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE MATERIALIZED VIEW "outdated" AS SELECT * FROM products WHERE old = true|
   end
 
   test "rename table" do

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -7,7 +7,7 @@ defmodule Ecto.MigrationTest do
   use Ecto.Migration
 
   alias Ecto.TestRepo
-  alias Ecto.Migration.{Table, Index, Reference, Constraint}
+  alias Ecto.Migration.{Table, Index, Reference, Constraint, View}
   alias Ecto.Migration.Runner
 
   setup meta do
@@ -29,6 +29,15 @@ defmodule Ecto.MigrationTest do
     assert table(:posts) == %Table{name: :posts, primary_key: true}
     assert table(:posts, primary_key: false) == %Table{name: :posts, primary_key: false}
     assert table(:posts, prefix: :foo) == %Table{name: :posts, primary_key: true, prefix: :foo}
+  end
+
+  test "creates a view" do
+    assert view(:old_posts) ==
+      %View{name: :old_posts, materialized: false, with: nil}
+    assert view(:old_posts, materialized: true) ==
+      %View{name: :old_posts, materialized: true, with: nil}
+    assert view(:old_posts, with: :cascaded) ==
+      %View{name: :old_posts, materialized: false, with: :cascaded}
   end
 
   test "creates an index" do


### PR DESCRIPTION
http://www.postgresql.org/docs/9.5/interactive/rules-views.html
http://www.postgresql.org/docs/9.5/interactive/sql-createview.html
http://www.postgresql.org/docs/9.5/interactive/rules-materializedviews.html

This is an initial stab at adding direct support for creating, altering, dropping, and using views. This is an important feature of Postgres that doesn't get much love, especially in the Rails/ActiveRecord world where there isn't any native support for it. I figured I'd open a PR as an RFC and start some of the work to scope it out.

I imagine the primary use to look like this:

```elixir
def change do
  create view(:products, materialized: true, prefix: :outdated, query: """
    SELECT * FROM products WHERE inserted_at > now() - '1 month'::interval
  """)
end

# CREATE MATERIALIZED VIEW outdated_products AS SELECT * FROM products WHERE ...
```

A few more of the options and details are in the View struct within `lib/ecto/migration.ex`. What do you think?