### PR TITLE
Teaches `Ecto.build_assoc/3` to handle `Ecto.Schema`s for new attributes

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -474,6 +474,9 @@ defmodule Ecto do
       iex> build_assoc(post, :comments, post_id: 1)
       %Comment{id: nil, post_id: 13}
   """
+  def build_assoc(%{__struct__: _} = struct, assoc, %{__struct__: _, __meta__: _} = attributes) do
+    build_assoc(struct, assoc, Map.from_struct(attributes))
+  end
   def build_assoc(%{__struct__: schema} = struct, assoc, attributes \\ %{}) do
     assoc = Ecto.Association.association_from_schema!(schema, assoc)
     assoc.__struct__.build(assoc, struct, Dict.delete(attributes, :__meta__))

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -384,6 +384,13 @@ defmodule Ecto.AssociationTest do
     assert build_assoc(%Post{id: 1}, :author, title: "Hello!") ==
            %Author{title: "Hello!"}
 
+    # 2 belongs to
+    with author_post = build_assoc(%Author{id: 1}, :posts),
+         author_and_summary_post = build_assoc(%Summary{id: 2}, :posts, author_post) do
+      assert author_and_summary_post.author_id == 1
+      assert author_and_summary_post.summary_id == 2
+    end
+
     # many to many
     assert build_assoc(%Permalink{id: 1}, :authors, title: "Hello!") ==
            %Author{title: "Hello!"}


### PR DESCRIPTION
If a model belongs to two different models, you can now use `build_assoc`
to attach it to both models.

```
with author_post = build_assoc(%Author{id: 1}, :posts),
  do: build_assoc(%Summary{id: 2}, :posts, author_post)
```