### PR TITLE
Adds inherited table support for Ecto migrations.

### DIFF
--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -37,6 +37,11 @@ defmodule Ecto.Adapter.Migration  do
   Checks if the adapter supports ddl transaction.
   """
   @callback supports_ddl_transaction? :: boolean
+  
+  @doc """
+  Checks if the adapter supports inherited tables
+  """
+  @callback supports_inherited_tables? :: boolean
 
   @doc """
   Executes migration commands.

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -162,6 +162,11 @@ defmodule Ecto.Adapters.MySQL do
   def supports_ddl_transaction? do
     true
   end
+  
+  @doc false
+  def supports_inherited_tables? do
+    false
+  end
 
   @doc false
   def insert(repo, %{source: {prefix, source}, autogenerate_id: {key, :id}}, params, [key], opts) do

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -140,4 +140,9 @@ defmodule Ecto.Adapters.Postgres do
   def supports_ddl_transaction? do
     true
   end
+  
+  @doc false
+  def supports_inherited_tables? do
+    true
+  end
 end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -567,11 +567,13 @@ if Code.ensure_loaded?(Postgrex) do
     def execute_ddl({command, %Table{}=table, columns}) when command in [:create, :create_if_not_exists] do
       options       = options_expr(table.options)
       if_not_exists = if command == :create_if_not_exists, do: " IF NOT EXISTS", else: ""
-      pk_definition = pk_definition(columns)
+      pk_definition = pk_definition(table, columns)
+      inherits      = if table.inherits, do: " INHERITS (#{inherits(table.prefix, table.inherits)})", else: ""
 
       "CREATE TABLE" <> if_not_exists <>
         " #{quote_table(table.prefix, table.name)}" <>
-        " (#{column_definitions(table, columns)}#{pk_definition})" <> options
+        " (#{column_definitions(table, columns)}#{prepend_comma_if_columns(pk_definition, columns)})" <>
+        "#{inherits}" <> options
     end
 
     def execute_ddl({command, %Table{}=table}) when command in @drops do
@@ -636,7 +638,25 @@ if Code.ensure_loaded?(Postgrex) do
 
     def execute_ddl(keyword) when is_list(keyword),
       do: error!(nil, "PostgreSQL adapter does not support keyword lists in execute")
-
+      
+    # Primary key definitions.  If the table is inherited the defailt is to
+    # define the primary key as the same columns as the inherited table.
+    defp pk_definition(%Table{}=table, columns),
+      do: pk_definition(table, table.inherits, columns)
+    
+    defp pk_definition(%Table{}=table, inherits, columns) when is_atom(inherits),
+      do: pk_definition(inherited_primary_keys(table) ++ columns)
+    
+    defp pk_definition(%Table{}=table, inherits, columns) when is_list(inherits) do
+      [_inherited_table | options] = inherits
+      case Keyword.get(options, :primary_keys, true) do
+        true ->
+          pk_definition(inherited_primary_keys(table) ++ columns)
+        false ->
+          pk_definition(columns)
+      end
+    end
+    
     defp pk_definition(columns) do
       pks =
         for {_, name, _, opts} <- columns,
@@ -645,10 +665,18 @@ if Code.ensure_loaded?(Postgrex) do
 
       case pks do
         [] -> ""
-        _  -> ", PRIMARY KEY (" <> Enum.map_join(pks, ", ", &quote_name/1) <> ")"
+        _  -> "PRIMARY KEY (" <> Enum.map_join(pks, ", ", &quote_name/1) <> ")"
       end
     end
-
+    
+    defp prepend_comma_if_columns(pk_def, []), do: pk_def
+    defp prepend_comma_if_columns("" = pk_def, _columns), do: pk_def
+    defp prepend_comma_if_columns(pk_def, _columns), do: ", " <> pk_def
+    
+    defp inherited_primary_keys(%Table{}=table) do
+      Enum.map(table.inherited_primary_keys, fn (y) -> {:add, y, nil, [primary_key: true]} end)
+    end
+    
     defp column_definitions(table, columns) do
       Enum.map_join(columns, ", ", &column_definition(table, &1))
     end
@@ -792,7 +820,64 @@ if Code.ensure_loaded?(Postgrex) do
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
     defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
     defp reference_on_delete(_), do: ""
+    
+    ## Metadata
+    
+    def primary_keys_from(table_name) do
+      """
+        SELECT a.attname::varchar
+        FROM   pg_index i
+        JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum = ANY(i.indkey)
+        WHERE  i.indrelid = #{single_quote(table_name)}::regclass
+        AND    i.indisprimary;
+      """
+    end
+    def primary_keys_from(nil, table_name),
+      do: primary_keys_from(table_name)
+    def primary_keys_from(prefix, table_name),
+      do: primary_keys_from(prefix <> "." <> table_name)
 
