### PR TITLE
Do not specify timezone in iso8601

### DIFF
--- a/lib/ecto/date_time.ex
+++ b/lib/ecto/date_time.ex
@@ -520,13 +520,8 @@ defmodule Ecto.DateTime do
   end
 
   @doc """
-  Converts `Ecto.DateTime` to its ISO 8601 UTC representation if the
-  `Ecto.DateTime` is UTC.
-
-  WARNING: This will produce an incorrect result unless the datetime is UTC!
-  Make sure that the datetime is UTC. `inserted_at` and `updated_at` fields
-  populated by the Ecto `timestamps` feature are UTC. But other `Ecto.DateTime`
-  fields are not always UTC.
+  Converts `Ecto.DateTime` to its ISO 8601 representation
+  without timezone specification.
   """
   def to_iso8601(%Ecto.DateTime{year: year, month: month, day: day,
                                 hour: hour, min: min, sec: sec, usec: usec}) do
@@ -534,9 +529,9 @@ defmodule Ecto.DateTime do
           zero_pad(hour, 2) <> ":" <> zero_pad(min, 2) <> ":" <> zero_pad(sec, 2)
 
     if is_nil(usec) or usec == 0 do
-      str <> "Z"
+      str
     else
-      str <> "." <> zero_pad(usec, 6) <> "Z"
+      str <> "." <> zero_pad(usec, 6)
     end
   end
 

--- a/test/ecto/date_time_test.exs
+++ b/test/ecto/date_time_test.exs
@@ -285,8 +285,8 @@ defmodule Ecto.DateTimeTest do
   end
 
   test "to_iso8601" do
-    assert Ecto.DateTime.to_iso8601(@datetime) == "2015-01-23T23:50:07Z"
-    assert Ecto.DateTime.to_iso8601(@datetime_usec) == "2015-01-23T23:50:07.008000Z"
+    assert Ecto.DateTime.to_iso8601(@datetime) == "2015-01-23T23:50:07"
+    assert Ecto.DateTime.to_iso8601(@datetime_usec) == "2015-01-23T23:50:07.008000"
   end
 
   test "to_erl and from_erl" do
@@ -294,9 +294,9 @@ defmodule Ecto.DateTimeTest do
   end
 
   test "inspect protocol" do
-    assert inspect(@datetime) == "#Ecto.DateTime<2015-01-23T23:50:07Z>"
-    assert inspect(@datetime_usec) == "#Ecto.DateTime<2015-01-23T23:50:07.008000Z>"
-    assert inspect(@datetime_large) == "#Ecto.DateTime<10000-01-23T23:50:07Z>"
+    assert inspect(@datetime) == "#Ecto.DateTime<2015-01-23T23:50:07>"
+    assert inspect(@datetime_usec) == "#Ecto.DateTime<2015-01-23T23:50:07.008000>"
+    assert inspect(@datetime_large) == "#Ecto.DateTime<10000-01-23T23:50:07>"
   end
 
   test "precision" do

--- a/test/ecto/poison_test.exs
+++ b/test/ecto/poison_test.exs
@@ -9,7 +9,7 @@ defmodule Ecto.PoisonTest do
     assert Poison.encode!(date) == ~s("2010-04-17")
 
     dt = %Ecto.DateTime{year: 2010, month: 4, day: 17, hour: 0, min: 0, sec: 0}
-    assert Poison.encode!(dt) == ~s("2010-04-17T00:00:00Z")
+    assert Poison.encode!(dt) == ~s("2010-04-17T00:00:00")
   end
 
   test "encodes decimal" do


### PR DESCRIPTION
datetime function. We do not know if the datetime
is in UTC or not, so we should not assume that it is.

I noticed that inspect also uses the iso8601 function and adds a Z.
This signals to the world that the datetime is UTC even though we do not know if it is or not.