### PR TITLE
BIT(1) type cannot load  as type :boolean #1366

### DIFF
--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -106,6 +106,8 @@ defmodule Ecto.Adapters.MySQL do
     do: [&json_decode/1, &Ecto.Adapters.SQL.load_embed(type, &1)]
   def loaders(_primitive, type), do: [type]
 
+  defp bool_decode(<<0>>), do: {:ok, false}
+  defp bool_decode(<<1>>), do: {:ok, true}
   defp bool_decode(0), do: {:ok, false}
   defp bool_decode(1), do: {:ok, true}
   defp bool_decode(x), do: {:ok, x}


### PR DESCRIPTION
I have not been able to test this code it is to facilitate for the use of BIT(1) in MySQL. I was able to test the previous pull request on branch v1.1 and it works. I have sent this as it was requested by Jose in a previous attempt I made at a pull request was wrong.

I believe https://github.com/liveforeverx thought he had updated this to echo 2.0 but could not find the changes there. Hence this update.