### PR TITLE
Invalidate changeset on non-map-params in Ecto.Changeset.cast/3

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -286,6 +286,10 @@ defmodule Ecto.Changeset do
   @spec cast(Ecto.Schema.t | t,
              %{binary => term} | %{atom => term},
              [String.t | atom]) :: t | no_return
+  def cast(data, params, allowed) when not is_map(params) do
+    cast(data, :empty, [], allowed)
+  end
+
   def cast(data, params, allowed) do
     cast(data, params, [], allowed)
   end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -46,6 +46,35 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
   end
 
+  test "cast/3: anything other than Map for params is invalid" do
+    struct = %Post{}
+
+    changeset = cast(struct, [], ~w(title body)a)
+    assert changeset.params == nil
+    assert changeset.data == struct
+    assert changeset.changes == %{}
+    assert changeset.errors == []
+    assert changeset.validations == []
+    assert changeset.required == []
+    refute changeset.valid?
+  end
+
+  test "cast/3: works when casting a changeset" do
+    params = %{title: "hello"}
+    base_changeset = cast(%Post{title: "valid"}, params, ~w(title))
+                     |> validate_length(:title, min: 3)
+                     |> unique_constraint(:title)
+
+    changeset = cast(base_changeset, [], ~w(title))
+    assert changeset.params == %{"title" => "hello"}
+    assert changeset.changes == params
+    assert changeset.errors == []
+    assert changeset.required == []
+    refute changeset.valid?
+    assert length(changeset.validations) == 1
+    assert length(changeset.constraints) == 1
+  end
+
   ## cast/4
 
   test "cast/4: with valid string keys" do


### PR DESCRIPTION
Currently `cast/3` raises `FunctionClauseError` on non-map-params, but shouldn't it be able to receive anything as params and return meaningful (invalid) result instead of raising a bunch of different errors?

I know that using an atom (`:empty` or `:invalid`) in `cast/4` is deprecated, but there is no other way to force an invalid changeset for such params - empty map, as stated in deprecation message, produces a valid changeset for some reason, so I didn't use it.

Is it an issue or what I am doing wrong? :)