### PR TITLE
Add support for prepared queries

### DIFF
--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -140,6 +140,17 @@ defmodule Ecto.Adapter do
               {integer, [[term]] | nil} | no_return
 
   @doc """
+  Carries out any database preparation and executes a query.
+
+  It must return a tuple containing a term representing the prepared query and
+  a tuple containing the equivalent result to `execute/6`.
+
+  See `execute/6`.
+  """
+  @callback prepare_execute(repo, query_meta, prepared, params :: list(), preprocess | nil, options) ::
+              {any, {integer, [[term]] | nil}} | no_return
+
+  @doc """
   Inserts multiple entries into the data store.
   """
   @callback insert_all(repo, schema_meta, header :: [atom], [fields], returning, options) ::

--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -147,7 +147,7 @@ defmodule Ecto.Adapter do
 
   See `execute/6`.
   """
-  @callback prepare_execute(repo, query_meta, prepared, params :: list(), preprocess | nil, options) ::
+  @callback prepare_execute(repo, query_meta, id :: pos_integer, prepared, params :: list(), preprocess | nil, options) ::
               {any, {integer, [[term]] | nil}} | no_return
 
   @doc """

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -73,12 +73,29 @@ if Code.ensure_loaded?(Postgrex) do
     ## Query
 
     def query(conn, sql, params, opts) do
-      params = Enum.map params, fn
+      query = %Postgrex.Query{name: "", statement: sql}
+      DBConnection.query(conn, query, map_params(params), opts)
+    end
+
+    def prepare_execute(conn, sql, params, opts) do
+      name =
+        sql
+        |> :erlang.phash2()
+        |> Integer.to_string()
+
+      query = %Postgrex.Query{name: ["ecto_" | name], statement: sql}
+      DBConnection.prepare_execute(conn, query, map_params(params), opts)
+    end
+
+    def execute(conn, query, params, opts) do
+      DBConnection.execute(conn, query, map_params(params), opts)
+    end
+
+    defp map_params(params) do
+      Enum.map params, fn
         %Ecto.Query.Tagged{value: value} -> value
         value -> value
       end
-      query = %Postgrex.Query{name: "", statement: sql}
-      DBConnection.query(conn, query, params, opts)
     end
 
     ## Sandbox

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -77,13 +77,8 @@ if Code.ensure_loaded?(Postgrex) do
       DBConnection.query(conn, query, map_params(params), opts)
     end
 
-    def prepare_execute(conn, sql, params, opts) do
-      name =
-        sql
-        |> :erlang.phash2()
-        |> Integer.to_string()
-
-      query = %Postgrex.Query{name: ["ecto_" | name], statement: sql}
+    def prepare_execute(conn, name, sql, params, opts) do
+      query = %Postgrex.Query{name: name, statement: sql}
       DBConnection.prepare_execute(conn, query, map_params(params), opts)
     end
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -455,9 +455,17 @@ defmodule Ecto.Adapters.SQL do
   defp log(repo, params, entry) do
     %{connection_time: query_time, decode_time: decode_time,
       pool_time: queue_time, result: result, query: query} = entry
-    repo.log(%Ecto.LogEntry{query_time: query_time, decode_time: decode_time, queue_time: queue_time,
-                            result: result, params: params, query: String.Chars.to_string(query)})
+    repo.log(%Ecto.LogEntry{query_time: log_time(query_time), decode_time: log_time(decode_time),
+                            queue_time: log_time(queue_time), result: log_result(result),
+                            params: params, query: String.Chars.to_string(query)})
   end
+
+  defp log_time(time) do
+    time && System.convert_time_unit(time, :native, :micro_seconds)
+  end
+
+  defp log_result({:ok, _query, res}), do: {:ok, res}
+  defp log_result(other), do: other
 
   ## Connection helpers
 

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -16,6 +16,18 @@ defmodule Ecto.Adapters.SQL.Connection do
             {:ok, term} | {:error, Exception.t}
 
   @doc """
+  Prepares and executes the given query with `DBConnection`.
+  """
+  @callback prepare_execute(DBConnection.t, sql :: String.t, params :: [term], Keyword.t) ::
+            {:ok, query :: map, term} | {:error, Exception.t}
+
+  @doc """
+  Executes the given prepared query with `DBConnection`.
+  """
+  @callback execute(DBConnection.t, query :: map, params :: [term], Keyword.t) ::
+            {:ok, term} | {:error, Exception.t}
+
+  @doc """
   Receives the exception returned by `query/4`.
 
   The constraints are in the keyword list and must return the

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -18,7 +18,7 @@ defmodule Ecto.Adapters.SQL.Connection do
   @doc """
   Prepares and executes the given query with `DBConnection`.
   """
-  @callback prepare_execute(DBConnection.t, sql :: String.t, params :: [term], Keyword.t) ::
+  @callback prepare_execute(DBConnection.t, name :: String.t, sql :: String.t, params :: [term], Keyword.t) ::
             {:ok, query :: map, term} | {:error, Exception.t}
 
   @doc """

--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -59,6 +59,7 @@ defmodule Ecto.LogEntry do
   ## Helpers
 
   defp ok_error({:ok, _}),    do: "OK"
