### PR TITLE
Add ON_UPDATE support in migrations

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -652,13 +652,13 @@ if Code.ensure_loaded?(Mariaex) do
       do: ", ADD CONSTRAINT #{reference_name(ref, table, name)} " <>
           "FOREIGN KEY (#{quote_name(name)}) " <>
           "REFERENCES #{quote_table(table.prefix, ref.table)}(#{quote_name(ref.column)})" <>
-          reference_on_delete(ref.on_delete)
+          reference_on_delete(ref.on_delete) <> reference_on_update(ref.on_update)
 
     defp reference_expr(%Reference{} = ref, table, name),
       do: ", CONSTRAINT #{reference_name(ref, table, name)} FOREIGN KEY " <>
           "(#{quote_name(name)}) REFERENCES " <>
           "#{quote_table(table.prefix, ref.table)}(#{quote_name(ref.column)})" <>
-          reference_on_delete(ref.on_delete)
+          reference_on_delete(ref.on_delete) <> reference_on_update(ref.on_update)
 
     defp reference_name(%Reference{name: nil}, table, column),
       do: quote_name("#{table.name}_#{column}_fkey")
@@ -671,6 +671,10 @@ if Code.ensure_loaded?(Mariaex) do
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
     defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
     defp reference_on_delete(_), do: ""
+
+    defp reference_on_update(:nilify_all), do: " ON UPDATE SET NULL"
+    defp reference_on_update(:update_all), do: " ON UPDATE CASCADE"
+    defp reference_on_update(_), do: ""
 
     ## Helpers
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -772,13 +772,13 @@ if Code.ensure_loaded?(Postgrex) do
     defp reference_expr(%Reference{} = ref, table, name),
       do: "CONSTRAINT #{reference_name(ref, table, name)} REFERENCES " <>
           "#{quote_table(table.prefix, ref.table)}(#{quote_name(ref.column)})" <>
-          reference_on_delete(ref.on_delete)
+          reference_on_delete(ref.on_delete) <> reference_on_update(ref.on_update)
 
     defp constraint_expr(%Reference{} = ref, table, name),
       do: ", ADD CONSTRAINT #{reference_name(ref, table, name)} " <>
           "FOREIGN KEY (#{quote_name(name)}) " <>
           "REFERENCES #{quote_table(table.prefix, ref.table)}(#{quote_name(ref.column)})" <>
-          reference_on_delete(ref.on_delete)
+          reference_on_delete(ref.on_delete) <> reference_on_update(ref.on_update)
 
     # A reference pointing to a serial column becomes integer in postgres
     defp reference_name(%Reference{name: nil}, table, column),
@@ -792,6 +792,10 @@ if Code.ensure_loaded?(Postgrex) do
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
     defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
     defp reference_on_delete(_), do: ""
+
+    defp reference_on_update(:nilify_all), do: " ON UPDATE SET NULL"
+    defp reference_on_update(:update_all), do: " ON UPDATE CASCADE"
+    defp reference_on_update(_), do: ""
 
     ## Helpers
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -177,8 +177,8 @@ defmodule Ecto.Migration do
     @moduledoc """
     Defines a reference struct used in migrations.
     """
-    defstruct name: nil, table: nil, column: :id, type: :serial, on_delete: :nothing
-    @type t :: %__MODULE__{table: atom, column: atom, type: atom, on_delete: atom}
+    defstruct name: nil, table: nil, column: :id, type: :serial, on_delete: :nothing, on_update: :nothing
+    @type t :: %__MODULE__{table: atom, column: atom, type: atom, on_delete: atom, on_update: atom}
   end
 
   defmodule Constraint do
@@ -670,8 +670,11 @@ defmodule Ecto.Migration do
     * `:column` - The foreign key column, default is `:id`
     * `:type`   - The foreign key type, default is `:serial`
     * `:on_delete` - What to perform if the entry is deleted.
-      May be `:nothing`, `:delete_all` or `:nilify_all`.
-      Defaults to `:nothing`.
+         May be `:nothing`, `:delete_all` or `:nilify_all`.
+         Defaults to `:nothing`.
+    * `:on_update` - What to perform if the entry is updated.
+         May be `:nothing`, `:update_all` or `:nilify_all`.
+         Defaults to `:nothing`.
 
   """
   def references(table, opts \\ []) when is_atom(table) do
@@ -679,6 +682,10 @@ defmodule Ecto.Migration do
 
     unless reference.on_delete in [:nothing, :delete_all, :nilify_all] do
       raise ArgumentError, "unknown :on_delete value: #{inspect reference.on_delete}"
+    end
+
+    unless reference.on_update in [:nothing, :update_all, :nilify_all] do
+      raise ArgumentError, "unknown :on_update value: #{inspect reference.on_update}"
     end
 
     reference

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -613,7 +613,11 @@ defmodule Ecto.Adapters.PostgresTest do
                 {:add, :category_1, references(:categories, name: :foo_bar), []},
                 {:add, :category_2, references(:categories, on_delete: :nothing), []},
                 {:add, :category_3, references(:categories, on_delete: :delete_all), [null: false]},
-                {:add, :category_4, references(:categories, on_delete: :nilify_all), []}]}
+                {:add, :category_4, references(:categories, on_delete: :nilify_all), []},
+                {:add, :category_5, references(:categories, on_update: :nothing), []},
+                {:add, :category_6, references(:categories, on_update: :update_all), [null: false]},
+                {:add, :category_7, references(:categories, on_update: :nilify_all), []},
+                {:add, :category_8, references(:categories, on_delete: :nilify_all, on_update: :update_all), [null: false]}]}
 
     assert SQL.execute_ddl(create) == """
     CREATE TABLE "posts" ("id" serial,
@@ -622,6 +626,10 @@ defmodule Ecto.Adapters.PostgresTest do
     "category_2" integer CONSTRAINT "posts_category_2_fkey" REFERENCES "categories"("id"),
     "category_3" integer NOT NULL CONSTRAINT "posts_category_3_fkey" REFERENCES "categories"("id") ON DELETE CASCADE,
     "category_4" integer CONSTRAINT "posts_category_4_fkey" REFERENCES "categories"("id") ON DELETE SET NULL,
+    "category_5" integer CONSTRAINT "posts_category_5_fkey" REFERENCES "categories"("id"),
+    "category_6" integer NOT NULL CONSTRAINT "posts_category_6_fkey" REFERENCES "categories"("id") ON UPDATE CASCADE,
+    "category_7" integer CONSTRAINT "posts_category_7_fkey" REFERENCES "categories"("id") ON UPDATE SET NULL,
+    "category_8" integer NOT NULL CONSTRAINT "posts_category_8_fkey" REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE CASCADE,
     PRIMARY KEY ("id"))
     """ |> remove_newlines
   end


### PR DESCRIPTION
Piggybacking off of https://github.com/elixir-lang/ecto/pull/705

Ecto currently supports adding `ON DELETE` column constraints in migrations. 

Analogous to `ON DELETE` there is also `ON UPDATE` which is invoked when a referenced column is changed (updated). The possible actions are the same as `ON DELETE`.

This PR supports `ON UPDATE` on column definitions.

Would love Ecto to support this!

:heart: :purple_heart: :blue_heart: :green_heart:

Thoughts?