### PR TITLE
Update cast and relation errors to tuples

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -370,7 +370,7 @@ defmodule Ecto.Changeset do
          {errors, valid?} = error_on_nil(kind, key, Map.get(changes, key, current), errors, valid?)
          {changes, errors, valid?}
        :invalid ->
-         {changes, [{key, "is invalid"}|errors], false}
+         {changes, [{key, {"is invalid", []}} | errors], false}
      end}
   end
 
@@ -420,7 +420,7 @@ defmodule Ecto.Changeset do
   end
 
   defp error_on_nil(:required, key, nil, errors, _valid?),
-    do: {[{key, "can't be blank"}|errors], false}
+    do: {[{key, {"can't be blank", []}} | errors], false}
   defp error_on_nil(_kind, _key, _value, errors, valid?),
     do: {errors, valid?}
 
@@ -500,7 +500,7 @@ defmodule Ecto.Changeset do
             {:ok, _, _, _} ->
               missing_relation(changeset, key, current, required?, relation)
             :error ->
-              %{changeset | errors: [{key, "is invalid"} | changeset.errors], valid?: false}
+              %{changeset | errors: [{key, {"is invalid", []}} | changeset.errors], valid?: false}
           end
         :error ->
           missing_relation(changeset, key, current, required?, relation)
@@ -514,7 +514,7 @@ defmodule Ecto.Changeset do
   defp missing_relation(%{changes: changes, errors: errors} = changeset, name, current, required?, relation) do
     current_changes = Map.get(changes, name, current)
     if required? and Relation.empty?(relation, current_changes) do
-      %{changeset | errors: [{name, "can't be blank"} | errors], valid?: false}
+      %{changeset | errors: [{name, {"can't be blank", []}} | errors], valid?: false}
     else
       changeset
     end
@@ -853,7 +853,7 @@ defmodule Ecto.Changeset do
         %{changeset | changes: Map.put(changes, name, change),
                       valid?: changeset.valid? && relation_valid?}
       :error ->
-        %{changeset | errors: [{name, "is invalid"} | changeset.errors], valid?: false}
+        %{changeset | errors: [{name, {"is invalid", []}} | changeset.errors], valid?: false}
     end
   end
 

--- a/test/ecto/changeset/belongs_to_test.exs
+++ b/test/ecto/changeset/belongs_to_test.exs
@@ -62,13 +62,13 @@ defmodule Ecto.Changeset.BelongsToTest do
   test "cast belongs_to with invalid params" do
     changeset = cast(%Author{}, %{"profile" => %{name: nil}}, :profile)
     assert changeset.changes.profile.changes == %{}
