### PR TITLE
Add migrations mix task to get up / down status of a given repo.

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -153,6 +153,23 @@ defmodule Ecto.Migrator do
     end
   end
 
+  @doc """
+  Returns an array of tuples as the migration status of the given repo,
+  without actually running any migrations.
+
+  """
+  def migrations(repo, directory) do
+    versions = migrated_versions(repo)
+
+    Enum.map(pending_in_direction(versions, directory, :down) |> Enum.reverse, fn {a, b, _}
+     -> {:up, a, b}
+    end)
+    ++
+    Enum.map(pending_in_direction(versions, directory, :up), fn {a, b, _} ->
+      {:down, a, b}
+    end)
+  end
+
   defp run_to(repo, versions, directory, direction, target, opts) do
     within_target_version? = fn
       {version, _, _}, target, :up ->

--- a/lib/mix/tasks/ecto.migrations.ex
+++ b/lib/mix/tasks/ecto.migrations.ex
@@ -1,0 +1,61 @@
+defmodule Mix.Tasks.Ecto.Migrations do
+  use Mix.Task
+  import Mix.Ecto
+
+  @shortdoc "Displays the up / down migration status for the given repository."
+  @recursive true
+
+  @moduledoc """
+  Displays the up / down migration status for the given repository.
+
+  By default, migrations are expected at "priv/YOUR_REPO/migrations"
+  directory of the current application but it can be configured
+  by specifying the `:priv` key under the repository configuration.
+
+  If the repository has not been started yet, one will be
+  started outside our application supervision tree and shutdown
+  afterwards.
+
+  ## Examples
+
+      mix ecto.migrations
+      mix ecto.migrations -r Custom.Repo
+
+  ## Command line options
+
+    * `-r`, `--repo` - the repo to obtain the status for (defaults to `YourApp.Repo`)
+
+  """
+
+  @doc false
+  def run(args, migrations \\ &Ecto.Migrator.migrations/2, puts \\ &IO.puts/1) do
+    repos = parse_repo(args)
+
+    result = Enum.map(repos, fn repo ->
+      ensure_repo(repo, args)
+      ensure_migrations_path(repo)
+      {:ok, pid} = ensure_started(repo, all: true)
+
+      repo_status = migrations.(repo, migrations_path(repo))
+
+      pid && repo.stop(pid)
+
+      """
+
+      Repo: #{repo}
+
+        Status    Migration ID    Migration Name
+      --------------------------------------------------
+      """ <>
+      Enum.map_join(repo_status, "\n", fn({status, number, description}) ->
+        if status == :up do
+          status = "up  "
+        end
+
+        "  #{status}      #{number}  #{description}"
+      end) <> "\n"
+    end)
+
+     puts.(Enum.join(result, "\n"))
+  end
+end

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -273,6 +273,26 @@ defmodule Ecto.MigratorTest do
     end
   end
 
+  test "migrations will give the up and down migration status" do
+    in_tmp fn path ->
+      create_migration "1_up_migration_1.exs"
+      create_migration "2_up_migration_2.exs"
+      create_migration "3_up_migration_3.exs"
+      create_migration "4_down_migration_1.exs"
+      create_migration "5_down_migration_2.exs"
+
+      expected_result = [
+        {:up, 1, "up_migration_1"},
+        {:up, 2, "up_migration_2"},
+        {:up, 3, "up_migration_3"},
+        {:down, 4, "down_migration_1"},
+        {:down, 5, "down_migration_2"}
+      ]
+
+      assert migrations(TestRepo, path) == expected_result
+    end
+  end
+
   test "migrations run inside a transaction if the adapter supports ddl transactions" do
     capture_log fn ->
       Process.put(:supports_ddl_transaction?, true)

--- a/test/mix/tasks/ecto.migrations_test.exs
+++ b/test/mix/tasks/ecto.migrations_test.exs
@@ -1,0 +1,87 @@
+defmodule Mix.Tasks.Ecto.MigrationsTest do
+  use ExUnit.Case
+
+  import Mix.Tasks.Ecto.Migrations, only: [run: 3]
+  import Support.FileHelpers
+
+  migrations_path = Path.join([tmp_path, inspect(Ecto.Migrations), "migrations"])
+
+  setup do
+    File.mkdir_p!(unquote(migrations_path))
+    :ok
+  end
+
+  defmodule Repo do
+    def start_link(_) do
+      Process.put(:started, true)
+      Task.start_link fn ->
+        Process.flag(:trap_exit, true)
+        receive do
+          {:EXIT, _, :normal} -> :ok
+        end
+      end
+    end
+
+    def stop(_pid) do
+      :ok
+    end
+
+    def __adapter__ do
+      Ecto.TestAdapter
+    end
+
+    def config do
+      [priv: "tmp/#{inspect(Ecto.Migrations)}", otp_app: :ecto]
+    end
+  end
+
+
+  test "migrations displays the up and down status for the default repo" do
+    Application.put_env(:ecto, :ecto_repos, [Repo])
+
+    migrations = fn _, _ ->
+      [
+        {:up,   20160000000001, "up_migration_1"},
+        {:up,   20160000000002, "up_migration_2"},
+        {:up,   20160000000003, "up_migration_3"},
+        {:down, 20160000000004, "down_migration_1"},
+        {:down, 20160000000005, "down_migration_2"}
+      ]
+    end
+
+    expected_output = """
+
+      Repo: Elixir.Mix.Tasks.Ecto.MigrationsTest.Repo
+
+        Status    Migration ID    Migration Name
+      --------------------------------------------------
+        up        20160000000001  up_migration_1
+        up        20160000000002  up_migration_2
+        up        20160000000003  up_migration_3
+        down      20160000000004  down_migration_1
+        down      20160000000005  down_migration_2
+      """
+    run [], migrations, fn i -> assert(i == expected_output) end
+  end
+
+  test "migrations displays the up and down status for any given repo" do
+    migrations = fn _, _ ->
+      [
+        {:up,   20160000000001, "up_migration_1"},
+        {:down, 20160000000002, "down_migration_1"}
+      ]
+    end
+
+    expected_output = """
+
+      Repo: Elixir.Mix.Tasks.Ecto.MigrationsTest.Repo
+
+        Status    Migration ID    Migration Name
+      --------------------------------------------------
+        up        20160000000001  up_migration_1
+        down      20160000000002  down_migration_1
+      """
+
+    run ["-r", to_string(Repo)], migrations, fn i -> assert(i == expected_output) end
+  end
+end


### PR DESCRIPTION
First off, thanks for everything you've done w/ regards to Ecto / Elixir.  I am a huge fan.

I was thinking it would be helpful to have a way to check the current migration status similar to how you would with ```db:migrate:status``` in Rails.

I was hoping to implement some of this, but didn't want to get too far ahead of myself.  To start I would like to propose adding a status method to Ecto.Migrator.

If this is accepted, the next step would be to create a mix task so that you can easily check the migration status from the command line.

Please let me know what you think or if there is a different way I should approach proposing this.

Thanks!