### PR TITLE
Include :invalid in the typespec for Changeset.cast/4

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -306,7 +306,7 @@ defmodule Ecto.Changeset do
   "stronger" than optional fields.
   """
   @spec cast(Ecto.Schema.t | t,
-             %{binary => term} | %{atom => term} | nil,
+             %{binary => term} | %{atom => term} | nil | :invalid,
              [String.t | atom],
              [String.t | atom]) :: t | no_return
   def cast(model_or_changeset, params, required, optional)


### PR DESCRIPTION
I ran dialyzer and almost all of my changeset functions threw errors because `:invalid` wasn't in the typespec. Since you can pass `:invalid` as the second argument, I think it makes sense to add it to the typespec.

I'm new to dialyzer and typespecs though so I may have gotten this wrong. I think this is the correct way to solve the issue though