-    assert changeset.changes.profile.errors  == [name: "can't be blank"]
+    assert changeset.changes.profile.errors  == [name: {"can't be blank", []}]
     assert changeset.changes.profile.action  == :insert
     refute changeset.changes.profile.valid?
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"profile" => "value"}, :profile)
-    assert changeset.errors == [profile: "is invalid"]
+    assert changeset.errors == [profile: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -136,12 +136,12 @@ defmodule Ecto.Changeset.BelongsToTest do
     changeset = cast(%Author{}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
 
     changeset = cast(%Author{profile: nil}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
@@ -151,12 +151,12 @@ defmodule Ecto.Changeset.BelongsToTest do
     changeset = cast(%Author{profile: nil}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{profile: nil}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
   end
 
   test "cast belongs_to with optional" do
@@ -226,12 +226,12 @@ defmodule Ecto.Changeset.BelongsToTest do
 
     changeset = cast(model, %{"invalid_profile" => nil}, :invalid_profile)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(model, %{"invalid_profile" => %{"id" => 2}}, :invalid_profile)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -371,7 +371,7 @@ defmodule Ecto.Changeset.BelongsToTest do
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_profile, nil)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
   end
 

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -102,13 +102,13 @@ defmodule Ecto.Changeset.EmbeddedTest do
   test "cast embeds_one with invalid params" do
     changeset = cast(%Author{}, %{"profile" => %{}}, :profile)
     assert changeset.changes.profile.changes == %{}
-    assert changeset.changes.profile.errors  == [name: "can't be blank"]
+    assert changeset.changes.profile.errors  == [name: {"can't be blank", []}]
     assert changeset.changes.profile.action  == :insert
     refute changeset.changes.profile.valid?
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"profile" => "value"}, :profile, required: true)
-    assert changeset.errors == [profile: "is invalid"]
+    assert changeset.errors == [profile: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -176,7 +176,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
     changeset = cast(%Author{profile: nil}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
@@ -186,12 +186,12 @@ defmodule Ecto.Changeset.EmbeddedTest do
     changeset = cast(%Author{profile: nil}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{profile: nil}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
   end
 
   test "cast embeds_one with optional" do
@@ -257,12 +257,12 @@ defmodule Ecto.Changeset.EmbeddedTest do
 
     changeset = cast(model, %{"invalid_profile" => nil}, :invalid_profile)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(model, %{"invalid_profile" => %{"id" => 2}}, :invalid_profile)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -321,7 +321,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
     assert new.valid?
 
     assert second.data.id == 2
-    assert second.errors == [title: "can't be blank"]
+    assert second.errors == [title: {"can't be blank", []}]
     assert second.action == :update
     refute second.valid?
 
@@ -340,19 +340,19 @@ defmodule Ecto.Changeset.EmbeddedTest do
 
   test "cast embeds_many with invalid params" do
     changeset = cast(%Author{}, %{"posts" => "value"}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"posts" => ["value"]}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"posts" => nil}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"posts" => %{"id" => "invalid"}}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -367,11 +367,11 @@ defmodule Ecto.Changeset.EmbeddedTest do
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: "can't be blank"]
+    assert changeset.errors == [posts: {"can't be blank", []}]
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
   end
 
   test "cast embeds_many with empty parameters" do
@@ -398,12 +398,12 @@ defmodule Ecto.Changeset.EmbeddedTest do
 
     changeset = cast(model, %{"invalid_posts" => []}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(model, %{"invalid_posts" => [%{"id" => 2}]}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -528,12 +528,12 @@ defmodule Ecto.Changeset.EmbeddedTest do
 
     changeset = Changeset.put_embed(base_changeset, :invalid_profile, nil)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = Changeset.put_embed(base_changeset, :invalid_profile, %Profile{id: 2})
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -624,12 +624,12 @@ defmodule Ecto.Changeset.EmbeddedTest do
 
     changeset = Changeset.put_embed(base_changeset, :invalid_posts, [])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = Changeset.put_embed(base_changeset, :invalid_posts, [%Post{id: 2}])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
   end
 

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -86,13 +86,13 @@ defmodule Ecto.Changeset.HasAssocTest do
   test "cast has_one with invalid params" do
     changeset = cast(%Author{}, %{"profile" => %{name: nil}}, :profile)
     assert changeset.changes.profile.changes == %{}
-    assert changeset.changes.profile.errors  == [name: "can't be blank"]
+    assert changeset.changes.profile.errors  == [name: {"can't be blank", []}]
     assert changeset.changes.profile.action  == :insert
     refute changeset.changes.profile.valid?
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"profile" => "value"}, :profile)
-    assert changeset.errors == [profile: "is invalid"]
+    assert changeset.errors == [profile: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -174,12 +174,12 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
 
     changeset = cast(%Author{profile: nil}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
@@ -189,12 +189,12 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{profile: nil}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{profile: nil}
-    assert changeset.errors == [profile: "can't be blank"]
+    assert changeset.errors == [profile: {"can't be blank", []}]
   end
 
   test "cast has_one with optional" do
@@ -263,12 +263,12 @@ defmodule Ecto.Changeset.HasAssocTest do
 
     changeset = cast(model, %{"invalid_profile" => nil}, :invalid_profile)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(model, %{"invalid_profile" => %{"id" => 2}}, :invalid_profile)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -341,7 +341,7 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert new.valid?
 
     assert second.data.id == 2
-    assert second.errors == [title: "can't be blank"]
+    assert second.errors == [title: {"can't be blank", []}]
     assert second.action == :update
     refute second.valid?
 
@@ -361,19 +361,19 @@ defmodule Ecto.Changeset.HasAssocTest do
 
   test "cast has_many with invalid params" do
     changeset = cast(%Author{}, %{"posts" => "value"}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"posts" => ["value"]}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"posts" => nil}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"posts" => %{"id" => "invalid"}}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -393,12 +393,12 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: "can't be blank"]
+    assert changeset.errors == [posts: {"can't be blank", []}]
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
   end
 
   test "cast has_many with empty parameters" do
