### PR TITLE
Fix some documentation typos/syntactical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ defmodule Sample.App do
 
   def keyword_query do
     query = from w in Weather,
-          where: w.prcp > 0 or is_nil(w.prcp),
+         where: w.prcp > 0 or is_nil(w.prcp),
          select: w
     Repo.all(query)
   end

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -393,7 +393,7 @@ defmodule Ecto do
 
   #### Repo resolution
 
-  Out of the box, Ecto tasks assumes that the location of your Repo lives within
+  Out of the box, Ecto tasks assume that the location of your Repo lives within
   your application's root namespace; for example, in the previous examples, Ecto
   will assume your Repo is located at MyApp.Repo.
 

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -3,14 +3,14 @@ defmodule Ecto.Adapters.SQL.Connection do
   Specifies the behaviour to be implemented by all SQL connections.
   """
 
-  @typedoc "The prepared query which is SQL command"
+  @typedoc "The prepared query which is an SQL command"
   @type prepared :: String.t
 
   @typedoc "The cache query which is a DBConnection Query"
   @type cached :: map
 
   @doc """
-  Receives options and returns `DBConnection` supervisor child 
+  Receives options and returns `DBConnection` supervisor child
   specification.
   """
   @callback child_spec(Keyword.t) :: {module, Keyword.t}

--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -17,8 +17,8 @@ defmodule Ecto.Adapters.SQL.Sandbox do
   ## Database support
 
   While both PostgreSQL and MySQL support SQL Sandbox, only PostgreSQL
-  support concurrent tests while running the SQL Sandbox. Therefore, do
-  not run concurrent tests with MySQL as may run into deadlocks due to
+  supports concurrent tests while running the SQL Sandbox. Therefore, do
+  not run concurrent tests with MySQL as you may run into deadlocks due to
   its transaction implementation.
 
   ## Example
@@ -109,8 +109,8 @@ defmodule Ecto.Adapters.SQL.Sandbox do
   the parent's connection (i.e. the test process' connection) to
   the task.
 
-  Because allowances uses an explicit mechanism, their advantage
-  is that you can still runs your tests in async mode. The downside
+  Because allowances use an explicit mechanism, their advantage
+  is that you can still run your tests in async mode. The downside
   is that you need to explicitly control and allow every single
   process. This is not always possible. In such cases, you will
   want to use shared mode.

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -775,7 +775,7 @@ defmodule Ecto.Association.ManyToMany do
     * `relationship` - The relationship to the specified schema, default `:child`
     * `join_keys` - The keyword list with many to many join keys
     * `join_through` - Atom (representing a schema) or a string (representing a table)
-      for many to many association
+      for many to many associations
   """
 
   @behaviour Ecto.Association

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -182,7 +182,7 @@ defmodule Ecto.Changeset do
     * directly changing a struct without performing castings nor validations
     * directly bulk-adding changes to a changeset
 
-  Since no validation nor casting is performed, `change/2` expects the keys in
+  Since neither validation nor casting is performed, `change/2` expects the keys in
   `changes` to be atoms. `changes` can be a map as well as a keyword list.
 
   When a changeset is passed as the first argument, the changes passed as the

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -6,8 +6,8 @@ defmodule Ecto.Multi do
   Ecto.Multi makes it possible to pack operations that should be performed
   together (in a single database transaction) and gives a way to introspect
   the queued operations without actually performing them.
-  Each operation is given a name that is unique and will identify it's result
-  or will help to identify place of failure in case it occurs.
+  Each operation is given a name that is unique and will identify its result
+  or will help to identify the place of failure in case it occurs.
 
   All operations will be executed in the order they were added.
 
@@ -286,7 +286,7 @@ defmodule Ecto.Multi do
   end
 
   @doc """
-  Adds an delete_all operation to the multi.
+  Adds a delete_all operation to the multi.
 
   Accepts the same arguments and options as `Ecto.Repo.delete_all/4` does.
   """

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -199,7 +199,7 @@ defmodule Ecto.Query do
 
   ## Fragments
 
-  If you need a escape hatch, Ecto provides fragments
+  If you need an escape hatch, Ecto provides fragments
   (see `Ecto.Query.API.fragment/1`) to inject SQL (and non-SQL)
   fragments into queries.
 
@@ -416,7 +416,7 @@ defmodule Ecto.Query do
   @joins    [:join, :inner_join, :left_join, :right_join, :full_join]
 
   defp from([{type, expr}|t], env, count_bind, quoted, binds) when type in @binds do
-    # If all bindings are integer indexes keep AST Macro.expand'able to %Query{},
+    # If all bindings are integer indexes keep AST Macro expandable to %Query{},
     # otherwise ensure that quoted code is evaluated before macro call
     quoted =
       if Enum.all?(binds, fn {_, value} -> is_integer(value) end) do
@@ -518,7 +518,7 @@ defmodule Ecto.Query do
       Comment
       |> join(:inner, [c], p in fragment("SOME COMPLEX QUERY", c.id, ^some_param))
 
-  This style discouraged due to its complexity.
+  This style is discouraged due to its complexity.
   """
   defmacro join(query, qual, binding \\ [], expr, on \\ nil) do
     Join.build(query, qual, binding, expr, on, nil, __CALLER__)
@@ -539,7 +539,7 @@ defmodule Ecto.Query do
   is omitted, the query will by default select the full schema.
 
   `select` also accepts a list of atoms where each atom refers to a field in
-  source to be selected.
+  the source to be selected.
 
   ## Keywords examples
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -437,7 +437,7 @@ defmodule Ecto.Repo do
   Inserts all entries into the repository.
 
   It expects a schema (`MyApp.User`) or a source (`"users"` or
-  `{"prefix", "users"}`) as first argument. The second argument
+  `{"prefix", "users"}`) as the first argument. The second argument
   is a list of entries to be inserted, either as keyword lists
   or as maps.
 


### PR DESCRIPTION
Reading through the docs, I noticed a few typos that needed fixing.

