### PR TITLE
Update docs about __schema__.(:types)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Finally, Ecto now allows putting existing records in changesets, and the proper 
   * [Repo] `:timeout` in `Repo.transaction` now affects the whole transaction block and not only the particular transaction queries
   * [Repo] Overriding `Repo.log/1` is no longer supported. Instead provide custom loggers configuration via `:loggers`. The default is: `[Ecto.LogEntry]`
   * [Schema] Array fields no longer default to an empty list `[]`. Previous behaviour can be achieved by passing `default: []` to the field definition
+  * [Schema] `__schema__(:types)` now returns map
   * [SQL] `Ecto.Adapters.SQL.begin_test_transaction`, `Ecto.Adapters.SQL.restart_test_transaction` and `Ecto.Adapters.SQL.rollback_test_transaction` have been removed in favor of the new ownership-based `Ecto.Adapters.SQL.Sandbox`
 
 ## Deprecations

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -234,7 +234,7 @@ defmodule Ecto.Schema do
 
   * `__schema__(:fields)` - Returns a list of all non-virtual field names;
   * `__schema__(:type, field)` - Returns the type of the given non-virtual field;
-  * `__schema__(:types)` - Returns a keyword list of all non-virtual
+  * `__schema__(:types)` - Returns a map of all non-virtual
     field names and their type;
 
   * `__schema__(:associations)` - Returns a list of all association field names;


### PR DESCRIPTION
Since [this commit](https://github.com/elixir-lang/ecto/commit/26cd206f39f019c47847f4697538eda1f50e2f8f), `__schema__(:types)` in `Ecto.Schema` returns a map.