@@ -428,12 +428,12 @@ defmodule Ecto.Changeset.HasAssocTest do
 
     changeset = cast(model, %{"invalid_posts" => []}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(model, %{"invalid_posts" => [%{"id" => 2}]}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -582,12 +582,12 @@ defmodule Ecto.Changeset.HasAssocTest do
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_profile, nil)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_profile, %Profile{id: 2})
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: "is invalid"]
+    assert changeset.errors == [invalid_profile: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -687,22 +687,22 @@ defmodule Ecto.Changeset.HasAssocTest do
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_posts, [])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_posts, [%Post{id: 2}])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_posts, [])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_posts, [%Post{id: 2}])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
   end
 

--- a/test/ecto/changeset/many_to_many_test.exs
+++ b/test/ecto/changeset/many_to_many_test.exs
@@ -92,7 +92,7 @@ defmodule Ecto.Changeset.ManyToManyTest do
     assert new.valid?
 
     assert second.data.id == 2
-    assert second.errors == [title: "can't be blank"]
+    assert second.errors == [title: {"can't be blank", []}]
     assert second.action == :update
     refute second.valid?
 
@@ -112,19 +112,19 @@ defmodule Ecto.Changeset.ManyToManyTest do
 
   test "cast many_to_many with invalid params" do
     changeset = cast(%Author{}, %{"posts" => "value"}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"posts" => ["value"]}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"posts" => nil}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(%Author{}, %{"posts" => %{"id" => "invalid"}}, :posts)
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -144,12 +144,12 @@ defmodule Ecto.Changeset.ManyToManyTest do
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: "can't be blank"]
+    assert changeset.errors == [posts: {"can't be blank", []}]
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: "is invalid"]
+    assert changeset.errors == [posts: {"is invalid", []}]
   end
 
   test "cast many_to_many with empty parameters" do
@@ -179,12 +179,12 @@ defmodule Ecto.Changeset.ManyToManyTest do
 
     changeset = cast(model, %{"invalid_posts" => []}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = cast(model, %{"invalid_posts" => [%{"id" => 2}]}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -293,22 +293,22 @@ defmodule Ecto.Changeset.ManyToManyTest do
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_posts, [])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_posts, [%Post{id: 2}])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_posts, [])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
 
     changeset = Changeset.put_assoc(base_changeset, :invalid_posts, [%Post{id: 2}])
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: "is invalid"]
+    assert changeset.errors == [invalid_posts: {"is invalid", []}]
     refute changeset.valid?
   end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -115,7 +115,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.params == params
     assert changeset.data  == struct
     assert changeset.changes == %{body: "world"}
-    assert changeset.errors == [title: "can't be blank"]
+    assert changeset.errors == [title: {"can't be blank", []}]
     refute changeset.valid?
   end
 
@@ -125,7 +125,7 @@ defmodule Ecto.ChangesetTest do
 
     changeset = cast(struct, params, ~w(body), ~w())
     assert changeset.changes == %{}
-    assert changeset.errors == [body: "is invalid"]
+    assert changeset.errors == [body: {"is invalid", []}]
     refute changeset.valid?
   end
 
@@ -135,23 +135,23 @@ defmodule Ecto.ChangesetTest do
 
     changeset = cast(struct, params, ~w(), ~w(body))
     assert changeset.changes == %{}
-    assert changeset.errors == [body: "is invalid"]
+    assert changeset.errors == [body: {"is invalid", []}]
     refute changeset.valid?
   end
 
   test "cast/4: required errors" do
     changeset = cast(%Post{}, %{"title" => nil}, ~w(title), ~w())
-    assert changeset.errors == [title: "can't be blank"]
+    assert changeset.errors == [title: {"can't be blank", []}]
     assert changeset.changes == %{}
     refute changeset.valid?
 
     changeset = cast(%Post{title: nil}, %{}, ~w(title), ~w())
-    assert changeset.errors == [title: "can't be blank"]
+    assert changeset.errors == [title: {"can't be blank", []}]
     assert changeset.changes == %{}
     refute changeset.valid?
 
     changeset = cast(%Post{title: "valid"}, %{"title" => nil}, ~w(title), ~w())
-    assert changeset.errors == [title: "can't be blank"]
+    assert changeset.errors == [title: {"can't be blank", []}]
     assert changeset.changes == %{}
     refute changeset.valid?
   end
@@ -254,7 +254,7 @@ defmodule Ecto.ChangesetTest do
     changeset = merge(cs1, cs2)
     refute changeset.valid?
     assert changeset.errors ==
-           [title: "can't be blank", body: "can't be blank"]
+           [title: {"can't be blank", []}, body: {"can't be blank", []}]
   end
 
   test "merge/2: merges validations" do


### PR DESCRIPTION
This follows up the changes applied to error messages to accommodate for a keyword list together with a string for easier localization of errors.