### PR TITLE
Remove old code for `Changeset.traverse_errors/2` tests

### DIFF
--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -702,13 +702,10 @@ defmodule Ecto.Changeset.EmbeddedTest do
       |> Changeset.cast_embed(:profile)
       |> Changeset.add_error(:name, "is invalid")
 
-    errors = Changeset.traverse_errors(changeset, fn
-      {err, opts} ->
-        err
-        |> String.replace("%{count}", to_string(opts[:count]))
-        |> String.upcase()
-      err ->
-        String.upcase(err)
+    errors = Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      msg
+      |> String.replace("%{count}", to_string(opts[:count]))
+      |> String.upcase()
     end)
 
     assert errors == %{
@@ -726,13 +723,10 @@ defmodule Ecto.Changeset.EmbeddedTest do
       |> Changeset.cast_embed(:posts)
       |> Changeset.add_error(:name, "is invalid")
 
-    errors = Changeset.traverse_errors(changeset, fn
-      {err, opts} ->
-        err
-        |> String.replace("%{count}", to_string(opts[:count]))
-        |> String.upcase()
-      err ->
-        String.upcase(err)
+    errors = Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      msg
+      |> String.replace("%{count}", to_string(opts[:count]))
+      |> String.upcase()
     end)
 
     assert errors == %{

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -959,8 +959,8 @@ defmodule Ecto.ChangesetTest do
       |> validate_format(:body, ~r/888/)
       |> add_error(:title, "is taken")
 
-    errors = traverse_errors(changeset, fn {err, opts} ->
-      err
+    errors = traverse_errors(changeset, fn {msg, opts} ->
+      msg
       |> String.replace("%{count}", to_string(opts[:count]))
       |> String.upcase()
     end)


### PR DESCRIPTION
Also, call the fn argument `msg` everywhere, since this is how it's called in docs.