### PR TITLE
Refer to schema rather than model

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -513,9 +513,9 @@ defmodule Ecto.Migration do
   `string` is converted to varchar, `datetime` to the underlying
   datetime or timestamp type, `binary` to bits or blob, and so on.
 
-  However, the column type is not always the same as the type in your
-  model. For example, a model that has a `string` field, can be
-  supported by columns of types `char`, `varchar`, `text` and others.
+  However, the column type is not always the same as the type used in your
+  schema. For example, a schema that has a `string` field,
+  can be supported by columns of types `char`, `varchar`, `text` and others.
   For this reason, this function also accepts `text` and other columns,
   which are sent as is to the underlying database.
 


### PR DESCRIPTION
Are we still referring to a module where Ecto.Schema is used as a model? If so then this change may not make sense. I was trying to make the docs very specific as to where the types are used. No hard feelings if it is not a good change.