### PR TITLE
Modified migration docs regarding `:priv` config

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -20,8 +20,8 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
 
   By default, the migration will be generated to the
   "priv/YOUR_REPO/migrations" directory of the current application
-  but it can be configured by specifying the `:priv` key under
-  the repository configuration.
+  but it can be configured to be any subdirectory of `priv` by
+  specifying the `:priv` key under the repository configuration.
 
   This generator will automatically open the generated file if
   you have `ECTO_EDITOR` set in your environment variable.

--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -13,7 +13,8 @@ defmodule Mix.Tasks.Ecto.Migrate do
 
   By default, migrations are expected at "priv/YOUR_REPO/migrations"
   directory of the current application but it can be configured
-  by specifying the `:priv` key under the repository configuration.
+  to be any subdirectory of `priv` by specifying the `:priv` key
+  under the repository configuration.
 
   Runs all pending migrations by default. To migrate up
   to a version number, supply `--to version_number`.


### PR DESCRIPTION
* Added that the `:priv` configuration must be a **subdirectory**
  of the `priv` directory itself.
* Relates to issue elixir-lang/ecto#1428.