### PR TITLE
Fix string casting in MySQL adapter

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -734,7 +734,7 @@ if Code.ensure_loaded?(Mariaex) do
       do: error!(query, "Array type is not supported by MySQL")
     defp ecto_to_db(:id, _query),        do: "integer"
     defp ecto_to_db(:binary_id, _query), do: "binary(16)"
-    defp ecto_to_db(:string, _query),    do: "varchar"
+    defp ecto_to_db(:string, _query),    do: "char"
     defp ecto_to_db(:float, _query),     do: "double"
     defp ecto_to_db(:binary, _query),    do: "blob"
     defp ecto_to_db(:uuid, _query),      do: "binary(16)" # MySQL does not support uuid

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -645,7 +645,11 @@ if Code.ensure_loaded?(Mariaex) do
       size      = Keyword.get(opts, :size)
       precision = Keyword.get(opts, :precision)
       scale     = Keyword.get(opts, :scale)
-      type_name = ecto_to_db(type)
+      type_name =
+        case type do
+          :string -> "varchar"
+          _ -> ecto_to_db(type)
+        end
 
       cond do
         size            -> "#{type_name}(#{size})"

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -213,6 +213,11 @@ defmodule Ecto.Adapters.MySQLTest do
     assert SQL.all(query) == ~s{SELECT CAST(? AS binary(16)) FROM `model` AS m0}
   end
 
+  test "string type" do
+    query = Model |> select([], type(^"test", :string)) |> normalize
+    assert SQL.all(query) == ~s{SELECT CAST(? AS char) FROM `model` AS m0}
+  end
+
   test "nested expressions" do
     z = 123
     query = from(r in Model, []) |> select([r], r.x > 0 and (r.y > ^(-z)) or true) |> normalize


### PR DESCRIPTION
When using to Ecto's `type` function to cast a value to type `:string` with the MySQL adapter, a SQL syntax error is produced. This is because casting to `varchar` is invalid in MySQL - we must instead cast to type `char` ([see here](http://stackoverflow.com/a/15368852/4530326)).

This works fine when comparing values that have been casted to `char` to columns of either type `char` or `varchar`.