+  defp ok_error({:ok, _, _}), do: "OK"
   defp ok_error({:error, _}), do: "ERROR"
 
   defp time(_label, nil, _force), do: []

--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -59,7 +59,6 @@ defmodule Ecto.LogEntry do
   ## Helpers
 
   defp ok_error({:ok, _}),    do: "OK"
-  defp ok_error({:ok, _, _}), do: "OK"
   defp ok_error({:error, _}), do: "ERROR"
 
   defp time(_label, nil, _force), do: []

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -40,29 +40,61 @@ defmodule Ecto.Query.Planner do
       {_, select, prepared} = query_without_cache(query, operation, adapter)
       {:execute, build_meta(query, select), prepared, params}
     else
-      table = repo.__query_cache__
-      case cache_lookup(repo, table, key) do
-        [{_, select, prepared}] ->
-          {:execute, build_meta(query, select), prepared, params}
-        [] ->
-          case query_without_cache(query, operation, adapter) do
-            {:cache, select, prepared} ->
-              meta =  build_meta(query, select)
-              insert = &:ets.insert(table, {key, select, &1})
-              {:prepare_execute, meta, prepared, params, insert}
-            {:nocache, select, prepared} ->
-              {:execute, build_meta(query, select), prepared, params}
-          end
-      end
+      query_with_cache(query, operation, repo, adapter, key, params)
     end
   end
 
-  defp cache_lookup(repo, table, key) do
-    :ets.lookup(table, key)
-  rescue
-    ArgumentError ->
-      raise ArgumentError,
-        "repo #{inspect repo} is not started, please ensure it is part of your supervision tree"
+  defp query_with_cache(query, operation, repo, adapter, key, params) do
+    table = repo.__query_cache__
+    case query_lookup(query, operation, repo, adapter, table, key) do
+      {_, :execute, select, _, prepared} ->
+        {:execute, build_meta(query, select), prepared, params}
+      {_, :prepare_execute, select, id, prepared} ->
+        select = build_meta(query, select)
+        update = &cache_update(table, key, &1)
+        {:prepare_execute, select, id, prepared, params, update}
+    end
+  end
+
+  defp query_lookup(query, operation, repo, adapter, table, key) do
+    try do
+      :ets.lookup(table, key)
+    rescue
+      ArgumentError ->
+        raise ArgumentError,
+          "repo #{inspect repo} is not started, please ensure it is part of your supervision tree"
+    else
+      [term] ->
+        term
+      [] ->
+        query_prepare(query, operation, adapter, table, key)
+    end
+  end
+
+  defp query_prepare(query, operation, adapter, table, key) do
+    case query_without_cache(query, operation, adapter) do
+      {:cache, select, prepared} ->
+        id = System.unique_integer([:positive])
+        elem = {key, :prepare_execute, select, id, prepared}
+        cache_insert(table, key, elem)
+      {:nocache, select, prepared} ->
+        {:nocache, :execute, select, nil, prepared}
+    end
+  end
+
+  defp cache_insert(table, key, elem) do
+    case :ets.insert_new(table, elem) do
+      true ->
+        elem
+      false ->
+        [elem] = :ets.lookup(table, key)
+        elem
+    end
+  end
+
+  defp cache_update(table, key, prepared) do
+    _ = :ets.update_element(table, key, [{2, :execute}, {5, prepared}])
+    :ok
   end
 
   defp query_without_cache(query, operation, adapter) do

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -104,12 +104,12 @@ defmodule Ecto.Repo.Queryable do
     case plan(operation, repo, adapter, queryable) do
       {:execute, meta, prepared, params} ->
         {&adapter.execute(repo, meta, prepared, params, &1, &2), meta}
-      {:prepare_execute, meta, prepared, params, insert} ->
+      {:prepare_execute, meta, id, prepared, params, update} ->
         execute =
           fn(preprocess, opts) ->
             {prepared, result} =
-              adapter.prepare_execute(repo, meta, prepared, params, preprocess, opts)
-            insert.(prepared)
+              adapter.prepare_execute(repo, meta, id, prepared, params, preprocess, opts)
+            update.(prepared)
             result
           end
         {execute, meta}

--- a/mix.lock
+++ b/mix.lock
@@ -8,5 +8,5 @@
   "mariaex": {:hex, :mariaex, "0.6.1"},
   "poison": {:hex, :poison, "1.3.1"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
-  "postgrex": {:git, "https://github.com/ericmj/postgrex.git", "5980794b885a86ebd51686d4112bc965dd2cf9e5", []},
+  "postgrex": {:git, "https://github.com/ericmj/postgrex.git", "e4bd1d01ff623fb84846f2440275a366605c8c96", []},
   "sbroker": {:hex, :sbroker, "0.7.0"}}


### PR DESCRIPTION
Add support for prepared by introducing `prepare_execute` adapter callback, and `prepare_execute` and `execute` sql connection callbacks.

Note there is a theoretical potential of hash collisions causing a query to always fail. Naming should switch to using `unique_integer` instead of a hash. Though we will need to ensure there are no race conditions so that the same integer is always used.