### PR TITLE
Fix `from/2` example in documentation

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -370,7 +370,7 @@ defmodule Ecto.Query do
 
   ## Keywords example
 
-      from(City, select: c)
+      from(c in City, select: c)
 
   ## Expressions example
 


### PR DESCRIPTION
Currently this example throws
```
 ** (Ecto.Query.CompileError) unbound variable `c` in query
    (ecto) expanding macro: Ecto.Query.select/3
           iex:17: (file)
    (ecto) expanding macro: Ecto.Query.from/2
           iex:17: (file)
```