### PR TITLE
Correct  != nil in the documentation

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -334,7 +334,7 @@ defmodule Ecto do
       Repo.all assoc(post, :comments)
 
       # Or build a query on top of the associated comments
-      query = from c in assoc(post, :comments), where: c.title != nil
+      query = from c in assoc(post, :comments), where: not is_nil(c.title)
       Repo.all(query)
 
   Another function in `Ecto` is `build_assoc/3`, which allows


### PR DESCRIPTION
I've seen the following error when trying to use `!= nil` like this.  I believe the documentation may be incorrect then.

```
 (Ecto.Query.CompileError) comparison with nil is forbidden as it always evaluates to false. If you want to check if a value is (not) nil, use is_nil/1 instead
```