### PR TITLE
fix(Mix.Ecto): ignore ensure_migrations in an umbrella project

### DIFF
--- a/lib/mix/ecto.ex
+++ b/lib/mix/ecto.ex
@@ -104,16 +104,11 @@ defmodule Mix.Ecto do
   """
   @spec ensure_migrations_path(Ecto.Repo.t) :: Ecto.Repo.t | no_return
   def ensure_migrations_path(repo) do
-    if Mix.Project.umbrella? do
-      true
-    else
-      path = Path.relative_to(migrations_path(repo), Mix.Project.app_path)
-      if File.dir?(path) do
-        repo
-      else
-        Mix.raise "could not find migrations directory #{inspect path} for repo #{inspect repo}"
-      end
-    end
+    with false <- Mix.Project.umbrella?,
+         path = Path.relative_to(migrations_path(repo), Mix.Project.app_path),
+         false <- File.dir?(path),
+         do: Mix.raise "could not find migrations directory #{inspect path} for repo #{inspect repo}"
+    repo
   end
 
   @doc """

--- a/lib/mix/ecto.ex
+++ b/lib/mix/ecto.ex
@@ -104,11 +104,15 @@ defmodule Mix.Ecto do
   """
   @spec ensure_migrations_path(Ecto.Repo.t) :: Ecto.Repo.t | no_return
   def ensure_migrations_path(repo) do
-    path = Path.relative_to(migrations_path(repo), Mix.Project.app_path)
-    if File.dir?(path) do
-      repo
+    if Mix.Project.umbrella? do
+      true
     else
-      Mix.raise "could not find migrations directory #{inspect path} for repo #{inspect repo}"
+      path = Path.relative_to(migrations_path(repo), Mix.Project.app_path)
+      if File.dir?(path) do
+        repo
+      else
+        Mix.raise "could not find migrations directory #{inspect path} for repo #{inspect repo}"
+      end
     end
   end
 


### PR DESCRIPTION
Previously attempting to run `mix ecto.migrate` or `mix test` which runs
`mix ecto.migrate` from the root of an umbrella app would result in the
following error:

 > ** (RuntimeError) Trying to access Mix.Project.app_path for an
 > umbrella project but umbrellas have no app

This is caused by calling:

    Path.relative_to(migrations_path(repo), Mix.Project.app_path)

Which was introduced in 9b5ede7 to
ensure the migrations directory exists. This check is now ignored in an
umbrella application.