### PR TITLE
Sets the binding key for `validate_number` errors to `number`.

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1050,7 +1050,7 @@ defmodule Ecto.Changeset do
     new_errors =
       for field <- fields,
           missing?(changeset, field),
-          do: {field, message}
+          do: {field, {message, []}}
 
     case new_errors do
       [] -> %{changeset | required: fields ++ required}
@@ -1086,7 +1086,7 @@ defmodule Ecto.Changeset do
   @spec validate_format(t, atom, Regex.t, Keyword.t) :: t
   def validate_format(changeset, field, format, opts \\ []) do
     validate_change changeset, field, {:format, format}, fn _, value ->
-      if value =~ format, do: [], else: [{field, message(opts, "has invalid format")}]
+      if value =~ format, do: [], else: [{field, {message(opts, "has invalid format"), []}}]
     end
   end
 
@@ -1106,7 +1106,7 @@ defmodule Ecto.Changeset do
   @spec validate_inclusion(t, atom, Enum.t, Keyword.t) :: t
   def validate_inclusion(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:inclusion, data}, fn _, value ->
-      if value in data, do: [], else: [{field, message(opts, "is invalid")}]
+      if value in data, do: [], else: [{field, {message(opts, "is invalid"), []}}]
     end
   end
 
@@ -1128,7 +1128,7 @@ defmodule Ecto.Changeset do
   def validate_subset(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:subset, data}, fn _, value ->
       case Enum.any?(value, fn(x) -> not x in data end) do
-        true -> [{field, message(opts, "has an invalid entry")}]
+        true -> [{field, {message(opts, "has an invalid entry"), []}}]
         false -> []
       end
     end
@@ -1149,7 +1149,7 @@ defmodule Ecto.Changeset do
   @spec validate_exclusion(t, atom, Enum.t, Keyword.t) :: t
   def validate_exclusion(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:exclusion, data}, fn _, value ->
-      if value in data, do: [{field, message(opts, "is reserved")}], else: []
+      if value in data, do: [{field, {message(opts, "is reserved"), []}}], else: []
     end
   end
 
@@ -1328,7 +1328,7 @@ defmodule Ecto.Changeset do
 
       case Map.fetch(changeset.params, error_param) do
         {:ok, ^value} -> []
-        {:ok, _}      -> [{error_field, message(opts, "does not match confirmation")}]
+        {:ok, _}      -> [{error_field, {message(opts, "does not match confirmation"), []}}]
         :error        -> []
       end
     end

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -162,11 +162,11 @@ defmodule Ecto.Changeset do
                         field: atom, message: error_message}
 
   @number_validators %{
-    less_than:                {&</2,  "must be less than %{count}"},
-    greater_than:             {&>/2,  "must be greater than %{count}"},
-    less_than_or_equal_to:    {&<=/2, "must be less than or equal to %{count}"},
-    greater_than_or_equal_to: {&>=/2, "must be greater than or equal to %{count}"},
-    equal_to:                 {&==/2, "must be equal to %{count}"},
+    less_than:                {&</2,  "must be less than %{number}"},
+    greater_than:             {&>/2,  "must be greater than %{number}"},
+    less_than_or_equal_to:    {&<=/2, "must be less than or equal to %{number}"},
+    greater_than_or_equal_to: {&>=/2, "must be greater than or equal to %{number}"},
+    equal_to:                 {&==/2, "must be equal to %{number}"},
   }
 
   @relations [:embed, :assoc]
@@ -1262,14 +1262,14 @@ defmodule Ecto.Changeset do
     result = Decimal.compare(value, target_value)
     case decimal_compare(result, spec_key) do
       true  -> nil
-      false -> [{field, {message, count: target_value}}]
+      false -> [{field, {message, number: target_value}}]
     end
   end
 
   defp validate_number(field, value, message, _spec_key, spec_function, target_value) do
     case apply(spec_function, [value, target_value]) do
       true  -> nil
-      false -> [{field, {message, count: target_value}}]
+      false -> [{field, {message, number: target_value}}]
     end
   end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -730,7 +730,7 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{"upvotes" => -1})
                 |> validate_number(:upvotes, greater_than: 0)
     refute changeset.valid?
-    assert changeset.errors == [upvotes: {"must be greater than %{count}", count: 0}]
+    assert changeset.errors == [upvotes: {"must be greater than %{number}", number: 0}]
     assert changeset.validations == [upvotes: {:number, [greater_than: 0]}]
 
     # Multiple validations
