### PR TITLE
Fix Date/DateTime serialization for years above 9999

### DIFF
--- a/lib/ecto/date_time.ex
+++ b/lib/ecto/date_time.ex
@@ -6,7 +6,8 @@ defmodule Ecto.DateTime.Utils do
   @doc "Pads with zero"
   def zero_pad(val, count) do
     num = Integer.to_string(val)
-    :binary.copy("0", count - byte_size(num)) <> num
+    pad_length = max(count - byte_size(num), 0)
+    :binary.copy("0", pad_length) <> num
   end
 
   @doc "Converts to integer if possible"

--- a/test/ecto/date_time_test.exs
+++ b/test/ecto/date_time_test.exs
@@ -192,6 +192,7 @@ defmodule Ecto.DateTimeTest do
   use ExUnit.Case, async: true
 
   @datetime %Ecto.DateTime{year: 2015, month: 1, day: 23, hour: 23, min: 50, sec: 07, usec: 0}
+  @datetime_large %Ecto.DateTime{year: 10000, month: 1, day: 23, hour: 23, min: 50, sec: 07, usec: 0}
   @datetime_zero %Ecto.DateTime{year: 2015, month: 1, day: 23, hour: 23, min: 50, sec: 0, usec: 0}
   @datetime_usec %Ecto.DateTime{year: 2015, month: 1, day: 23, hour: 23, min: 50, sec: 07, usec: 8000}
   @datetime_notime %Ecto.DateTime{year: 2015, month: 1, day: 23, hour: 0, min: 0, sec: 0, usec: 0}
@@ -295,6 +296,7 @@ defmodule Ecto.DateTimeTest do
   test "inspect protocol" do
     assert inspect(@datetime) == "#Ecto.DateTime<2015-01-23T23:50:07Z>"
     assert inspect(@datetime_usec) == "#Ecto.DateTime<2015-01-23T23:50:07.008000Z>"
+    assert inspect(@datetime_large) == "#Ecto.DateTime<10000-01-23T23:50:07Z>"
   end
 
   test "precision" do


### PR DESCRIPTION
It's currently not possible to print or serialize Ecto.Date / DateTime objects when the year has more than four digits:

    iex(20)> %Ecto.Date{year: 9999, day: 1, month: 1}
    #Ecto.Date<9999-01-01>
    iex(21)> %Ecto.Date{year: 10000, day: 1, month: 1}
    %Inspect.Error{message: "got ArgumentError with message \"argument error\" while inspecting %{__struct__: Ecto.Date, day: 1, month: 1, year: 10000}"}

    iex(23)> Poison.encode  %Ecto.Date{year: 9999, day: 1, month: 1}
    {:ok, "\"9999-01-01\""}
    iex(24)> Poison.encode  %Ecto.Date{year: 10000, day: 1, month: 1}
        ** (ArgumentError) argument error
          (stdlib) :binary.copy("0", -1)
        (engineer) lib/ecto_fix.ex:13: Ecto.DateTime.Utils.zero_pad/2
        (engineer) lib/ecto_fix.ex:181: Ecto.Date.to_string/1
            (ecto) lib/ecto/poison.ex:7: Poison.Encoder.Ecto.Date.encode/2
          (poison) lib/poison.ex:41: Poison.encode!/2
          (poison) lib/poison.ex:15: Poison.encode/2

This happens in practice when a postgresql datetime field is set to `infinity` - Ecto interprets it as a date with very large year, so Poison crashes trying to serialize it.

The commit fixes `zero_pad` so it does not try to pad a negative amount of zeroes if the field already has more digits than the padding length.