### PR TITLE
Remove default length specifier from PostgreSQL string type

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -753,7 +753,6 @@ if Code.ensure_loaded?(Postgrex) do
       cond do
         size            -> "#{type_name}(#{size})"
         precision       -> "#{type_name}(#{precision},#{scale || 0})"
-        type == :string -> "#{type_name}(255)"
         true            -> "#{type_name}"
       end
     end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -592,7 +592,7 @@ defmodule Ecto.Adapters.PostgresTest do
     "price" numeric(8,2) DEFAULT expr,
     "on_hand" integer DEFAULT 0 NULL,
     "is_active" boolean DEFAULT true,
-    "tags" varchar(255)[] DEFAULT ARRAY[]::varchar[])
+    "tags" varchar[] DEFAULT ARRAY[]::varchar[])
     """ |> remove_newlines
   end
 
@@ -649,7 +649,7 @@ defmodule Ecto.Adapters.PostgresTest do
                 {:add, :name, :string, []}]}
 
     assert SQL.execute_ddl(create) == """
-    CREATE TABLE "posts" ("a" integer, "b" integer, "name" varchar(255), PRIMARY KEY ("a", "b"))
+    CREATE TABLE "posts" ("a" integer, "b" integer, "name" varchar, PRIMARY KEY ("a", "b"))
     """ |> remove_newlines
   end
 


### PR DESCRIPTION
The absence of a length specifier is a better default - the 255 character limit
is arbitrary and is actually inferior from a performance perspective within
PostgreSQL.

See http://www.postgresql.org/docs/current/static/datatype-character.html.