### PR TITLE
Add Ecto.Multi.merge/2

### DIFF
--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -16,6 +16,7 @@ defmodule Ecto.MultiTest do
   end
 
   def ok(x), do: {:ok, x}
+  def multi(x), do: Multi.new |> Multi.update(:update, Changeset.change(x.insert))
 
   test "new" do
     assert Multi.new == %Multi{}
@@ -328,6 +329,75 @@ defmodule Ecto.MultiTest do
     fun = fn _ -> {:ok, :ok} end
     assert_raise RuntimeError, ~r":run is already a member", fn ->
       Multi.new |> Multi.run(:run, fun) |> Multi.run(:run, fun)
+    end
+  end
+
+  test "merge with fun" do
+    changeset = Changeset.change(%Comment{})
+    multi =
+      Multi.new
+      |> Multi.insert(:insert, changeset)
+      |> Multi.merge(fn data ->
+        Multi.new |> Multi.update(:update, Changeset.change(data.insert))
+      end)
+
+    assert {:ok, data} = TestRepo.transaction(multi)
+    assert %Comment{} = data.insert
+    assert %Comment{} = data.update
+  end
+
+  test "merge with mfa" do
+    changeset = Changeset.change(%Comment{})
+    multi =
+      Multi.new
+      |> Multi.insert(:insert, changeset)
+      |> Multi.merge(__MODULE__, :multi, [])
+
+      assert {:ok, data} = TestRepo.transaction(multi)
+      assert %Comment{} = data.insert
+      assert %Comment{} = data.update
+  end
+
+  test "merge rollbacks on errors" do
+    error = fn _ -> {:error, :error} end
+    ok    = fn _ -> {:ok, :ok} end
+
+    multi =
+      Multi.new
+      |> Multi.run(:outside_ok, ok)
+      |> Multi.merge(fn _ ->
+        Multi.new
+        |> Multi.run(:inside_ok, ok)
+        |> Multi.run(:inside_error, error)
+      end)
+      |> Multi.run(:outside_error, error)
+
+    assert {:error, :inside_error, :error, data} = TestRepo.transaction(multi)
+    assert :ok == data.outside_ok
+    assert :ok == data.inside_ok
+  end
+
+  test "merge does not allow repeated operations" do
+    fun = fn _ -> {:ok, :ok} end
+
+    multi =
+      Multi.new
+      |> Multi.merge(fn _ ->
+        Multi.new |> Multi.run(:run, fun)
+      end)
+      |> Multi.run(:run, fun)
+
+    assert_raise RuntimeError, ~r"found in both Ecto.Multi: \[:run\]", fn ->
+      TestRepo.transaction(multi)
+    end
+
+    multi =
+      Multi.new
+      |> Multi.merge(fn _ -> Multi.new |> Multi.run(:run, fun) end)
+      |> Multi.merge(fn _ -> Multi.new |> Multi.run(:run, fun) end)
+
+    assert_raise RuntimeError, ~r"found in both Ecto.Multi: \[:run\]", fn ->
+      TestRepo.transaction(multi)
     end
   end
 end


### PR DESCRIPTION
The function passed to merge accepts an initial multi - that allows us to easily guard against duplicated operations, that would cause issues later on when merging results.

This still needs docs.

Closes #1464