### PR TITLE
Fix insert all to work like the docs when specifying prefix

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -482,13 +482,17 @@ defmodule Ecto.Integration.RepoTest do
 
   test "insert all" do
     assert {2, nil} = TestRepo.insert_all("comments", [[text: "1"], %{text: "2", lock_version: 2}])
+    assert {2, nil} = TestRepo.insert_all({nil, "comments"}, [[text: "3"], %{text: "4", lock_version: 2}])
     assert [%Comment{text: "1", lock_version: 1},
-            %Comment{text: "2", lock_version: 2}] = TestRepo.all(Comment)
+            %Comment{text: "2", lock_version: 2},
+            %Comment{text: "3", lock_version: 1},
+            %Comment{text: "4", lock_version: 2}] = TestRepo.all(Comment)
 
     assert {2, nil} = TestRepo.insert_all(Post, [[], []])
     assert [%Post{}, %Post{}] = TestRepo.all(Post)
 
     assert {0, nil} = TestRepo.insert_all("posts", [])
+    assert {0, nil} = TestRepo.insert_all({nil, "posts"}, [])
   end
 
   @tag :returning

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -18,6 +18,10 @@ defmodule Ecto.Repo.Schema do
     do_insert_all(repo, adapter, nil, {nil, table}, rows, opts)
   end
 
+  def insert_all(repo, adapter, {_prefix, _source} = table, rows, opts) do
+    do_insert_all(repo, adapter, nil, table, rows, opts)
+  end
+
   defp do_insert_all(_repo, _adapter, _schema, _source, [], opts) do
     if opts[:returning] do
       {0, []}


### PR DESCRIPTION
`insert_all` wasn't working like described in https://github.com/elixir-lang/ecto/blob/master/lib/ecto/repo.ex#L429 with regards to sending a `{"prefix", "source"}` tuple.
> It expects a schema (`MyApp.User`) or a source (`"users"` or
> `{"prefix", "users"}`) as first argument.

I'm not really sure what the design of some of this is, so let me know if I did it wrong. I *could* make a pickier gaurd with matching, if that would make a more friendly error.