### PR TITLE
Include a `mix ecto` help task similar to hex

### DIFF
--- a/lib/mix/tasks/ecto.ex
+++ b/lib/mix/tasks/ecto.ex
@@ -1,0 +1,31 @@
+defmodule Mix.Tasks.Ecto do
+  use Mix.Task
+
+  @shortdoc "Prints Ecto help information"
+
+  @moduledoc """
+  Prints Ecto tasks and their information.
+
+      mix ecto
+
+  """
+
+  @doc false
+  def run(args) do
+    {_opts, args, _} = OptionParser.parse(args)
+
+    case args do
+      [] -> general()
+      _ ->
+        Mix.raise "Invalid arguments, expected: mix ecto"
+    end
+  end
+
+  defp general() do
+    Application.ensure_all_started(:ecto)
+    Mix.shell.info "Ecto v#{Application.spec(:ecto, :vsn)}"
+    Mix.shell.info "A database wrapper and language integrated query for Elixir."
+    Mix.shell.info "\nAvailable tasks:\n"
+    Mix.Tasks.Help.run(["--search", "ecto."])
+  end
+end

--- a/test/mix/tasks/ecto_test.exs
+++ b/test/mix/tasks/ecto_test.exs
@@ -1,0 +1,22 @@
+defmodule Mix.Tasks.EctoTest do
+  use ExUnit.Case, async: true
+
+  test "provide a list of available ecto mix tasks" do
+    Mix.Tasks.Ecto.run []
+    assert_received {:mix_shell, :info, ["Ecto v" <> _]}
+    assert_received {:mix_shell, :info, ["mix ecto.create" <> _]}
+    assert_received {:mix_shell, :info, ["mix ecto.drop" <> _]}
+    assert_received {:mix_shell, :info, ["mix ecto.dump" <> _]}
+    assert_received {:mix_shell, :info, ["mix ecto.gen.migration" <> _]}
+    assert_received {:mix_shell, :info, ["mix ecto.gen.repo" <> _]}
+    assert_received {:mix_shell, :info, ["mix ecto.load" <> _]}
+    assert_received {:mix_shell, :info, ["mix ecto.migrate" <> _]}
+    assert_received {:mix_shell, :info, ["mix ecto.rollback" <> _]}
+  end
+
+  test "expects no arguments" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Ecto.run ["invalid"]
+    end
+  end
+end


### PR DESCRIPTION
Lists the Ecto version, a tagline and the available Ecto mix tasks excluding itself.

```sh
✪ mix ecto
Ecto v2.0.0-rc.5
A database wrapper and language integrated query for Elixir.

Available tasks:

mix ecto.create        # Creates the repository storage
mix ecto.drop          # Drops the repository storage
mix ecto.dump          # Dumps database structure
mix ecto.gen.migration # Generate a new migration for the repo
mix ecto.gen.repo      # Generate a new repository
mix ecto.load          # Loads previously dumped database structure
mix ecto.migrate       # Runs the repository migrations
mix ecto.rollback      # Rolls back migrations
```

Closes #1440