### PR TITLE
Ecto 2.0 issue with `in ^[x]`

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -389,8 +389,14 @@ defmodule Ecto.Association.Has do
 
   @doc false
   def assoc_query(%{queryable: queryable, related_key: related_key}, query, values) do
-    from x in (query || queryable),
-      where: field(x, ^related_key) in ^values
+    assoc_query_where(query || queryable, related_key, values)
+  end
+
+  defp assoc_query_where(query, related_key, [value]) do
+    from x in query, where: field(x, ^related_key) == ^value
+  end
+  defp assoc_query_where(query, related_key, values) do
+    from x in query, where: field(x, ^related_key) in ^values
   end
 
   @doc false

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -431,7 +431,7 @@ defmodule Ecto.AssociationTest do
 
   test "assoc/2" do
     assert inspect(assoc(%Post{id: 1}, :comments)) ==
-           inspect(from c in Comment, where: c.post_id in ^[1])
+           inspect(from c in Comment, where: c.post_id == ^1)
 
     assert inspect(assoc([%Post{id: 1}, %Post{id: 2}], :comments)) ==
            inspect(from c in Comment, where: c.post_id in ^[1, 2])


### PR DESCRIPTION
TL;DR: Ecto used to translate `in ^[1]` as `IN (1)`. Now it does. `= ANY('{1}')` This messes up indices.

Proposed Fix: When using Ecto.assoc/2 with only a single value, use `== ^value` instead of `in ^values`.

I have a multicolumn index on a rather large table `readings`. When doing `SELECT max(readings.recorded_at) WHERE readings.recording_session_id = $id` it will crucially use that multicolumn index on `recorded_at, recording_session_id`.

In my Elixir code I had `session |> assoc(:readings) |> stuff` however and that generates `recording_session_id in ^[$id]`. In ecto 1.X this generated the SQL `IN (1)` and that made use of the multicolumn index without any issue. However, `= ANY('{2762}')` does not.

This change simply makes sure that when using `assoc` on a single model it uses the `==` query.

I am curious why the translation of `in ^[x]` was changed. When folks use `in` in Ecto I think they reasonably expect that to become an `IN` in SQL. The performance characteristics and valid inputs with respect to items in `IN` vs `ANY` aren't the same. Don't get me wrong I think ANY is great and should be easy to use, I'm just sure if it's the right default for `IN`. I'm not gonna be the only one affected by this change.