### PR TITLE
Use child_spec in Ecto.Adapters.SQL.Connection behaviour

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -8,7 +8,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     ## Module and Options
 
-    def connection(opts) do
+    def child_spec(opts) do
       json = Application.get_env(:ecto, :json_library)
       extensions = [{Ecto.Adapters.Postgres.DateTime, []},
                     {Postgrex.Extensions.JSON, library: json}]
@@ -19,7 +19,7 @@ if Code.ensure_loaded?(Postgrex) do
         |> Keyword.update(:port, @default_port, &normalize_port/1)
         |> Keyword.put(:types, true)
 
-      {Postgrex.Protocol, opts}
+      Postgrex.child_spec(opts)
     end
 
     defp normalize_port(port) when is_binary(port), do: String.to_integer(port)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -281,7 +281,6 @@ defmodule Ecto.Adapters.SQL do
 
     {pool_name, pool_opts} = repo.__pool__
     opts = [name: pool_name] ++ Keyword.delete(opts, :pool) ++ pool_opts
-    {mod, opts} = connection.connection(opts)
 
     opts =
       if function_exported?(repo, :after_connect, 1) and not Keyword.has_key?(opts, :after_connect) do
@@ -293,7 +292,7 @@ defmodule Ecto.Adapters.SQL do
         opts
       end
 
-    DBConnection.child_spec(mod, opts)
+    connection.child_spec(opts)
   end
 
   ## Types

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -10,10 +10,10 @@ defmodule Ecto.Adapters.SQL.Connection do
   @type cached :: map
 
   @doc """
-  Receives options and returns `DBConnection` module and
-  options to use to handle queries.
+  Receives options and returns `DBConnection` supervisor child 
+  specification.
   """
-  @callback connection(Keyword.t) :: {module, Keyword.t}
+  @callback child_spec(Keyword.t) :: {module, Keyword.t}
 
   @doc """
   Prepares and executes the given query with `DBConnection`.

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Ecto.Mixfile do
 
      # Drivers
      {:mariaex, "~> 0.6", optional: true},
-     {:postgrex, "~> 0.11", optional: true},
+     {:postgrex, github: "ericmj/postgrex", optional: true},
 
      # Optional
      {:sbroker, "~> 0.7", optional: true},


### PR DESCRIPTION
Replaces `connection/1` with `child_spec/1` in Ecto.Adapters.SQL.Connection behaviour. 

This allows adapters to normalize options before returning the connection supervisor child specification (`DBConnection.child_spec/2`).

See https://github.com/ericmj/postgrex/pull/163.