### PR TITLE
Add typespec for Ecto.Repo.rollback/1

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -88,6 +88,7 @@ defmodule Ecto.Repo do
         @adapter.transaction(__MODULE__, opts, fun)
       end
 
+      @spec rollback(term) :: no_return
       def rollback(value) do
         @adapter.rollback(__MODULE__, value)
       end


### PR DESCRIPTION
Deduced from `Ecto.Pool.with_rollback/3` typespec and `Ecto.Pool.rollback/3` implementation.

Gets rid of Dialyzer's `repo.ex:4: Function rollback/1 has no local return` warning on bootstrapped Phoenix application.