### PR TITLE
Fix typos in the docs of Ecto.migration.modify/3

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -644,8 +644,8 @@ defmodule Ecto.Migration do
     * `:null` - sets to null or not null
     * `:default` - changes the default
     * `:size` - the size of the type (for example the numbers of characters). Default is no size.
-    * `:precision` - the precision for a numberic type. Default is no precision.
-    * `:scale` - the scale of a numberic type. Default is 0 scale.
+    * `:precision` - the precision for a numeric type. Default is no precision.
+    * `:scale` - the scale of a numeric type. Default is 0 scale.
   """
   def modify(column, type, opts \\ []) when is_atom(column) do
     Runner.subcommand {:modify, column, type, opts}


### PR DESCRIPTION
A small PR that fixes a typo in `lib/ecto/migration.ex`.