### PR TITLE
Improve error when a variable is accidentally passed to assoc/2

### DIFF
--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -68,6 +68,7 @@ defmodule Ecto.Query.Builder.Join do
 
   def escape({:assoc, _, [{var, _, context}, field]}, vars, _env)
       when is_atom(var) and is_atom(context) do
+    ensure_field!(field)
     var   = Builder.find_var!(var, vars)
     field = Builder.quoted_field!(field)
     {:_, nil, {var, field}, %{}}
@@ -190,4 +191,9 @@ defmodule Ecto.Query.Builder.Join do
       "invalid join qualifier `#{inspect qual}`, accepted qualifiers are: " <>
       Enum.map_join(@qualifiers, ", ", &"`#{inspect &1}`")
   end
+
+  defp ensure_field!({var, _, _}) when var != :^ do
+    Builder.error! "you passed the variable `#{var}` to `assoc/2`. Did you mean to pass the atom `:#{var}?`"
+  end
+  defp ensure_field!(_), do: true
 end

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -36,4 +36,15 @@ defmodule Ecto.Query.Builder.JoinTest do
     assert %{joins: [%{source: {"user_comments", Comment}}]} =
             join("posts", qual, [p], c in ^source, true)
   end
+
+  test "invalid assoc/2 field" do
+    assert_raise Ecto.Query.CompileError,
+    ~r/you passed the variable \`field_var\` to \`assoc\/2\`/, fn ->
+      escape({:assoc, nil, [{:join_var, nil, nil}, {:field_var, nil, nil}]}, nil, nil)
+    end
+  end
+
+  test "interpolated values are ok for assoc/2 field" do
+    escape({:assoc, nil, [{:join_var, nil, :context}, {:^, nil, [:interpolated_value]}]}, [join_var: true], nil)
+  end
 end


### PR DESCRIPTION
I mess this up all the time. Currently you get

```
** (Ecto.Query.CompileError) expected literal atom or interpolated value in field/2, got: `{:some_assoc, [line: 405], nil}`
```

which always surprises me since I wasn't using `field` in my query. Then I have to track it down (for the 12th time). 

This PR tries to improve on that for slow learners like me by returning:

```
You passed the variable some_assoc to `assoc/2`. Did you mean to pass the atom :some_assoc?
```

