### PR TITLE
Fix moduledoc for ecto.load and ecto.dump tasks

### DIFF
--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -14,8 +14,8 @@ defmodule Mix.Tasks.Ecto.Dump do
 
   ## Command line options
 
-    * `-r`, `--repo` - the repo to load the structure info into
-    * `-d`, `--dump-path` - the path of the dump file to load from`
+    * `-r`, `--repo` - the repo to load the structure info from
+    * `-d`, `--dump-path` - the path of the dump file to create
   """
 
   def run(args) do

--- a/lib/mix/tasks/ecto.load.ex
+++ b/lib/mix/tasks/ecto.load.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Ecto.Load do
   ## Command line options
 
     * `-r`, `--repo` - the repo to load the structure info into
-    * `-d`, `--dump-path` - the path of the dump file to load from`
+    * `-d`, `--dump-path` - the path of the dump file to load from
   """
 
   def run(args) do


### PR DESCRIPTION
There was a trailing ` in the module docs and the docs for dump were incorrectly copied from load.