### PR TITLE
Ensure that changeset_fun always returns a Changeset in Multi

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -246,17 +246,21 @@ defmodule Ecto.Multi do
     add_operation(multi, name, {:changeset, put_action(changeset, action), opts})
   end
 
-  defp put_action(%{action: nil} = changeset, action) do
+  defp put_action(%Changeset{action: nil} = changeset, action) do
     %{changeset | action: action}
   end
 
-  defp put_action(%{action: action} = changeset, action) do
+  defp put_action(%Changeset{action: action} = changeset, action) do
     changeset
   end
 
-  defp put_action(%{action: original}, action) do
+  defp put_action(%Changeset{action: original}, action) do
     raise ArgumentError, "you provided a changeset with an action already set " <>
       "to #{inspect original} when trying to #{action} it"
+  end
+
+  defp put_action(changeset, _action) do
+    raise ArgumentError, "expected an Ecto.Changeset, got #{inspect changeset}"
   end
 
   @doc """

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -291,6 +291,16 @@ defmodule Ecto.MultiTest do
     refute Map.has_key?(changes, :update)
   end
 
+  test "Repo.transaction rejects invalid changeset_fun" do
+    multi =
+      Multi.new
+      |> Multi.insert(:log, fn _ -> :invalid end)
+
+    assert_raise ArgumentError, "expected an Ecto.Changeset, got :invalid", fn ->
+      TestRepo.transaction(multi)
+    end
+  end
+
   test "checks invalid changesets before starting transaction" do
     changeset = %{Changeset.change(%Comment{}) | valid?: false}
     multi = Multi.new |> Multi.insert(:invalid, changeset)


### PR DESCRIPTION
I was using insert with a changeset_fun and forgot that it must return a changeset, not a struct or map.
I got confused, because Ecto.Multi.insert without a function does accept both a changeset and struct.
When I passed in a struct that happened to contain `action: "user.create"` value, I got a really confusing error, see below.

```
** (ArgumentError) you provided a changeset with an action already set to "user.create" when trying to insert it
stacktrace:
  (ecto) lib/ecto/multi.ex:258: Ecto.Multi.put_action/2
  (ecto) lib/ecto/multi.ex:389: Ecto.Multi.apply_operation/3
  (ecto) lib/ecto/multi.ex:374: Ecto.Multi.apply_operation/4
  (elixir) lib/enum.ex:1473: Enum."-reduce/3-lists^foldl/2-0-"/3
  test/support/test_repo.exs:88: Ecto.TestAdapter.transaction/3
  (ecto) lib/ecto/repo/queryable.ex:27: Ecto.Repo.Queryable.transaction/4
```

This PR adds some guards and a friendly error.