@@ -744,12 +744,12 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{"upvotes" => 3})
                 |> validate_number(:upvotes, greater_than: 100, less_than: 0)
     refute changeset.valid?
-    assert changeset.errors == [upvotes: {"must be greater than %{count}", count: 100}]
+    assert changeset.errors == [upvotes: {"must be greater than %{number}", number: 100}]
 
     # Multiple validations with custom message errors
     changeset = changeset(%{"upvotes" => 3})
                 |> validate_number(:upvotes, greater_than: 100, less_than: 0, message: "yada")
-    assert changeset.errors == [upvotes: {"yada", count: 100}]
+    assert changeset.errors == [upvotes: {"yada", number: 100}]
   end
 
   test "validate_number/3 with decimal" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -563,14 +563,14 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{}) |> validate_required(:title)
     refute changeset.valid?
     assert changeset.required == [:title]
-    assert changeset.errors == [title: "can't be blank"]
+    assert changeset.errors == [title: {"can't be blank", []}]
 
     changeset =
       changeset(%{title: nil, body: "\n"})
       |> validate_required([:title, :body], message: "is blank")
     refute changeset.valid?
     assert changeset.required == [:title, :body]
-    assert changeset.errors == [title: "is blank", body: "is blank"]
+    assert changeset.errors == [title: {"is blank", []}, body: {"is blank", []}]
 
     changeset =
       changeset(%{"title" => "hello", "body" => "something"})
@@ -591,13 +591,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "foobar"})
       |> validate_format(:title, ~r/@/)
     refute changeset.valid?
-    assert changeset.errors == [title: "has invalid format"]
+    assert changeset.errors == [title: {"has invalid format", []}]
     assert changeset.validations == [title: {:format, ~r/@/}]
 
     changeset =
       changeset(%{"title" => "foobar"})
       |> validate_format(:title, ~r/@/, message: "yada")
-    assert changeset.errors == [title: "yada"]
+    assert changeset.errors == [title: {"yada", []}]
   end
 
   test "validate_inclusion/3" do
@@ -612,13 +612,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world))
     refute changeset.valid?
-    assert changeset.errors == [title: "is invalid"]
+    assert changeset.errors == [title: {"is invalid", []}]
     assert changeset.validations == [title: {:inclusion, ~w(world)}]
 
     changeset =
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world), message: "yada")
-    assert changeset.errors == [title: "yada"]
+    assert changeset.errors == [title: {"yada", []}]
   end
 
   test "validate_subset/3" do
@@ -633,13 +633,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"topics" => ["cat", "laptop"]})
       |> validate_subset(:topics, ~w(cat dog))
     refute changeset.valid?
-    assert changeset.errors == [topics: "has an invalid entry"]
+    assert changeset.errors == [topics: {"has an invalid entry", []}]
     assert changeset.validations == [topics: {:subset, ~w(cat dog)}]
 
     changeset =
       changeset(%{"topics" => ["laptop"]})
       |> validate_subset(:topics, ~w(cat dog), message: "yada")
-    assert changeset.errors == [topics: "yada"]
+    assert changeset.errors == [topics: {"yada", []}]
   end
 
   test "validate_exclusion/3" do
@@ -654,13 +654,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(world))
     refute changeset.valid?
-    assert changeset.errors == [title: "is reserved"]
+    assert changeset.errors == [title: {"is reserved", []}]
     assert changeset.validations == [title: {:exclusion, ~w(world)}]
 
     changeset =
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(world), message: "yada")
-    assert changeset.errors == [title: "yada"]
+    assert changeset.errors == [title: {"yada", []}]
   end
 
   test "validate_length/3 with string" do
@@ -795,17 +795,17 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{"title" => "title", "title_confirmation" => nil})
                 |> validate_confirmation(:title)
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: "does not match confirmation"]
+    assert changeset.errors == [title_confirmation: {"does not match confirmation", []}]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
                 |> validate_confirmation(:title)
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: "does not match confirmation"]
+    assert changeset.errors == [title_confirmation: {"does not match confirmation", []}]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
                 |> validate_confirmation(:title, message: "doesn't match field below")
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: "doesn't match field below"]
+    assert changeset.errors == [title_confirmation: {"doesn't match field below", []}]
 
     # Skip when no parameter
     changeset = changeset(%{"title" => "title"})


### PR DESCRIPTION
Given that there is not going to be a singular and plural version of
the errors related to `validate_number`, this changes the relevant key,
in order for this to be handled as a singular translation with a binding
rather than a singular/plural in Gettext.

Fixes #1308