### PR TITLE
Restore ensure_repo within ecto tasks

### DIFF
--- a/lib/mix/ecto.ex
+++ b/lib/mix/ecto.ex
@@ -44,6 +44,9 @@ defmodule Mix.Ecto do
   Ensures the given module is a repository.
   """
   @spec ensure_repo(module, list) :: Ecto.Repo.t | no_return
+  def ensure_repo(repos, args) when is_list(repos) do
+    Enum.map repos, &ensure_repo(&1, args)
+  end
   def ensure_repo(repo, args) do
     Mix.Task.run "loadpaths", args
 

--- a/lib/mix/tasks/ecto.create.ex
+++ b/lib/mix/tasks/ecto.create.ex
@@ -23,6 +23,7 @@ defmodule Mix.Tasks.Ecto.Create do
   @doc false
   def run(args) do
     repos = parse_repo(args)
+    ensure_repo(repos, args)
 
     Enum.all?(repos, &ensure_implements(&1.__adapter__, Ecto.Adapter.Storage,
                                         "to create storage for #{inspect &1}"))
@@ -30,8 +31,6 @@ defmodule Mix.Tasks.Ecto.Create do
     {opts, _, _} = OptionParser.parse args, switches: [quiet: :boolean]
 
     Enum.each repos, fn repo ->
-      ensure_repo(repo, args)
-
       case Ecto.Storage.up(repo) do
         :ok ->
           unless opts[:quiet] do

--- a/lib/mix/tasks/ecto.drop.ex
+++ b/lib/mix/tasks/ecto.drop.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Ecto.Drop do
   @doc false
   def run(args) do
     repos = parse_repo(args)
+    ensure_repo(repos, args)
 
     Enum.all?(repos, &ensure_implements(&1.__adapter__, Ecto.Adapter.Storage,
                                         "to drop storage for #{inspect &1}"))
@@ -29,7 +30,6 @@ defmodule Mix.Tasks.Ecto.Drop do
     {opts, _, _} = OptionParser.parse args, switches: [quiet: :boolean]
 
     Enum.each repos, fn repo ->
-      ensure_repo(repo, args)
       if skip_safety_warnings?() or
          Mix.shell.yes?("Are you sure you want to drop the database for repo #{inspect repo}?") do
         drop_database(repo, opts)


### PR DESCRIPTION
Formerly ensure_repo could operate on a list, and was ran before `ensure_implements`. The create and drop tasks broke when `ensure_repo` was moved after `ensure_implements`.

Closes #1251

@josevalim Alternatively `ensure_implements` could be called within the `Enum.each` where all the work is being done.