+    def index_definitions_from(table_name) do
+      """
+        SELECT                  
+          pg_get_indexdef(idx.indexrelid) AS index_definition
+        FROM pg_index AS idx
+          JOIN pg_class AS i
+            ON i.oid = idx.indexrelid
+          JOIN pg_am AS am
+            ON i.relam = am.oid
+          JOIN pg_namespace AS NS ON i.relnamespace = NS.OID
+          JOIN pg_user AS U ON i.relowner = U.usesysid
+        WHERE idx.indisprimary = 'f' 
+          AND idx.indrelid = #{single_quote(table_name)}::regclass
+      """
+    end
+    def index_definitions_from(nil, table_name),
+      do: index_definitions_from(table_name)
+    def index_definitions_from(prefix, table_name),
+      do: index_definitions_from(table_name) <> " AND ns.nspname = #{single_quote(prefix)}"
+      
+    def trigger_definitions_from(table_name) do
+      """
+        SELECT pg_get_triggerdef(oid) 
+        FROM pg_trigger 
+        WHERE tgrelid = #{single_quote(table_name)}::regclass
+      """
+    end
+    def trigger_definitions_from(nil, table_name),
+      do: trigger_definitions_from(table_name)
+    def trigger_definitions_from(prefix, table_name),
+      do: trigger_definitions_from(prefix <> "." <> table_name)
+      
+    def inherits(table_prefix, table_name) when is_atom(table_name),
+      do: quote_table(table_prefix, table_name)
+    def inherits(table_prefix, inherit) when is_list(inherit) do
+      [table_name | options] = inherit
+      prefix = Keyword.get(options, :prefix, table_prefix)
+      quote_table(prefix, table_name)
+    end
+    
     ## Helpers
 
     defp get_source(query, sources, ix, source) do
@@ -820,6 +905,34 @@ if Code.ensure_loaded?(Postgrex) do
         error!(nil, "bad table name #{inspect name}")
       end
       <<?", name::binary, ?">>
+    end
+    
+    # Quote a table name for use in metadata look ups where the table name 
+    # is part of a predicate
+    defp single_quote(nil, name) do
+      single_quote(name)
+    end
+    defp single_quote(prefix, name) when is_atom(prefix) and is_atom(name) do
+      single_quote(Atom.to_string(prefix), Atom.to_string(name))
+    end
+    defp single_quote(prefix, name) do
+      single_quote(prefix <> "." <> name)
+    end
+    defp single_quote(name) when is_atom(name) do
+      single_quote(Atom.to_string(name))
+    end
+    defp single_quote(name) when is_binary(name) do
+      cond do
+        String.contains?(name, "\"") ->
+          error!(nil, "bad table name #{inspect name}")
+        true ->
+          <<?', name::binary, ?'>>
+      end
+    end
+    defp single_quote(name) when is_list(name) do
+      [table_name | options] = name
+      prefix = Keyword.get(options, :prefix, nil)
+      single_quote(prefix, table_name)
     end
 
     defp assemble(list) do

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -61,6 +61,14 @@ defmodule Ecto.Migration.Runner do
   def migrator_direction do
     Agent.get(runner(), & &1.migrator_direction)
   end
+  
+  @doc """
+  Returns the repo the migrator is using
+  
+  """
+  def repo do
+    Agent.get(runner(), & &1.repo)
+  end
 
   @doc """
   Gets the prefix for this migration

--- a/test/ecto/adapters/sql_test.exs
+++ b/test/ecto/adapters/sql_test.exs
@@ -4,6 +4,7 @@ defmodule Ecto.Adapters.SQLTest do
   defmodule Adapter do
     use Ecto.Adapters.SQL
     def supports_ddl_transaction?, do: false
+    def supports_inherited_tables?, do: false
   end
 
   Application.put_env(:ecto, __MODULE__.Repo, adapter: Adapter)


### PR DESCRIPTION
Adds syntax to the table() macro to permit the creation of inherited tables
for adapters that support that functionality (currently limited to Postgres).

Given the migration:

    defmodule InheritedMigration do
      use Ecto.Migration

      def up do
        create table(:things) do
          add :name, :string
        end

        create table(:posts, inherits: :things) do
          add :content, :text
        end
      end

      def down do
        drop table(:posts)
        drop table(:things)
      end
    end

Then the table :posts will be created and inherit the columns from :things
as well as having the additional columns defined on :posts.  This is the
native Postgres behaviour of table inheritance.

This native behaviour does not inherit the primary key definition, doesn't
inherit any indexes and doesn't inherit any triggers.

By default, this commit will copy the primary key definition, indexes and
triggers from the inherited table to the new table since this is the likely
expected behaviour.

To modify the behaviour, the inheritance can be given options:

    create table(:posts, inherits: [:things, primary_keys: false, indexes: false, triggers: false) do
      add :content, :text
    end

This configuration will reproduce the default Postgres behaviour.  Each option
can of course be set separately.

Tests have been added and the tests specifically related to inheritance can be
run by:

    mix test --only inheritance

This is the first of three pull requests, the next two build upon this one:

* Add Ecto.Schema support for inherited tables that will copy the fields,
primary keys and associations from another `schema`.

* Eco.Query support that will polymorphically assign retrieved rows to the
appropriate `schema`
