### PR TITLE
Potential regression on skipping preload?

### DIFF
--- a/integration_test/cases/preload.exs
+++ b/integration_test/cases/preload.exs
@@ -442,6 +442,18 @@ defmodule Ecto.Integration.PreloadTest do
     assert u.custom.bid == c.bid
   end
 
+  test "skip preloads with association set but without id set" do
+    c1 = TestRepo.insert!(%Comment{text: "1"})
+    u1 = TestRepo.insert!(%User{name: "name"})
+    p1 = TestRepo.insert!(%Post{title: "title"})
+
+    c1 = %{c1 | author: u1, author_id: nil, post: p1, post_id: nil}
+
+    c1 = TestRepo.preload(c1, [:author, :post])
+    assert c1.author == u1
+    assert c1.post == p1
+  end
+
   test "preload skips already loaded for cardinality one" do
     %Post{id: pid} = TestRepo.insert!(%Post{title: "1"})
 

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -113,16 +113,16 @@ defmodule Ecto.Repo.Preloader do
       %{^owner_key => id, ^field => value} = struct
 
       cond do
-        is_nil(id) ->
-          {fetch_ids, loaded_ids, loaded_structs}
-        force? or not Ecto.assoc_loaded?(value) ->
-          {[id|fetch_ids], loaded_ids, loaded_structs}
-        card == :one ->
+        card == :one and not is_nil(value) and Ecto.assoc_loaded?(value) and not force? ->
           {fetch_ids, [id|loaded_ids], [value|loaded_structs]}
-        card == :many ->
+        card == :many and not is_nil(value) and Ecto.assoc_loaded?(value) and not force? ->
           {fetch_ids,
            List.duplicate(id, length(value)) ++ loaded_ids,
            value ++ loaded_structs}
+        is_nil(id) ->
+          {fetch_ids, loaded_ids, loaded_structs}
+        true ->
+          {[id|fetch_ids], loaded_ids, loaded_structs}
       end
     end
   end


### PR DESCRIPTION
I wrote a test below that is currently failing for me on master and 2.0.0-beta.0, but passes on v1.1.3.  I didn't see anything in the changelog about it, so I wasn't sure if this was an intended change or not?

Edit:
If it helps, it looks the test passes if I set `author_id` and `post_id`:
`c1 = %{c1 | author: u1, author_id: u1.id, post: p1, post_id: p1.id}`

Willing to take a go at fixing it if this is indeed not the intended functionality.