### PR TITLE
Ecto.Changeset.validate_change/3 should keep errors consistent.

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1014,7 +1014,7 @@ defmodule Ecto.Changeset do
       iex> changeset = change(%Post{}, %{title: "foo"})
       iex> changeset = validate_change changeset, :title, fn
       ...>   # Value must not be "foo"!
-      ...>   :title, "foo" -> [title: "is foo"]
+      ...>   :title, "foo" -> [{:title, {"is foo", []}]
       ...>   :title, _     -> []
       ...> end
       iex> changeset.errors
@@ -1385,7 +1385,7 @@ defmodule Ecto.Changeset do
 
   defp confirmation_missing(opts, error_field) do
     required = Keyword.get(opts, :required, false)
-    if required, do: [{error_field, {message(opts, "can't be blank"), []}}], else: []    
+    if required, do: [{error_field, {message(opts, "can't be blank"), []}}], else: []
   end
 
   defp message(opts, key \\ :message, default) do


### PR DESCRIPTION
I am working with `traverse_errors/2`, which's doc says `The error message function receives an error tuple {msg, opts}`

I follow this doc and set the error message to `[title: "is foo"]`, then when I traverse errors, the message is not formatted as `{msg, opts}`.

I'm not sure we should change to doc or change to code:

```
    case new do
      []    -> changeset
      [_|_] -> %{changeset | errors: new ++ errors, valid?: false}
    end
```
