### PR TITLE
Fix LIKE and ILIKE clauses in MySQL adapter

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -168,7 +168,7 @@ if Code.ensure_loaded?(Mariaex) do
     binary_ops =
       [==: "=", !=: "!=", <=: "<=", >=: ">=", <:  "<", >:  ">",
        and: "AND", or: "OR",
-       ilike: "ILIKE", like: "LIKE"]
+       ilike: "LIKE", like: "LIKE"]
 
     @binary_ops Keyword.keys(binary_ops)
 

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -168,7 +168,7 @@ if Code.ensure_loaded?(Mariaex) do
     binary_ops =
       [==: "=", !=: "!=", <=: "<=", >=: ">=", <:  "<", >:  ">",
        and: "AND", or: "OR",
-       ilike: "LIKE", like: "LIKE"]
+       ilike: "LIKE", like: "LIKE BINARY"]
 
     @binary_ops Keyword.keys(binary_ops)
 


### PR DESCRIPTION
MySQL does not have an `ILIKE` clause, and so attempting to use Ecto's `ilike` function results in an SQL error. MySQL's `LIKE` clause is case-insensitive by default, however, and so that can simply be used. Also, since Ecto's `like` function is suppose to be case-sensitive, we need to perform a binary string comparison in MySQL to get the desired behaviour.