### PR TITLE
Improve error message when fk matches association

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1178,6 +1178,10 @@ defmodule Ecto.Schema do
     opts = Keyword.put_new(opts, :foreign_key, :"#{name}_id")
     foreign_key_type = opts[:type] || Module.get_attribute(mod, :foreign_key_type)
 
+    if name == Keyword.get(opts, :foreign_key) do
+      raise ArgumentError, "foreign_key #{inspect name} must be distinct from corresponding association name"
+    end
+
     if Keyword.get(opts, :define_field, true) do
       __field__(mod, opts[:foreign_key], foreign_key_type, opts)
     end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -616,4 +616,18 @@ defmodule Ecto.SchemaTest do
       end
     end
   end
+
+  test "belongs_to raises helpful error with redundant foreign key name" do
+    name = :author
+    message = ~r"foreign_key :#{name} must be distinct from corresponding association name"
+    assert_raise ArgumentError, message, fn ->
+      defmodule SchemaBadForeignKey do
+        use Ecto.Schema
+
+        schema "fk_assoc_name_clash" do
+          belongs_to name, User, foreign_key: name
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Improve error message is foreign_key is identical to corresponding association name. Re: #1468