### PR TITLE
Use adapter commands in storage integration tests

### DIFF
--- a/integration_test/pg/storage_test.exs
+++ b/integration_test/pg/storage_test.exs
@@ -18,11 +18,11 @@ defmodule Ecto.Integration.StorageTest do
   end
 
   def create_database do
-    :os.cmd 'psql -U postgres -c "CREATE DATABASE storage_mgt;"'
+    Postgres.storage_up(correct_params)
   end
 
   def drop_database do
-    :os.cmd 'psql -U postgres -c "DROP DATABASE IF EXISTS storage_mgt;"'
+    Postgres.storage_down(correct_params)
   end
 
   setup do


### PR DESCRIPTION
The existing create and drop database functions shelled out to `cmd`, which didn't respect `PG_URL`. With the storage tests all functioning properly it is safe (and clean) to use `storage_up` and `storage_down` directly.

Closes #1249