### PR TITLE
Support required has_many in traverse_errors

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1787,7 +1787,7 @@ defmodule Ecto.Changeset do
     Enum.reduce types, map, fn
       {field, {tag, %{cardinality: :many}}}, acc when tag in @relations ->
         if changesets = Map.get(changes, field) do
-          Map.put(acc, field, Enum.map(changesets, &traverse_errors(&1, msg_func)))
+          Map.put_new_lazy(acc, field, fn -> Enum.map(changesets, &traverse_errors(&1, msg_func)) end)
         else
           acc
         end

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -712,4 +712,22 @@ defmodule Ecto.Changeset.EmbeddedTest do
       name: ["IS INVALID"]
     }
   end
+
+  test "traverses changeset errors with embeds_many when required" do
+    changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
+    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
+
+    changeset = cast(%Author{}, %{"posts" => []}, :posts, required: true)
+    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
+
+    changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
+    assert changeset.errors == [posts: {"is invalid", [type: {:array, :map}]}]
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"is invalid", [type: {:array, :map}]}]}
+
+    changeset = cast(%Author{posts: []}, %{"posts" => [%{title: nil}]}, :posts, required: true)
+    assert changeset.errors == []
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [%{title: [{"can't be blank", []}]}]}
+  end
 end


### PR DESCRIPTION
A required has_many association already reports a Changeset error when the value is empty:

    iex> changeset = %Author{}
    iex>   |> Changeset.cast(%{posts: []}, ~w())
    iex>   |> Changeset.cast_assoc(:posts, required: true)
    iex> changeset.errors
    [posts: {"can't be blank", []}]

However, calling `Changeset.traverse_errors` on this changeset currently results in a blank set of errors for `posts`:

    iex> Ecto.Changeset.traverse_errors(changeset, &(&1))
    %{posts: []}

This happened because the errors on the nested association -- of which there were none -- overwrote the error on the parent for the association name, i.e. it was the equivalent of the following:

    iex> Map.put(%{posts: [{"can't be blank", []}]}, :posts, [])
    %{posts: []}

The fix has been implemented by merging the nested errors only if there is no error on the parent for the association.  I believe this is safe because if there is an error on the association itself, we should not care about errors on the children.