### PR TITLE
Delegate prefix to migration runner

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -519,6 +519,13 @@ defmodule Ecto.Migration do
   end
 
   @doc """
+  Gets the migrator prefix.
+  """
+  def prefix do
+    Runner.prefix
+  end
+
+  @doc """
   Adds a column when creating or altering a table.
 
   This function also accepts Ecto primitive types as column types

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -25,6 +25,11 @@ defmodule Ecto.MigrationTest do
     assert direction() == :up
   end
 
+  @tag prefix: :foo
+  test "allows prefix to be retrieved" do
+    assert prefix() == :foo
+  end
+
   test "creates a table" do
     assert table(:posts) == %Table{name: :posts, primary_key: true}
     assert table(:posts, primary_key: false) == %Table{name: :posts, primary_key: false}


### PR DESCRIPTION
When running the migrations for tenants with `mix ecto.migrate --prefix tenant0`, we should not run the migrations related to the public namespace.

This commit will allow to do the following:
```
def change do
  unless prefix do
    create_table(:tenants, prefix: :public) do
      add :identifier, :string
    end
  end
end
```

Discussion: https://github.com/elixir-lang/ecto/issues/1005#issuecomment-225506810
/cc @josevalim 