### PR TITLE
Better errors on field that is both required and invalid

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1090,7 +1090,7 @@ defmodule Ecto.Changeset do
   defp missing?(changeset, field) when is_atom(field) do
     case get_field(changeset, field) do
       value when is_binary(value) -> String.lstrip(value) == ""
-      value -> value == nil
+      value -> value == nil && changeset.errors[field] == nil
     end
   end
 
@@ -1485,7 +1485,7 @@ defmodule Ecto.Changeset do
         end)
       end
 
-  We retrieve the repo and from the comment changeset it self, and use 
+  We retrieve the repo and from the comment changeset it self, and use
   update_all to update the counter cache in one query. Finally the original
   changeset must be returned.
   """

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -46,6 +46,28 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
   end
 
+  test "cast/3: optional field of wrong type is marked as invalid" do
+    params = %{"body" => :world}
+    struct = %Post{}
+
+    changeset = cast(struct, params, ~w(body))
+    assert changeset.changes == %{}
+    assert changeset.errors == [body: {"is invalid", [type: :string]}]
+    refute changeset.valid?
+  end
+
+  test "cast/3: required field (via validate_required/2) of wrong type is marked as invalid" do
+    params = %{"body" => :world}
+    struct = %Post{}
+
+    changeset = cast(struct, params, [:body])
+                |> validate_required([:body])
+
+    assert changeset.changes == %{}
+    assert changeset.errors == [body: {"is invalid", [type: :string]}]
+    refute changeset.valid?
+  end
+
   ## cast/4
 
   test "cast/4: with valid string keys" do


### PR DESCRIPTION
Using `cast/3` and `validate_required/2` together on a field that is of the wrong type will produce 2 errors that seem conflicting.

For example, given the following schema:

```ex
  defmodule Post do
    use Ecto.Schema

    schema "posts" do
      field :body
    end
  end
```

Casting the wrong type for `body` while also marking it as required produces 2 errors on the `body` field:

```ex
iex> changeset = cast(%Post{}, %{body: :invalid}, [:body]) |> validate_required([:body])
iex> changeset.changes
%{}
iex> changeset.errors
[body: {"can't be blank", []}, body: {"is invalid", [type: :string]}]
```

This change prevents the "can't be blank" error when the field as already been deemed invalid, since the field is not actually blank.

---

The way I have fixed this, ANY error that is present on a field when `validate_required` is called will prevent the "can't be blank" error from being added.  This _seems_ like it would be expected in most cases, but will it be potentially surprising to the user?  If we do go this way, perhaps a note should be added to the `validate_required/2` docs indicating that any fields with a pre-existing error will be skipped?

The other way I thought of fixing this was to change the type check such that the field is NOT removed from the `changes` map, but this seems to change even more pre-existing behavior (and breaks more tests).