### PR TITLE
Display human-friendly errors for queries using &&/||/!

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -215,6 +215,13 @@ defmodule Ecto.Query.Builder do
     {expr, params}
   end
 
+  def escape({op, _, _}, _type, _params, _vars, _env) when op in ~w(|| && !)a do
+    error! """
+          Short-form operators are not supported: `#{op}`
+          Instead use the full name as found in SQL: `and`, `or`, and `not`.
+          """
+  end
+
   # Other functions - no type casting
   def escape({name, _, args} = expr, type, params, vars, env) when is_atom(name) and is_list(args) do
     case call_type(name, length(args)) do

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -79,6 +79,10 @@ defmodule Ecto.Query.BuilderTest do
       escape(quote(do: :atom), [], __ENV__)
     end
 
+    assert_raise Ecto.Query.CompileError, ~r"Short-form operators are not supported: `&&`", fn ->
+      escape(quote(do: true && false), [], __ENV__)
+    end
+
     assert_raise Ecto.Query.CompileError, ~r"`unknown\(1, 2\)` is not a valid query expression", fn ->
       escape(quote(do: unknown(1, 2)), [], __ENV__)
     end


### PR DESCRIPTION
Currently using these operators produces a very confusing message (https://gist.github.com/ciaran/164e1afae5d2fac5bdcc121e9f8de31a), and it’s not at all obvious to the user what is causing the issue. I’ve seen quite a few cases of people asking for help after writing code on auto-pilot using these terms and then not knowing what they’ve done wrong.

This patch simply adds a more helpful error message when one of these invalid operators is used.